### PR TITLE
package.json: remove unnecessary `./node_modules/.bin` from `scripts.test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "grunt-filerev": "^0.2.1"
   },
   "scripts": {
-    "test": "./node_modules/.bin/karma start webapp/config/karma.conf.js --single-run --browsers Firefox"
+    "test": "karma start webapp/config/karma.conf.js --single-run --browsers Firefox"
   }
 }


### PR DESCRIPTION
`./node_modules/.bin` is automatically added to PATH when running npm commands, so there's no need to explicitly mention it.
