### PR TITLE
fix bug 1032463 - click repo link opens new tab

### DIFF
--- a/webapp/app/partials/thRepoPanel.html
+++ b/webapp/app/partials/thRepoPanel.html
@@ -17,8 +17,13 @@
                        ng-checked="watchedRepos[repo.name].isWatched"
                        ng-click="toggleRepo(repo.name)">
                 <a href="" class="repo-link"
-                      ng-click="changeRepo(repo.name)">{{repo.name}}
+                   title="add to watch list and view repo"
+                   ng-click="changeRepo(repo.name)"><span class="fa fa-plus"></span>
                 </a>
+                <a href="/ui/#/jobs?repo={{repo.name}}"
+                   title="open repo in new tab"
+                   target="_blank"
+                   class="repo-link">{{repo.name}}</a>
                 <span class="dropdown-toggle"
                         data-toggle="dropdown"
                         title="{{repo.name}} info"


### PR DESCRIPTION
now if you click the link in the browser, it opens a new tab with that repo.
Added a "+" button to do what it did before: add that repo to watch list, view it and close the repo panel.

With this workflow, we will stop adding the repos automatically to the watch list when you view them.  And we should add a save button to persist watched repos rather than doing it automatically.  But that'll be a different PR.
