### PR TITLE
Update sample config to point to production by default

### DIFF
--- a/webapp/app/js/config/sample.local.conf.js
+++ b/webapp/app/js/config/sample.local.conf.js
@@ -1,13 +1,15 @@
 'use strict';
 
-// window.thServiceDomain holds a reference to backend service
-// this can be one of:
-//
-// -  http://local.treeherder.mozilla.org (local vagrant)
-// -  http://treeherder-dev.allizom.org (dev)
-// -  https://treeherder.allizom.org (stage)
-// -  https://treeherder.mozilla.org (prod)
-window.thServiceDomain = "http://local.treeherder.mozilla.org";
+/* window.thServiceDomain holds a reference to a backend service
+ * for result data. This can be one of:
+ *
+ * -  http://local.treeherder.mozilla.org (local vagrant)
+ * -  http://treeherder-dev.allizom.org (dev)
+ * -  https://treeherder.allizom.org (stage)
+ * -  https://treeherder.mozilla.org (production) */
+
+// By default the service looks to production
+window.thServiceDomain = "https://treeherder.mozilla.org";
 
 //treeherder.config(['$logProvider', 'ThLogConfigProvider',
 //    function($logProvider, ThLogConfigProvider) {

--- a/webapp/test/unit/controllers/jobs.tests.js
+++ b/webapp/test/unit/controllers/jobs.tests.js
@@ -9,12 +9,12 @@ describe('JobsCtrl', function(){
 
     beforeEach(inject(function ($injector, $rootScope, $controller
     ) {
-        var projectPrefix = 'http://local.treeherder.mozilla.org/api/project/mozilla-central/';
+        var projectPrefix = 'https://treeherder.mozilla.org/api/project/mozilla-central/';
 
         $httpBackend = $injector.get('$httpBackend');
         jasmine.getJSONFixtures().fixturesPath='base/test/mock';
 
-        $httpBackend.whenGET('http://local.treeherder.mozilla.org/api/repository/').respond(
+        $httpBackend.whenGET('https://treeherder.mozilla.org/api/repository/').respond(
             getJSONFixture('repositories.json')
         );
 
@@ -31,7 +31,7 @@ describe('JobsCtrl', function(){
             }
         );
 
-        $httpBackend.whenGET('http://local.treeherder.mozilla.org/api/project/mozilla-central/jobs/0/unclassified_failure_count/').respond(
+        $httpBackend.whenGET('https://treeherder.mozilla.org/api/project/mozilla-central/jobs/0/unclassified_failure_count/').respond(
             {
                 "unclassified_failure_count": 1152,
                 "repository": "mozilla-central"

--- a/webapp/test/unit/models/resultsets.tests.js
+++ b/webapp/test/unit/models/resultsets.tests.js
@@ -7,7 +7,7 @@ describe('ThResultSetModel', function(){
         model,
         foregroundRepo = "foreground-repo",
         backgroundRepo = "background-repo",
-        projectPrefix = 'http://local.treeherder.mozilla.org/api/project/',
+        projectPrefix = 'https://treeherder.mozilla.org/api/project/',
         foregroundPrefix = projectPrefix + 'foreground-repo',
         backgroundPrefix = projectPrefix + 'background-repo';
 


### PR DESCRIPTION
As discussed on IRC today, it seems reasonable to switch the sample config to point to production by default. It somewhat mitigates risk with the new process adopted today of grunt building directly on master and pushing to stage/production. But more so, it ensures an out of-the-box local config actually works when copied to `local.conf.js`.

Some very minor comment tweaking included.

Adding @jeads, @maurodoglio, and @camd for visibility.

Pulling in the data correctly on Windows:
FF Release **30.0**
Chrome Latest Release **35.0.1916.153 m**
