### PR TITLE
Remove legacy backend service from sample config

### DIFF
--- a/webapp/app/js/config/sample.local.conf.js
+++ b/webapp/app/js/config/sample.local.conf.js
@@ -1,8 +1,5 @@
 'use strict';
 
-// mozilla hosted service
-//window.thServiceDomain = "http://dev.treeherder.mozilla.org";
-
 // window.thServiceDomain holds a reference to backend service
 // this can be one of:
 //


### PR DESCRIPTION
This tweak removes the legacy service as discussed with @maurodoglio on IRC this morning. It was apparently about a year old, and has been superseded by the new entries, just below it.
