### PR TITLE
Remove unused selection css in index

### DIFF
--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -8,7 +8,6 @@
 
         <!-- build:css css/index.min.css -->
         <link href="css/bootstrap.css" rel="stylesheet" media="screen">
-        <link href="css/select2.css" rel="stylesheet" media="screen">
         <link href="css/font-awesome.min.css" rel="stylesheet" media="screen">
         <link href="css/treeherder.css" rel="stylesheet" media="screen">
         <link href="css/persona-buttons.css" rel="stylesheet" media="screen">


### PR DESCRIPTION
Nothing exciting here, but for some time I had noticed this referenced css does not exist and was generating console errors on launch on my local server.

`GET http://localhost:8000/app/css/select2.css 404 (Not Found)`

This PR removes that unused reference. With it removed, the console error is gone. I also checked to ensure there was no other possibly intended 'select' css in app/css. There doesn't appear to be any.

Tested on Windows:
FF Release **30.0**
Chrome Latest Release **35.0.1916.153 m**

Adding @jeads and @camd for visbility.
