### PR TITLE
fix and consolidate button class (color) logic

### DIFF
--- a/webapp/app/js/controllers/jobs.js
+++ b/webapp/app/js/controllers/jobs.js
@@ -43,11 +43,11 @@ treeherder.controller('ResultSetCtrl',
                            thUrl, thServiceDomain) {
 
         var SEVERITY = {
-            "busted":     {
+            "busted": {
                 level: 1,
                 isCollapsedResults: false
             },
-            "exception":  {
+            "exception": {
                 level: 2,
                 isCollapsedResults: false
             },
@@ -55,19 +55,27 @@ treeherder.controller('ResultSetCtrl',
                 level: 3,
                 isCollapsedResults: false
             },
-            "usercancel":    {
+            "unknown": { // completed, unknown error
                 level: 4,
-                isCollapsedResults: false
-            },
-            "retry":      {
-                level: 5,
                 isCollapsedResults: true
             },
-            "success":    {
+            "usercancel": {
+                level: 5,
+                isCollapsedResults: false
+            },
+            "retry": {
                 level: 6,
                 isCollapsedResults: true
             },
-            "unknown":    {
+            "success": {
+                level: 7,
+                isCollapsedResults: true
+            },
+            "running": {
+                level: 8,
+                isCollapsedResults: true
+            },
+            "pending": {
                 level: 100,
                 isCollapsedResults: true
             }

--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -34,3 +34,78 @@ treeherder.provider('thStarTypes', function() {
         };
     };
 });
+
+treeherder.provider('thResultStatusInfo', function() {
+    this.$get = function() {
+        return function(resultState) {
+            // default if there is no match, used for pending
+            var resultStatusInfo = {
+                btnClass: "btn-default",
+                showButtonIcon: "glyphicon glyphicon-time",
+                jobButtonIcon: ""
+            };
+
+            switch (resultState) {
+                case "busted":
+                    resultStatusInfo = {
+                        btnClass: "btn-danger",
+                        showButtonIcon: "glyphicon glyphicon-fire",
+                        jobButtonIcon: "glyphicon glyphicon-fire"
+                    };
+                    break;
+                case "exception":
+                    resultStatusInfo = {
+                        btnClass: "btn-purple",
+                        showButtonIcon: "glyphicon glyphicon-fire",
+                        jobButtonIcon: "glyphicon glyphicon-fire"
+                    };
+                    break;
+                case "running":
+                    resultStatusInfo = {
+                        btnClass: "btn-ltgray",
+                        showButtonIcon: "glyphicon glyphicon-time",
+                        jobButtonIcon: ""
+                    };
+                    break;
+                case "retry":
+                    resultStatusInfo = {
+                        btnClass: "btn-primary",
+                        showButtonIcon: "glyphicon glyphicon-time",
+                        jobButtonIcon: ""
+                    };
+                    break;
+                case "success":
+                    resultStatusInfo = {
+                        btnClass: "btn-success",
+                        showButtonIcon: "glyphicon glyphicon-ok",
+                        jobButtonIcon: ""
+                    };
+                    break;
+                case "testfailed":
+                    resultStatusInfo = {
+                        btnClass: "btn-warning",
+                        showButtonIcon: "glyphicon glyphicon-warning-sign",
+                        jobButtonIcon: "glyphicon glyphicon-warning-sign"
+                    };
+                    break;
+                case "usercancel":
+                    resultStatusInfo = {
+                        btnClass: "btn-pink",
+                        showButtonIcon: "glyphicon glyphicon-stop",
+                        jobButtonIcon: ""
+                    };
+                    break;
+                case "unknown":
+                    resultStatusInfo = {
+                        btnClass: "btn-black",
+                        showButtonIcon: "glyphicon glyphicon-time",
+                        jobButtonIcon: ""
+                    };
+                    break;
+            }
+
+            return resultStatusInfo;
+        };
+
+    };
+});

--- a/webapp/app/partials/thJobButton.html
+++ b/webapp/app/partials/thJobButton.html
@@ -7,6 +7,6 @@
           We should conditionally remove the fire icon once they have
           starred it, most likely.
       -->
-      <i class="glyphicon glyphicon-fire" ng-show="job.display.onFire"></i>
+      <i class="{{ job.display.jobButtonIcon }}"></i>
       {{ job.job_type_symbol }}
 </span>


### PR DESCRIPTION
this has a companion PR in the service side: https://github.com/mozilla/treeherder-service/pull/84
The service PR returns the correct `result_types` for `pending` and `running`.  Without that chance, the hide/show jobs button will show black for pending and running.

This now uses the same logic to get the button class and icon for job buttons as well as the hide/show job button and places that in a provider.

Also, fixed a few areas where I was returning the wrong color.
