### PR TITLE
Add revision link to logviewer (1032504)

### DIFF
--- a/webapp/app/js/controllers/logviewer.js
+++ b/webapp/app/js/controllers/logviewer.js
@@ -1,17 +1,19 @@
 'use strict';
 
 logViewer.controller('LogviewerCtrl', [
-    '$anchorScroll', '$scope', 'ThLog', '$rootScope', '$location', '$http',
-    '$timeout', '$q', 'ThJobArtifactModel', 'ThLogSliceModel',
+    '$anchorScroll', '$http', '$location', '$q', '$rootScope', '$scope',
+    '$timeout', 'ThJobArtifactModel', 'ThLog', 'ThLogSliceModel',
     function Logviewer(
-        $anchorScroll, $scope, ThLog, $rootScope, $location, $http,
-        $timeout, $q, ThJobArtifactModel, ThLogSliceModel) {
+        $anchorScroll, $http, $location, $q, $rootScope, $scope,
+        $timeout, ThJobArtifactModel, ThLog, ThLogSliceModel) {
 
         var $log = new ThLog('LogviewerCtrl');
 
         // changes the size of chunks pulled from server
         var LINE_BUFFER_SIZE = 100;
         var LogSlice;
+
+        $rootScope.urlBasePath = $location.absUrl().split('logviewer')[0];
 
         var query_string = $location.search();
         if (query_string.repo !== "") {
@@ -73,8 +75,8 @@ logViewer.controller('LogviewerCtrl', [
                 $scope.loading = true;
 
                 LogSlice.get_line_range({
-                    job_id: $scope.job_id, 
-                    start_line: range.start, 
+                    job_id: $scope.job_id,
+                    start_line: range.start,
                     end_line: range.end
                 }, {
                     buffer_size: LINE_BUFFER_SIZE
@@ -96,7 +98,7 @@ logViewer.controller('LogviewerCtrl', [
                     } else if (bounds.bottom) {
                         var sh = element.scrollHeight;
                         var lines = $scope.displayedLogLines;
-    
+
                         for (var i = 0; i < data.length; i++) {
                             // make sure we are inserting at the right place
                             if (lines[ lines.length - 1 ].index != data[i].index - 1) continue;
@@ -146,6 +148,10 @@ logViewer.controller('LogviewerCtrl', [
             .then(function(artifact_list){
                 if(artifact_list.length > 0){
                     $scope.artifact = artifact_list[0].blob;
+
+                    var revision = $scope.artifact.header.revision.substr(0,12);
+                    $scope.logRevisionFilterUrl = $scope.urlBasePath + "index.html#/jobs?repo=" +
+                                                  $scope.repoName + "&revision=" + revision;
                 }
             });
         };
@@ -200,7 +206,7 @@ logViewer.controller('LogviewerCtrl', [
 
         function getChunkContaining (line, request) {
             var index = Math.floor(line/LINE_BUFFER_SIZE);
-            
+
             request.start = index * LINE_BUFFER_SIZE;
             request.end = (index + 1) * LINE_BUFFER_SIZE;
         }
@@ -239,6 +245,5 @@ logViewer.controller('LogviewerCtrl', [
             var endSlice = $scope.displayedLogLines.length - LINE_BUFFER_SIZE;
             $scope.displayedLogLines = $scope.displayedLogLines.slice(0, endSlice);
         }
-
     }
 ]);

--- a/webapp/app/logviewer.html
+++ b/webapp/app/logviewer.html
@@ -13,7 +13,14 @@
             <div class="col-md-6">
                 <table class="table table-condensed">
                     <tr ng-repeat="(label, value) in artifact.header">
-                        <th>{{label}}</th><td>{{value}}</td>
+                        <th>{{label}}</th>
+                        <td ng-if="label == 'revision'">
+                            <a href="{{logRevisionFilterUrl}}"
+                               title="open resultset in new tab"
+                               target="_blank"
+                               class="repo-link">{{value}}</a>
+                        </td>
+                        <td ng-if="label != 'revision'">{{value}}</td>
                     </tr>
                 </table>
             </div>
@@ -29,27 +36,38 @@
 
 
     <!-- build:js js/logviewer.min.js -->
+    <script src="vendor/jquery-2.0.3.js"></script>
     <script src="vendor/angular/angular.js"></script>
     <script src="vendor/angular/angular-route.js"></script>
     <script src="vendor/angular/angular-resource.js"></script>
     <script src="vendor/angular/angular-cookies.js"></script>
     <script src="vendor/angular-local-storage.min.js"></script>
-    <script src="vendor/underscore-min.js"></script>
-    <script src="vendor/ui-bootstrap-tpls-0.10.0.min.js"></script>
-    <script src="vendor/jquery-2.0.3.js"></script>
-    <script src="vendor/bootstrap.js"></script>
     <script src="vendor/angular/angular-sanitize.min.js"></script>
-    <script src="js/config/local.conf.js"></script>
+    <script src="vendor/ui-bootstrap-tpls-0.10.0.min.js"></script>
+    <script src="vendor/bootstrap.js"></script>
+    <script src="vendor/socket.io.js"></script>
+    <script src="vendor/underscore-min.js"></script>
+
     <script src="js/app.js"></script>
-    <script src="js/services/main.js"></script>
-    <script src="js/services/log.js"></script>
-    <script src="js/models/job_artifact.js"></script>
-    <script src="js/models/log_slice.js"></script>
+    <script src="js/config/local.conf.js"></script>
     <script src="js/providers.js"></script>
-    <script src="js/controllers/logviewer.js"></script>
+
+    <!-- Directives -->
     <script src="js/directives/log_viewer_infinite_scroll.js"></script>
     <script src="js/directives/log_viewer_lines.js"></script>
     <script src="js/directives/log_viewer_steps.js"></script>
+
+    <!-- Main services -->
+    <script src="js/services/main.js"></script>
+    <script src="js/services/log.js"></script>
+
+    <!-- Model services -->
+    <script src="js/models/job_artifact.js"></script>
+    <script src="js/models/log_slice.js"></script>
+
+    <!-- Controllers -->
+    <script src="js/controllers/logviewer.js"></script>
     <!-- endbuild -->
+
     </body>
 </html>


### PR DESCRIPTION
This work addresses item 2 of Bugzilla bug [1032504](https://bugzilla.mozilla.org/show_bug.cgi?id=1032504).
`It would be really handy if the log viewer, linked to its resultset on treeherder.`

I have split the main bug above into separate PR's to speed up delivery. And to make things easier to revert anything, in the (hopefully unlikely) event that was necessary.

The revision now appears as a suitable link in logviewer, and handles revisions of varying sizes. I've tested a variety of logs from failed jobs from different repos and it appears to behave correctly on both Firefox and Chrome.

During the work, I thought I might have required other logviewer controller parameters. That turned out not to be the case. However during that period, I agreed with @camd on IRC that a sorted alphabetic list for main elements followed by alphabetic Th elements made sense. Similarly mimicking the same ordering for the .js modules in logviewer.html (which is already sort-of in place in index.html) as alphabetic and divided by category. So even though no additions ended up being needed, I left that re-ordering in. There was also some minor white space cleanup.

If I get time I will do that alphabetic re-ordering across all files, later, in separate work. It seemed to make it a bit easier for me to compare files.

Tested on Windows:
FF Release **30.0**
Chrome Latest Release **35.0.1916.153 m**
