### PR TITLE
Enable text copy from log steps buttons (1030627)

### DIFF
--- a/webapp/app/css/logviewer.css
+++ b/webapp/app/css/logviewer.css
@@ -1,6 +1,6 @@
 body {
     padding: 20px;
-	padding-top: 270px;
+    padding-top: 270px;
     white-space: nowrap;
     float: left;
 }
@@ -15,7 +15,10 @@ body {
     background-color: white;
     color: #333333;
     width: 100%;
-    overflow: hidden;
+}
+
+.lv-error-line span:nth-child(2) {
+    white-space: normal;
 }
 
 .lv-log-container {
@@ -72,6 +75,11 @@ body {
 
 .logviewer-step {
     overflow: hidden;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    -o-user-select: text;
+    user-select: text;
 }
 
 .logviewer-step.selected {
@@ -89,6 +97,7 @@ body {
 
 .lv-line-no.label {
     border-radius: 0px;
+    margin: 0em 0.6em 0em 0em;
 }
 
 .lv-log-loading {

--- a/webapp/app/partials/lvLogSteps.html
+++ b/webapp/app/partials/lvLogSteps.html
@@ -2,7 +2,7 @@
     <div ng-repeat="step in artifact.step_data.steps"
          ng-click="displayLog(step)"
          ng-class="{'selected': (displayedStep.order === step.order),
-                    'btn-success': (step.error_count === 0), 
+                    'btn-success': (step.error_count === 0),
                     'btn-warning': (step.error_count > 0)}"
          ng-if="showSuccessful === true || step.error_count !== 0"
          class="btn btn-block logviewer-step clearfix"
@@ -30,11 +30,7 @@
                 </span>
 
                 <span title="{{error.line}}">
-                    {{error.line | limitTo: 67}}
-                </span>
-
-                <span ng-if="error.line.length > 70">
-                    ...
+                    {{error.line}}
                 </span>
             </div>
         </div>
@@ -42,7 +38,7 @@
 </div>
 
 <div ng-if="artifact && totalErrors() !== 0">
-    <input type="checkbox"  
+    <input type="checkbox"
            ng-model="showSuccessful"
            ng-change="toggleSuccessfulSteps()" />
 


### PR DESCRIPTION
This work addresses Bugzilla bug [1030627](https://bugzilla.mozilla.org/show_bug.cgi?id=1030627).

The log steps and the log step error lines can now be selected, copied and pasted, like TBPL. I've tested a variety of failed jobs using different log content of varying sizes (short, hugely long) and it seems to behave as expected on Firefox.

As noted in the bug, it works fine on Google Chrome, but the carriage-returns get lost during the copy. I have been digging on stack overflow, and trying some workarounds injecting discrete line endings, but Chrome seems to ignore them too. There seems to be a number of complaints about Chrome with this behavior in both directions, including [this example](https://github.com/ether/etherpad-lite/issues/2078).

There were a few white space corrections made in the files, in proximity to changed code.

Adding @jeads for visibility.

Tested on Windows:
FF Release **30.0**
Chrome Latest Release **35.0.1916.153 m**
