### PR TITLE
Match job pinning keyboard shortcut to TBPL (1033268)

### DIFF
--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -56,7 +56,7 @@
             <div class="panel-heading"><h3>Keyboard shortcuts</h3></div>
             <div class="panel-body">
                 <table id="shortcuts">
-                    <tr><th>s</th>
+                    <tr><th>spacebar</th>
                     <td>Add selected job to the pin board</td></tr>
                     <tr><th>j</th>
                     <td>Highlight next unstarred failure</td></tr>

--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -54,9 +54,15 @@ treeherder.controller('MainCtrl', [
                         thEvents.selectPreviousUnclassifiedFailure
                     );
 
-                } else if (ev.keyCode === 83) {
-                    //Select/deselect active build or changeset, keys:s
-                    $rootScope.$broadcast(thEvents.jobPin, $rootScope.selectedJob);
+                } else if (ev.keyCode === 32) {
+                    // If a job is selected add it otherwise
+                    // let the browser handle the spacebar
+                    if ($scope.selectedJob) {
+                        // Pin selected job to pinboard, key:[spacebar]
+                        // and prevent page down propagating to the jobs panel
+                        ev.preventDefault();
+                        $rootScope.$broadcast(thEvents.jobPin, $rootScope.selectedJob);
+                    }
 
                 } else if (ev.keyCode === 85) {
                     //display only unclassified failures, keys:u


### PR DESCRIPTION
This work fixes Bugzilla bug [1033268](https://bugzilla.mozilla.org/show_bug.cgi?id=1033268).

The key event `spacebar`, now pins the selected job to the pin board. If no job is selected the method is bypassed. I've tested a variety of jobs, with 
- new pin (jobs page down suppressed)
- single, multiple pins (as above)
- pinning with a collapsed pin board (job counter increments, page down suppressed)
- re-pinning to a cleared pin board
- spacebar event with no selected jobs (page down event)
- spacebar event with closed job details panel (page down event)

and it appears to behave correctly on both Firefox and Chrome. A big thanks to @camd for helping me worth through the mystery of Chrome working and internally setting the event, where Firefox was not.

Tested on Windows:
FF Release **30.0**
Chrome Latest Release **35.0.1916.153 m**
