### PR TITLE
Improve readability of failure summary content (1043785)

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -517,9 +517,8 @@ div#bottom-panel.with-pinboard #bottom-center-panel{
     overflow: auto;
 }
 
-ul.failure-summary-list li{
-    padding: 1px 0 1px 5px ;
-
+ul.failure-summary-list li {
+    padding: 0px 0px 0px 8px;
 }
 
 ul.failure-summary-list li .btn-xs{
@@ -527,8 +526,17 @@ ul.failure-summary-list li .btn-xs{
 }
 
 .failure-summary-line {
-    background-color: rgba(169, 169, 169, 0.47);
+    padding: 7px 0px 3px;
     color: #444444;
+}
+
+.failure-summary-bugs {
+    padding: 0px 0px 0px 14px;
+}
+
+.failure-summary-bugs button {
+    padding: 2px 5px 2px 4px;
+    margin: 0px 0px 1px;
 }
 
 .shadowed-panel {

--- a/webapp/app/plugins/failure_summary/main.html
+++ b/webapp/app/plugins/failure_summary/main.html
@@ -2,15 +2,15 @@
     <ul class="list-unstyled failure-summary-list">
 
         <li ng-repeat="failure in bugs">
-            <div class="failure-summary-line"><strong ng-bind="failure.search"></strong></div>
+            <div class="failure-summary-line"><span ng-bind="failure.search"></span></div>
             <span ng-repeat="visible in ['open','closed']">
-                <ul class="list-unstyled">
+                <ul class="list-unstyled failure-summary-bugs">
                     <li ng-repeat="bug in failure[visible] | orderBy:bug.relevance:reverse"
                         ng-show="$index<3 || show_all">
                         <button class="btn btn-xs btn-default"
                                 ng-click="pinboard_service.addBug(bug, selectedJob)"
                                 title="add to list of bugs to associate with all pinned jobs">
-                            <i class="fa fa-plus"></i>
+                            <i class="glyphicon glyphicon-pushpin"></i>
                         </button>
                         <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{bug.id}}"
                            ng-class="{'deleted': bug.resolution != ''}">{{bug.id}}</a>


### PR DESCRIPTION
This work fixes Bugzilla bug [1043785](https://bugzilla.mozilla.org/show_bug.cgi?id=1043785).

The Failure Summary content now:
- has a failure line which is slightly inset, plain text (not bold), with page background (not grey)
- has an indented bug list
- has a subtle grouping of an error and its corresponding bugs, for readability
- has non-strike/strike bug-list item blocks which now have uniform leading
- has a more subtle pushpin glyph, replacing the old higher contrast [+]  fa-plus icon

The last point above with approval from Sheriffs - since 'adding the bug to the the pin board' is the action triggered by a click. The rest of the line is preserved for now in plain text, after similar discussion with several Sheriffs in the bug and IRC about the merits (or not) of making the entire bug line a blue link, like TPBL. Doing that would also prevent partial selection of the line. It is an easy template change though later, if we decide to do that.

We decided not to justify long wrapped bug lines underneath the bug number for now, to reduce risk of line feed issues during copy/paste.

I've looked at quite a few failures on mozilla-central during the iterations with the Sheriffs, and the various types of errors seem to work well and seem more readable with the new layout.

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **36.0.1985.125 m**

Adding @jeads and @camd for visibility.
