### PR TITLE
Remove up and down arrows in bug number input (1045611)

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -631,6 +631,17 @@ ul.failure-summary-list li .btn-xs{
     background-color: #FFFFFF;
 }
 
+/* Spin button suppression on chrome */
+#pinboard-related-bugs form input[type=number]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+/* Spin button suppression on firefox */
+#pinboard-related-bugs form input[type=number] {
+    -moz-appearance: textfield;
+}
+
 #pinboard-classification{
     position: absolute;
     top: 2px;


### PR DESCRIPTION
This work fixes Bugzilla bug [1045611](https://bugzilla.mozilla.org/show_bug.cgi?id=1045611).

The up/down spin button arrows in the bug number input field have been suppressed, since they don't really have meaning in this UI context. I am not sure if the `input[type=number]` is really required for Chrome but that specificity didn't seem to do any harm.

We elected to keep the input field its current width for now, since there's no harm in doing so.

![buginputfieldcurrentwidth](https://cloud.githubusercontent.com/assets/3660661/3740021/d0bd7f04-1750-11e4-8146-2c68f45a831d.jpg)

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **36.0.1985.125 m**

Adding @jeads and @camd for visibility.
