### PR TITLE
Un-ellipsize and wrap Failure summary content (1032495)

### DIFF
--- a/webapp/app/plugins/failure_summary/main.html
+++ b/webapp/app/plugins/failure_summary/main.html
@@ -4,7 +4,7 @@
             <strong>{{error}}</strong>
             <span ng-repeat="visible in ['open','closed']">
                 <ul class="list-unstyled">
-                    <li class="nowrap" ng-repeat="bug in bug_list[visible] | orderBy:bug.relevance:reverse"
+                    <li ng-repeat="bug in bug_list[visible] | orderBy:bug.relevance:reverse"
                         ng-show="$index<3 || show_all">
                         <button class="btn btn-xs btn-default"
                                 ng-click="pinboard_service.addBug(bug)"


### PR DESCRIPTION
This work addresses Bugzilla bug [1032495](https://bugzilla.mozilla.org/show_bug.cgi?id=1032495).

The full bug summary will now always be visible and wrapped, like TBPL. I've tested a variety of failed jobs containing bug summaries, using different repos, browser sizes and dynamic resizing and it seems to behave as expected. 

As mentioned in the bug I've pushed the supplementary grunt as a separate commit, so we can actually see the real work and change in the commit history.

Adding @maurodoglio and @camd for visibility.

Tested on Windows:
FF Release **30.0**
Chrome Latest Release **35.0.1916.153 m**
