### PR TITLE
Horizontally align revision elements

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -273,6 +273,12 @@ body {
     overflow: auto;
 }
 
+.revision > a:first-child {
+    float: left;
+    width: 7.5em;
+    padding-top: 2px;
+}
+
 .platform {
     font-size: 12px;
     padding-left: 0;


### PR DESCRIPTION
This tweak aligns the 'open revision' anchor as discussed with @jeads on IRC yesterday.

It appears to be working correctly in all the scenarios I was able to test locally (show/hide revisions, show/hide jobs, resizing, scrolling the revision list) in both FF and Chrome. I'm only targeting the first descendant anchor via `>`, so we don't end up floating-left descendant Bugzilla links. I've included a before and after for posterity. Here is the before:

![therderrevisionalignbefore](https://cloud.githubusercontent.com/assets/3660661/3390991/746e52f2-fca5-11e3-9db8-2d36be58ac7a.jpg)

Here is the after:

![therderrevisionalignafter](https://cloud.githubusercontent.com/assets/3660661/3390998/85da27e6-fca5-11e3-91cc-410b152c3854.jpg)

If you'd like any em adjustment between the resultset and the revision anchor let me know.
