### PR TITLE
Move Failure Summary tab before the Annotations tab (1032508)

### DIFF
--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -66,12 +66,31 @@
         </li>
 
     </ul>
-    <ul class="nav navbar-nav tab-headers">
-        <li ng-repeat="(tab_id, tab) in tabs" ng-class="{'active': tab.active}">
-            <a title="show {{ tab.title }}" href="" ng-click="show_tab(tab)">{{ tab.title }}</a>
-        </li>
 
+    <ul class="nav navbar-nav tab-headers">
+        <li ng-class="{'active': tabs.failure_summary.active}">
+            <a title="show Failure summary"
+               href=""
+               ng-click="show_tab(tabs.failure_summary)">
+               Failure summary
+            </a>
+        </li>
+        <li ng-class="{'active': tabs.annotations.active}">
+            <a title="show Annotations"
+               href=""
+               ng-click="show_tab(tabs.annotations)">
+               Annotations
+            </a>
+        </li>
+        <li ng-class="{'active': tabs.similar_jobs.active}">
+            <a title="show Similar jobs"
+               href=""
+               ng-click="show_tab(tabs.similar_jobs)">
+               Similar jobs
+            </a>
+        </li>
     </ul>
+
     <ul class="nav navbar-nav pull-right">
         <li>
             <a href="" ng-click="togglePinboardVisibility()">


### PR DESCRIPTION
This work fixes Bugzilla bug [1032508](https://bugzilla.mozilla.org/show_bug.cgi?id=1032508).

The _Failure summary_ tab now appears as the first tab in the plugin panel, followed by _Annotations_ and _Similar jobs_.

In discussion with @camd we were thinking originally we might implement an object array filter. Which, with an added index number on each tab object, would allow us to access our object array as a plain array for use with `ng-repeat.. orderBy :` - which currently only works with a plain array. This would keep the markup down to one line, but would result in a larger amount of filter code added elsewhere.

For historical reference - I've included a nice example of that filter concept [here](http://stackoverflow.com/questions/14478106/angularjs-sorting-by-property), and its [jsfiddle](http://jsfiddle.net/xZEnK/14/), in case we ever need to revisit that later.

In discussion with @jeads on Friday on IRC he felt it would be simpler and more obvious just to order them in the markup. So I have done that. I needed to modify the request in the markup, accessing each tab object separately.

I've tested all the functionality that was obvious to me as a newbie (tab switching, reloading, job selection, pin-list selection) comparing the UX directly with production, and everything seemed to be working as expected.

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **36.0.1985.125 m**

Adding @jeads and @camd for visibility.
