### PR TITLE
fixing ``platform_opt`` to ``platform_option``

### DIFF
--- a/webapp/app/js/models/resultsets.js
+++ b/webapp/app/js/models/resultsets.js
@@ -234,7 +234,7 @@ treeherder.factory('ThResultSetModel',
 
             var pl_obj = {
                 name: newJob.platform,
-                option: newJob.platform_opt,
+                option: newJob.platform_option,
                 groups: []
             };
 
@@ -351,7 +351,7 @@ treeherder.factory('ThResultSetModel',
 
         resultsetId = job.result_set_id;
         platformName = job.platform;
-        platformOption = job.platform_opt;
+        platformOption = job.platform_option;
 
         if(_.isEmpty(repositories[repoName].rsMap[ resultsetId ])){
             //We don't have this resultset
@@ -362,7 +362,7 @@ treeherder.factory('ThResultSetModel',
             repoName,
             job.result_set_id,
             job.platform,
-            job.platform_opt
+            job.platform_option
             );
 
         if(!platformData[platformAggregateId]){
@@ -377,6 +377,7 @@ treeherder.factory('ThResultSetModel',
 
                 platformKey = getPlatformKey(platformName, platformOption);
 
+                $log.debug("aggregateJobPlatform", repoName, resultsetId, platformKey, repositories);
                 jobGroups = repositories[repoName].rsMap[resultsetId].platforms[platformKey].pl_obj.groups;
                 platformData[platformAggregateId] = {
                     platformName:platformName,


### PR DESCRIPTION
we broke starring a bit ago because we stopped doing a `_.extend` on job detail to the stored job in resultset model.  This extend was hiding the fact that the `resultset` endpoint was returning this field as `platform_option` but the `jobs` endpoint was returning it as `platform_opt`

So this is the ui portion that standardizes on `platform_option`.  
The companion service pr is: https://github.com/mozilla/treeherder-service/pull/126
