### PR TITLE
Strictly assert type of searchQuery

### DIFF
--- a/webapp/app/js/services/jobfilters.js
+++ b/webapp/app/js/services/jobfilters.js
@@ -193,7 +193,7 @@ treeherder.factory('thJobFilters',
                     return false;
                 }
             }
-            if($rootScope.searchQuery !== ""){
+            if(typeof $rootScope.searchQuery === 'string'){
                 //Confirm job matches search query
                 if(job.searchableStr.toLowerCase().indexOf(
                     $rootScope.searchQuery.toLowerCase()


### PR DESCRIPTION
Honestly- I did not try very hard to figure out why it was undefined in the first place locally but here is a safe patch that will ensure searchQuery really is a string (rather then undefined in my case which dies on toLowerCase)
