### PR TITLE
Match multiple-job pin key modifier to TBPL (1033266)

### DIFF
--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -70,7 +70,7 @@
                     <td>Show only unstarred failures</td></tr>
                     <tr><th>i</th>
                     <td>toggle in-progress (running/pending) jobs</td></tr>
-                    <tr><th>Shift-Click</th>
+                    <tr><th>Ctrl-Click</th>
                     <td>Add job to the pinboard</td></tr>
                 </table>
             </div>

--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -302,7 +302,7 @@ treeherder.directive('thCloneJobs', [
             switch (ev.which) {
                 case 1:
                     //Left mouse button pressed
-                    if (ev.shiftKey) {
+                    if (ev.ctrlKey) {
                         _.bind(togglePinJobCb, this, ev, el, job)();
                     } else {
                         _.bind(clickJobCb, this, ev, el, job)();

--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -184,7 +184,7 @@ treeherder.provider('thEvents', function() {
             // fired when the job details are loaded
             jobDetailLoaded: "job-detail-loaded-EVT",
 
-            // fired when a job is shift-clicked
+            // fired with a selected job on ctrl-click or spacebar
             jobPin: "job-pin-EVT",
 
             // fired when the user middle-clicks on a job to view the log

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -32,7 +32,7 @@
             <!--the first 3 items are in the same box-->
             <ul class="nav navbar-nav">
                 <li>
-                    <a href="" title="Add the current job to the pinboard. You can click+shift on any job to pin it"
+                    <a href="" title="Add the selected job to the pinboard via ctrl+click or spacebar"
                           ng-click="pinboard_service.pinJob(selectedJob)">
                         <span class="glyphicon glyphicon-pushpin"></span>
                         <span class="pinned-job-count"><strong>{{ getCountPinnedJobs() }}</strong></span>


### PR DESCRIPTION
This work fixes Bugzilla bug [1033266](https://bugzilla.mozilla.org/show_bug.cgi?id=1033266).

The event `ctrl+LMB-click`, now pins the selected job to the pin board. If no job is under the mouse event the method is bypassed. I've tested a variety of jobs, with both Firefox and Chrome and the switch over from `shift` to `ctrl` appears to be behaving as expected.

I've updated all the help and documentation, and I think I have found all occurrences. It would be good to sanity check that in the review. I've included mention of the recent change for `spacebar` pinning, where applicable.

Tested on Windows:
FF Release **30.0**
Chrome Latest Release **35.0.1916.153 m**
