### PR TITLE
Add raw log link to logviewer (1032504)

### DIFF
--- a/webapp/app/css/logviewer.css
+++ b/webapp/app/css/logviewer.css
@@ -1,6 +1,6 @@
 body {
     padding: 20px;
-    padding-top: 270px;
+    padding-top: 284px;
     white-space: nowrap;
     float: left;
 }
@@ -27,7 +27,7 @@ body {
     position: absolute;
     overflow: auto;
     right: 0px;
-    top: 270px;
+    top: 284px;
     left: 0px;
     bottom: 0px;
     padding: 20px;
@@ -56,24 +56,26 @@ body {
 }
 
 .run-data {
-    height: 270px;
+    height: 284px;
     width: 100%;
     position: fixed;
     top: 0px;
     left: 0px;
     background-color: #FFF;
-    padding: 30px;
+    padding: 20px;
     border-bottom: 1px solid #EFEFEF;
 }
 
 .run-data .steps-data {
     height: 210px;
     overflow: auto;
-    border: 1px solid #EFEFEF;
-	padding: 10px;
+    border-color: #dddddd;
+    border-width: 1px;
+    border-style: solid none;
 }
 
 .logviewer-step {
+    border-radius: 2px;
     overflow: hidden;
     -webkit-user-select: text;
     -moz-user-select: text;
@@ -95,6 +97,22 @@ body {
     border-color: #d58512;
 }
 
+.logviewer-stepbar {
+    display: inline-block;
+    margin: 8px 8px 8px 0px;
+    padding: 6px 8px;
+    border: 1px solid #dddddd;
+}
+
+.logviewer-stepbar span {
+    color: #9fa3a5;
+}
+
+.logviewer-stepbar input[type="checkbox"] {
+    margin: 0;
+    vertical-align: middle;
+}
+
 .lv-line-no.label {
     border-radius: 0px;
     margin: 0em 0.6em 0em 0em;
@@ -102,7 +120,7 @@ body {
 
 .lv-log-loading {
     position: fixed;
-    top: 280px;
+    top: 284px;
     left: 50%;
     background: #FFF;
     color: #585858;

--- a/webapp/app/partials/lvLogSteps.html
+++ b/webapp/app/partials/lvLogSteps.html
@@ -37,7 +37,14 @@
     </div>
 </div>
 
-<div ng-if="artifact && totalErrors() !== 0">
+<div class="logviewer-stepbar">
+    <a title="Open the raw log in a new window" target="_blank" href="{{artifact.logurl}}">
+        <span class="glyphicon glyphicon-align-left"></span>
+    </a>
+</div>
+
+<div ng-if="artifact && totalErrors() !== 0"
+     class="logviewer-stepbar">
     <input type="checkbox"
            ng-model="showSuccessful"
            ng-change="toggleSuccessfulSteps()" />

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -25,7 +25,7 @@
 
         <li ng-repeat="job_log_url in job_log_urls">
             <a title="Open the raw log in a new window" target="_blank" href="{{ job_log_url.url }}">
-                <span class="glyphicon glyphicon-list-alt"></span>
+                <span class="glyphicon glyphicon-align-left"></span>
             </a>
         </li>
         <li>


### PR DESCRIPTION
This work addresses item 1 of Bugzilla bug [1032504](https://bugzilla.mozilla.org/show_bug.cgi?id=1032504).
`It would be really handy if the log viewer, linked to its raw log on treeherder.`

The raw log now appears as a suitable link in logviewer, below the log steps in a new class I've called `logviewer-stepbar` (evocative of navbar). I did a bunch of other optimizations to increase real estate, removing 10px of padding overall from the entire top run-data div, removing padding from the log steps div so each log step now draws across the entire width of its container. I added a bootstrap color matched grey boundary line at the top and bottom of the steps container, with none on the sides (since each log step provides that border). I overrode the bootstrap corner radius of 4px and tightened it to 2px so those upper and lower boundary lines don't overhang. I aligned the check box, which wasn't aligned. The raw log and 'successful step' elements now have a 1px border, to be evocative of a button.

I've re-purposed `glyphicon-align-left` as the icon for the raw log, as seems to 'read' very well as a log. I adjusted the same icon in the pinboard so they are consistent.

Net, I've increased the entire run-data container dimensions by about 10px vertically. But on the good side we've also created some white space on the left hand side, in case we need an extra item,value pair which Ed alluded to in his bug.

Here is the before and after.

![logviewbefore](https://cloud.githubusercontent.com/assets/3660661/3619890/665e0d3c-0df9-11e4-8202-acda920bfe22.jpg)
![logviewafter_jul17_14](https://cloud.githubusercontent.com/assets/3660661/3619893/6baa959e-0df9-11e4-9a9b-f86effeff1df.jpg)

I've tested the link launch and general UI interaction and appears to behave and look correct on both Firefox and Chrome.

Adding @camd for visibility.

Tested on Windows:
FF Release **30.0**
Chrome Latest Release **35.0.1916.153 m**
