### PR TITLE
Remove links to timeline and machines view (1032470)

### DIFF
--- a/webapp/app/partials/thGlobalTopNavPanel.html
+++ b/webapp/app/partials/thGlobalTopNavPanel.html
@@ -5,8 +5,9 @@
     <div class="navbar-collapse collapse th-global-navbar">
         <!-- nav begin -->
         <span class="nav navbar-nav">
+            <!-- 'timeline' and 'machines' currently removed from viewOption -->
             <span class="btn-group"
-                  ng-repeat="viewOption in ['jobs', 'timeline', 'machines']">
+                  ng-repeat="viewOption in ['jobs']">
                 <a class="btn btn-view-nav"
                    ng-class="{'active': (locationPath===viewOption)}"
                    href="#/{{viewOption}}">{{viewOption}}</a>


### PR DESCRIPTION
This work addresses Bugzilla bug [1032470](https://bugzilla.mozilla.org/show_bug.cgi?id=1032470).

As per discussion on IRC, it seemed the simplest method of suppressing the UI in the template, rather than trying to target injected elements with an ng-hide, or new css class on an nth-child() of the parent. We could try the ng-hide though if you feel it is a better approach.

I've added a comment in the code for ease of re-introduction later.

Adding @jeads and @camd for visibility.

Tested on Windows:
FF Release **30.0**
Chrome Latest Release **35.0.1916.153 m**
