### PR TITLE
Share able links

### DIFF
--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -83,14 +83,14 @@
         <span class="revision">
             <a href="{{urlBasePath}}?repo={{currentRepo.name}}&revision={{revision}}"
                target="_blank"
-               title="filter to only resultsets that contain revision {{revision}}"
+               title="open resultsets that contain revision {{revision}}"
                >{{revision}}</a>
             <a href="{{currentRepo.url}}/rev/{{revision}}"
                target="_blank"
                class="btn btn-default btn-xs"
                title="open revision {{revision}} on {{currentRepo.url}}"
                >
-                <i class="fa fa-code"></i>
+                <i class="fa fa-external-link-square"></i>
             </a>
             <span title="{{name}}: {{email}}">{{name}}</span>
             <span title="{{comments}}"><em>"{{comments}}"</em></span>

--- a/webapp/app/js/controllers/jobs.js
+++ b/webapp/app/js/controllers/jobs.js
@@ -119,7 +119,6 @@ treeherder.controller('ResultSetCtrl',
             return thJobFilters.showJob(job, $scope.resultStatusFilters);
         };
 
-        $scope.idResultsetFilterUrl = $scope.urlBasePath + "?repo=" + $scope.repoName + "&id=" + $scope.resultset.id;
         $scope.revisionResultsetFilterUrl = $scope.urlBasePath + "?repo=" + $scope.repoName + "&revision=" + $scope.resultset.revision;
         $scope.authorResultsetFilterUrl = $scope.urlBasePath + "?repo=" + $scope.repoName + "&author=" + $scope.resultset.author;
 

--- a/webapp/app/js/directives.js
+++ b/webapp/app/js/directives.js
@@ -850,7 +850,9 @@ treeherder.directive('thAuthor', function () {
             scope.authorName = userTokens[0].trim();
             scope.authorEmail = email;
         },
-        template: '<span title="{{authorName}}: {{authorEmail}}"><a href="{{authorResultsetFilterUrl}}">{{authorName}}</a></span>'
+        template: '<span title="open resultsets for {{authorName}}: {{authorEmail}}">' +
+                      '<a href="{{authorResultsetFilterUrl}}" ' +
+                         'target="_blank">{{authorName}}</a></span>'
     };
 });
 

--- a/webapp/app/js/services/resultsets.js
+++ b/webapp/app/js/services/resultsets.js
@@ -18,7 +18,11 @@ treeherder.factory('thResultSets',
 
             // if there are any search params on the url line, they should
             // pass directly to the set of resultsets.
-            _.extend(params, $location.search());
+            // with the exception of ``repo``.  That has no effect on the
+            // service at this time, but it could be confusing.
+            var locationParams = $location.search();
+            delete locationParams.repo;
+            _.extend(params, locationParams);
 
             if (resultsetlist) {
                 _.extend(params, {

--- a/webapp/app/partials/jobs.html
+++ b/webapp/app/partials/jobs.html
@@ -1,5 +1,5 @@
 <div class="progress progress-striped active"
-     ng-show="isLoadingRsBatch.prepending">
+     ng-show="isLoadingRsBatch.prepending && result_sets.length === 0">
     <div class="progress-bar"  role="progressbar" style="width: 100%"></div>
 </div>
 
@@ -14,13 +14,16 @@
             <span class="btn btn-default btn-sm glyphicon glyphicon-download" ng-show="isLoadingJobs"></span>
             <th-action-button ng-hide="isLoadingJobs"></th-action-button>
             <span class="timestamp-name">
-                <span><a href="{{idResultsetFilterUrl}}">{{resultset.push_timestamp*1000|date:'medium'}}</a> - </span>
+                <span>
+                    <a href="{{revisionResultsetFilterUrl}}"
+                       title="open resultsets that contain revision {{resultset.revision}}"
+                       target="_blank">{{resultset.push_timestamp*1000|date:'medium'}}</a> - </span>
                 <th-author author="{{resultset.author}}"></th-author>
             </span>
         </span>
         <span class="col-xs-3 revision-link">
             <a href="{{revisionResultsetFilterUrl}}"
-               title="filter to only resultsets that contain revision {{resultset.revision}}"
+               title="open resultsets that contain revision {{resultset.revision}}"
                target="_blank">{{resultset.revision}}</a>
         </span>
         <span class="col-xs-1 btn btn-default btn-sm revision-button"

--- a/webapp/app/partials/thResultCounts.html
+++ b/webapp/app/partials/thResultCounts.html
@@ -1,6 +1,6 @@
     <span class="btn btn-default btn-sm result-status-total-count"
           ng-click="toggleJobs()"
-          title="total job count - view/hide jobs"><i class="fa fa-tasks fa-lg"></i> {{resultset.job_counts.total}}</span>
+          title="total job count - toggle jobs"><i class="fa fa-tasks fa-lg"></i> {{resultset.job_counts.total}}</span>
     <span class="result-status-count-group">
         <th-result-status-count ng-repeat="resultStatus in statusList"/>
     </span>

--- a/webapp/app/partials/thResultStatusCount.html
+++ b/webapp/app/partials/thResultStatusCount.html
@@ -1,7 +1,7 @@
 <span class="result-status-count text-right {{countAlertClass}}"
       ng-class="{'result-status-count-{{resultStatus}}': (windowWidth >= 1200), 'result-status-count-min-width': (windowWidth < 1200)}"
       ng-click="toggleResultSetResultStatusFilter(resultStatus)"
-      title="{{resultStatus}}">
+      title="toggle {{resultStatus}}">
         <span ng-bind="resultCount"></span>
         <span ng-show="windowWidth >= 1200"> {{resultCountText}}</span>
     </span>


### PR DESCRIPTION
READY FOR MERGE

fix to share-able links for resultsets by `id`, `author`, `revision`.  Filtering by revision will return all resultsets that contain that revision.

This does not contain the share-able link for a specific job.
