### PR TITLE
display log parse status in the bottom panel

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -405,6 +405,11 @@ div#bottom-panel .navbar-nav > li > a{
     line-height: 19px;
 }
 
+div#bottom-panel .navbar-nav > li > a.disabled {
+    cursor: not-allowed;
+    text-decoration: none;
+}
+
 div#bottom-panel ul.bottom-panel-controls{
     width:401px;
     border-right: 1px solid #42484F;

--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -82,6 +82,7 @@
         <script src="js/models/exclusion_profile.js"></script>
         <script src="js/models/build_platform.js"></script>
         <script src="js/models/job_type.js"></script>
+        <script src="js/models/job_log_url.js"></script>
         <script src="js/models/option.js"></script>
         <script src="js/models/user.js"></script>
         <!-- Controllers -->

--- a/webapp/app/js/models/job_log_url.js
+++ b/webapp/app/js/models/job_log_url.js
@@ -1,0 +1,41 @@
+'use strict';
+
+treeherder.factory('ThJobLogUrlModel', [
+    '$http', '$log', 'thUrl',
+    function($http, $log, thUrl) {
+
+    // ThJobLogUrlModel is the js counterpart of job_type
+
+    var ThJobLogUrlModelModel = function(data) {
+        // creates a new instance of ThJobLogUrlModelModel
+        // using the provided properties
+        angular.extend(this, data);
+    };
+
+    ThJobLogUrlModelModel.get_uri = function(){
+        var url = thUrl.getProjectUrl("/job-log-url/");
+        $log.log(url);
+        return url;
+    };
+
+    ThJobLogUrlModelModel.get_list = function(job_id) {
+        // a static method to retrieve a list of ThJobLogUrlModelModel
+        return $http.get(ThJobLogUrlModelModel.get_uri()+"?job_id="+job_id)
+            .then(function(response) {
+                var item_list = [];
+                angular.forEach(response.data, function(elem){
+                    item_list.push(new ThJobLogUrlModelModel(elem));
+                });
+                return item_list;
+        });
+    };
+
+    ThJobLogUrlModelModel.get = function(pk) {
+        // a static method to retrieve a single instance of ThJobLogUrlModelModel
+        return $http.get(ThJobLogUrlModelModel.get_uri()+pk).then(function(response) {
+            return new ThJobLogUrlModelModel(response.data);
+        });
+    };
+
+    return ThJobLogUrlModelModel;
+}]);

--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -5,13 +5,13 @@ treeherder.controller('PluginCtrl', [
     'thClassificationTypes', 'ThJobModel', 'thEvents', 'dateFilter',
     'numberFilter', 'ThBugJobMapModel', 'thResultStatus', 'thSocket',
     'ThResultSetModel', 'ThLog', '$q', 'thPinboard', 'ThJobArtifactModel',
-    'thBuildApi', 'thNotify',
+    'thBuildApi', 'thNotify', 'ThJobLogUrlModel',
     function PluginCtrl(
         $scope, $rootScope, thUrl, ThJobClassificationModel,
         thClassificationTypes, ThJobModel, thEvents, dateFilter,
         numberFilter, ThBugJobMapModel, thResultStatus, thSocket,
         ThResultSetModel, ThLog, $q, thPinboard, ThJobArtifactModel,
-        thBuildApi, thNotify) {
+        thBuildApi, thNotify, ThJobLogUrlModel) {
 
         var $log = new ThLog("PluginCtrl");
 
@@ -56,6 +56,11 @@ treeherder.controller('PluginCtrl', [
                         });
                         $log.debug("buildapi artifacts", $scope.artifacts);
                     }
+                });
+
+                ThJobLogUrlModel.get_list($scope.job.id)
+                .then(function(data){
+                    $scope.job_log_urls = data;
                 });
 
                 $scope.visibleFields = {

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -2,15 +2,29 @@
 
 <nav class="navbar navbar-dark">
     <ul class="nav navbar-nav bottom-panel-controls">
-        <li ng-if="logs" ng-disabled="artifacts.length>0">
-            <a title="Open the structured log in a new window" target="_blank" href="{{ lvUrl }}">
+
+        <li ng-repeat="job_log_url in job_log_urls">
+            <a ng-if="job_log_url.parse_status == 'parsed'"
+               title="Open the structured log in a new window"
+               target="_blank"
+               href="{{ lvUrl }}"
+               class="">
+                <span class="glyphicon glyphicon-tasks"></span>
+            </a>
+            <a ng-if="job_log_url.parse_status == 'failed'"
+               title="Log parsing has failed"
+               class="disabled" >
+                <span class="glyphicon glyphicon-tasks"></span>
+            </a>
+            <a ng-if="job_log_url.parse_status == 'pending'"
+               class="disabled"
+               title="Log parsing in progress">
                 <span class="glyphicon glyphicon-tasks"></span>
             </a>
         </li>
-        <li ng-repeat="joblog in logs">
-            <a title="Open the raw log in a new window"
-               target="_blank"
-               href="{{ joblog.url }}">
+
+        <li ng-repeat="job_log_url in job_log_urls">
+            <a title="Open the raw log in a new window" target="_blank" href="{{ job_log_url.url }}">
                 <span class="glyphicon glyphicon-list-alt"></span>
             </a>
         </li>
@@ -109,6 +123,10 @@
         <li class="small" ng-repeat="(label, value) in visibleFields">
             <label>{{label}}:</label>
             <span>{{value}}</span>
+        </li>
+        <li class="small" ng-repeat="job_log_url in job_log_urls">
+            <label>Log parsing status:</label>
+            <span>{{ job_log_url.parse_status }}</span>
         </li>
     </ul>
     <div class="printlines">


### PR DESCRIPTION
This patch shows the log parsing status for a job in the bottom panel. The structured log button is disabled or not accordingly to it.
See https://github.com/mozilla/treeherder-service/pull/173 for the server side counterpart
