### PR TITLE
Fix bug summary sanitization (1030401 and 1030959)

### DIFF
--- a/webapp/app/js/filters.js
+++ b/webapp/app/js/filters.js
@@ -69,3 +69,16 @@ treeherder.filter('highlightCommonTerms', function(){
     };
 });
 
+treeherder.filter('escapeHTML', function() {
+    return function(text){
+        if (text) {
+        return text.
+            replace(/&/g, '&amp;').
+            replace(/</g, '&lt;').
+            replace(/>/g, '&gt;').
+            replace(/'/g, '&#39;').
+            replace(/"/g, '&quot;');
+        }
+        return '';
+    };
+});

--- a/webapp/app/plugins/failure_summary/main.html
+++ b/webapp/app/plugins/failure_summary/main.html
@@ -1,5 +1,6 @@
 <div class="full-height" ng-controller="BugsPluginCtrl">
     <ul class="list-unstyled failure-summary-list">
+
         <li ng-repeat="failure in bugs">
             <div class="failure-summary-line"><strong>{{failure.search}}</strong></div>
             <span ng-repeat="visible in ['open','closed']">
@@ -13,7 +14,7 @@
                         </button>
                         <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{bug.id}}"
                            ng-class="{'deleted': bug.resolution != ''}">{{bug.id}}</a>
-                        <span ng-bind-html="bug.summary | highlightCommonTerms:failure.search"
+                        <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:failure.search"
                               title="{{bug.summary}}"
                               ng-class="{'deleted': bug.resolution != ''}">
                         </span>


### PR DESCRIPTION
The angular sanitize module was failing because some bug summaries
contain unclosed tags. I added a filter to escape '<' and '>' characters
before the word highlighter filter. This fixes both bug 1030401 and
1030959
