### PR TITLE
Class based filtering

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -285,6 +285,7 @@ body {
     font-size: 12px;
     padding-left: 0;
     padding-right: 5px;
+    min-width: 110px;
 }
 
 .result-set {

--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -156,7 +156,7 @@
 </script>
 <!-- Clone target for each platform -->
 <script type="'text/ng-template'" id="platformClone.html">
-    <td class="col-xs-2 platform">
+    <td class="platform">
         <span>{{ name }} {{ option }}</span>
     </td>
 </script>
@@ -170,6 +170,7 @@
 <script type="'text/ng-template'" id="jobGroupBeginClone.html">
     <span style="margin-right:2px;" class="platform-group">
         <span class="disabled job-group" title="{{ name }}">{{ symbol }}(</span>
+        <span class="job-group-list"></span>)
     </span>
 </script>
 <!-- Close span for job groups -->
@@ -179,7 +180,10 @@
 
 <!-- Job Btn span -->
 <script type="'text/ng-template'" id="jobBtnClone.html">
-    <span style="margin-right:1px;" class="btn job-btn btn-xs {{ btnClass }} {{ key }}" data-jmkey="{{ key }}" title="{{ title }}">{{ value }}</span>
+    <span style="margin-right:1px;"
+          class="btn job-btn btn-xs {{ btnClass }}"
+          data-jmkey="{{ key }}"
+          title="{{ title }}">{{ value }}</span>
 </script>
 
 <!-- revision url window -->

--- a/webapp/app/js/controllers/filters.js
+++ b/webapp/app/js/controllers/filters.js
@@ -3,16 +3,13 @@
 treeherder.controller('FilterPanelCtrl', [
     '$scope', '$rootScope', '$route', '$routeParams', '$location', 'ThLog',
     'localStorageService', 'thResultStatusList', 'thEvents', 'thJobFilters',
-    'thClassificationTypes',
+    'thClassificationTypes', 'ThResultSetModel', 'thPinboard', 'thNotify',
     function FilterPanelCtrl(
         $scope, $rootScope, $route, $routeParams, $location, ThLog,
         localStorageService, thResultStatusList, thEvents, thJobFilters,
-        thClassificationTypes) {
+        thClassificationTypes, ThResultSetModel, thPinboard, thNotify) {
 
         var $log = new ThLog(this.constructor.name);
-        var filterPrefix = "field-";
-        var filterPrefixLen = filterPrefix.length;
-
 
         $scope.filterOptions = thResultStatusList.all();
 
@@ -192,12 +189,31 @@ treeherder.controller('FilterPanelCtrl', [
             $scope.fieldFilters.splice(index, 1);
         };
 
+        $scope.pinAllShownJobs = function() {
+            if (!thPinboard.spaceRemaining()) {
+                thNotify.send("Pinboard is full.  Can not pin any more jobs.",
+                    "danger",
+                    true);
+                return;
+            }
+            var shownJobs = ThResultSetModel.getAllShownJobs(
+                $rootScope.repoName,
+                thPinboard.spaceRemaining()
+            );
+            thPinboard.pinJobs(shownJobs);
+
+            if (!$rootScope.selectedJob) {
+                $rootScope.selectedJob = shownJobs[0];
+            }
+        };
+
         $scope.thJobFilters = thJobFilters;
 
         var updateToggleFilters = function() {
             for (var i = 0; i < $scope.filterOptions.length; i++) {
                 var opt = $scope.filterOptions[i];
-                $scope.resultStatusFilters[opt] = _.contains(thJobFilters.filters.resultStatus.values, opt);
+                $scope.resultStatusFilters[opt] = _.contains(
+                    thJobFilters.filters.resultStatus.values, opt);
             }
 
             // whether or not to show classified jobs
@@ -231,100 +247,29 @@ treeherder.controller('FilterPanelCtrl', [
          */
         $rootScope.skipNextSearchChangeReload = false;
         $scope.$on('$routeUpdate', function(){
+            $log.debug("route updated", $location.search());
             if (!$rootScope.skipNextSearchChangeReload) {
+                // when switching repos via the repos panel, you click a link
+                // that is a new route.  So it comes here, and we reload
+                // the route.  But the filters will be left on in thJobFilters
+                // but not in the URL.  So we reset all the filters here.
+                // If we wanted to retain the filters (like set to unclassified
+                // failures only) then we'd take out the next line and rebuild
+                // the url from the filters that are set.  Possibly just with
+                // a broadcast of ``globalFilterChanged``.
+                thJobFilters.buildFiltersFromQueryString();
+                $log.debug("route reloading");
                 $route.reload();
             } else {
-                $rootScope.skipNextSearchChangeReload = false;
+                $log.debug("route NOT reloading");
             }
+            $rootScope.skipNextSearchChangeReload = false;
         });
-
-        var updateSearchWithoutReload = function(key, values) {
-            $rootScope.skipNextSearchChangeReload = true;
-            $location.search(key, values);
-        };
 
         $scope.$on(thEvents.globalFilterChanged, function() {
             updateToggleFilters();
-
-            // update the url search params accordingly
-            $location.search("isClassified", null);
-            $location.search("resultStatus", null);
-            $location.search("searchQuery", null);
-            // remove any field filters
-            _.each($location.search(), function(filterVal, filterKey) {
-                if (filterKey.slice(0, filterPrefixLen) === filterPrefix) {
-                    $rootScope.skipNextSearchChangeReload = true;
-                    $location.search(filterKey, null);
-                }
-            });
-
-            _.each(thJobFilters.filters, function(val, key) {
-                var values = _.uniq(val.values);
-                if (key === "resultStatus" || key === "isClassified") {
-                    // don't add to query string if it matches the defaults
-                    $log.debug("set query string checks", key, values);
-                    if (!thJobFilters.matchesDefaults(key, values)) {
-                        if (key === "isClassified") {
-                            values = _.map(values, function(item) {return item.toString();});
-                        }
-                        $log.debug("not defaults, setting check query strings", key, values);
-                        updateSearchWithoutReload(key, values);
-                    }
-
-                } else {
-                    $log.debug("setting field query strings", key, values);
-                    updateSearchWithoutReload(filterPrefix + key, values);
-                }
-            });
-
-            if ($rootScope.searchQuery && typeof $rootScope.searchQuery === 'string'){
-                updateSearchWithoutReload("searchQuery", $rootScope.searchQuery);
-            }
-
+            thJobFilters.buildQueryStringFromFilters();
         });
-
-        /**
-         * When the page first loads, check the query string params for
-         * filters and apply them.
-         */
-        var loadFiltersFromQueryString = function() {
-            // field filters
-            var search = _.clone($location.search());
-            $log.debug("query string params", $location.search());
-
-            _.each(search, function (filterVal, filterKey) {
-                $log.debug("field filter", filterKey, filterVal);
-                if (filterKey.slice(0, filterPrefixLen) === filterPrefix) {
-                    $log.debug("adding field filter", filterKey, filterVal);
-                    $scope.newFieldFilter = {
-                        field: filterKey.slice(filterPrefixLen),
-                        value: filterVal
-
-                    };
-                    $scope.addFieldFilter(true);
-
-                } else if (filterKey === "resultStatus" || filterKey === "isClassified") {
-                    $log.debug("adding check filter", filterKey, filterVal);
-                    if (!_.isArray(filterVal)) {
-                        filterVal = [filterVal];
-                    }
-                    // these will come through as strings, so convert to actual booleans
-                    if (filterKey === "isClassified") {
-                        filterVal = _.map(filterVal, function(item) {return item !== "false";});
-                    }
-                    thJobFilters.setCheckFilterValues(filterKey, _.uniq(filterVal), true);
-                } else if (filterKey === "searchQuery") {
-                    filterVal = _.isArray(filterVal)? filterVal[0]: filterVal;
-                    $log.debug("searchQuery added", filterVal);
-                    $rootScope.searchQuery = filterVal;
-                }
-            });
-            $log.debug("done with loadFiltersFromQueryString", thJobFilters.filters);
-            $rootScope.$broadcast(thEvents.globalFilterChanged);
-
-        };
-
-        loadFiltersFromQueryString();
 
     }
 ]);

--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -157,6 +157,8 @@ treeherder.controller('MainCtrl', [
             thJobFilters.toggleInProgress();
         };
 
+        thJobFilters.buildFiltersFromQueryString();
+
         $scope.allExpanded = function(cls) {
             var fullList = $("." + cls);
             var visibleList = $("." + cls + ":visible");
@@ -232,10 +234,11 @@ treeherder.controller('MainCtrl', [
             $rootScope.selectedJob = null;
             thPinboard.unPinAll();
 
-            $location.search("repo", repo_name);
+            $rootScope.skipNextSearchChangeReload = true;
             $location.search("revision", null);
+            $rootScope.skipNextSearchChangeReload = false;
+            $location.search("repo", repo_name);
             $scope.repoModel.setCurrent(repo_name);
-
         };
 
         $scope.pinboardCount = thPinboard.count;

--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -198,7 +198,6 @@ treeherder.directive('thCloneJobs', [
     var addJobBtnEls = function(
         jgObj, jobBtnInterpolator, jobTdEl, resultStatusFilters, jobCounts){
 
-        var showJob = false;
         var jobsShown = 0;
 
         var lastJobSelected = ThResultSetModel.getSelectedJob(
@@ -206,6 +205,7 @@ treeherder.directive('thCloneJobs', [
             );
 
         var hText, key, resultState, job, jobStatus, jobBtn, l;
+        var jobBtnArray = [];
 
         for(l=0; l<jgObj.jobs.length; l++){
 
@@ -230,12 +230,10 @@ treeherder.directive('thCloneJobs', [
                 //way down stream job consumers don't need to repeatedly
                 //call showJob
                 job.visible = false;
-                continue;
+            } else {
+                jobsShown++;
+                job.visible = true;
             }
-
-            jobsShown++;
-
-            job.visible = true;
 
             hText = getHoverText(job);
             key = getJobMapKey(job);
@@ -252,10 +250,10 @@ treeherder.directive('thCloneJobs', [
 
             jobStatus.title = hText;
 
+            jobBtn = $( jobBtnInterpolator(jobStatus));
+            jobBtnArray.push(jobBtn);
 
-            jobStatus.btnClass = jobStatus.btnClass;
-
-            jobBtn = $( jobBtnInterpolator(jobStatus) );
+            showHideJob(jobBtn, job.visible);
 
             //If the job is currently selected make sure to re-apply
             //the job selection styles
@@ -268,9 +266,8 @@ treeherder.directive('thCloneJobs', [
                 ThResultSetModel.setSelectedJob(
                     $rootScope.repoName, jobBtn, job);
             }
-
-            jobTdEl.append(jobBtn);
         }
+        jobTdEl.append(jobBtnArray);
 
         return jobsShown;
     };
@@ -506,10 +503,6 @@ treeherder.directive('thCloneJobs', [
 
         var resultSetMap = ThResultSetModel.getResultSetsMap($rootScope.repoName);
 
-        //If at least one job is visible we need to display the platform
-        //otherwise hide it
-        var jobsShownTotal = 0;
-
         var jobCounts = thResultStatusObject.getResultStatusObject();
 
         //Reset counts for the platform every time we render the
@@ -530,21 +523,11 @@ treeherder.directive('thCloneJobs', [
 
                 // Add the job btn spans
                 jobsShown = addJobBtnEls(
-                    jgObj, jobBtnInterpolator, jobTdEl, resultStatusFilters,
+                    jgObj, jobBtnInterpolator, jobGroup.find(".job-group-list"),
+                    resultStatusFilters,
                     jobCounts
                     );
-
-                if(jobsShown > 0){
-                    // Add the job group closure span
-                    jobTdEl.append(
-                        $( thCloneHtml.get('jobGroupEndClone').text )
-                        );
-
-                }else {
-                    // No jobs were displayed in the group, hide
-                    // the group symbol
-                    jobGroup.hide();
-                }
+                jobGroup.css("display", jobsShown? "inline": "none");
 
             }else{
 
@@ -555,18 +538,9 @@ treeherder.directive('thCloneJobs', [
                     );
 
             }
-            //Keep track of all of the jobs shown in a row
-            jobsShownTotal += jobsShown;
         }
-
-        if(jobsShownTotal === 0){
-            //No jobs shown hide the whole row
-            row.hide();
-        }else{
-            row.show();
-        }
-
         row.append(jobTdEl);
+        filterPlatform(row);
 
         //reset the resultset counts for the platformKey
         resultSetMap[resultsetId].platforms[platformKey].job_counts = jobCounts;
@@ -576,34 +550,61 @@ treeherder.directive('thCloneJobs', [
     };
 
     var filterJobs = function(element, resultStatusFilters){
+        $log.debug("filterJobs", element, resultStatusFilters);
 
-        var platformId, platformKey, rowEl, tdEls, i;
+        var job, jmKey, show;
+        var jobMap = ThResultSetModel.getJobMap($rootScope.repoName);
 
-        for(i=0; i<this.resultset.platforms.length; i++){
+        element.find('.job-list .job-btn').each(function internalFilterJob() {
+            // using jquery to do these things was quite a bit slower,
+            // so just using raw JS for speed.
+            jmKey = this.dataset.jmkey;
+            job = jobMap[jmKey].job_obj;
+            show = thJobFilters.showJob(job, resultStatusFilters);
+            job.visible = show;
 
-            platformId = thAggregateIds.getPlatformRowId(
-                $rootScope.repoName,
-                this.resultset.id,
-                this.resultset.platforms[i].name,
-                this.resultset.platforms[i].option
-                );
+            showHideJob($(this), show);
+        });
 
-            rowEl = $( document.getElementById(platformId) );
+        // hide platforms and groups where all jobs are hidden
+        element.find(".platform").each(function internalFilterPlatform() {
+            var platform = $(this.parentNode);
+            filterPlatform(platform);
+        });
 
-            tdEls = rowEl.find('td');
-            // tdEls[0] is the platform <td> and
-            // tdEls[1] is the jobs <td>
-
-            platformKey = ThResultSetModel.getPlatformKey(
-                this.resultset.platforms[i].name, this.resultset.platforms[i].option
-                );
-
-            renderJobTableRow(
-                rowEl, $(tdEls[1]), this.resultset.platforms[i].groups,
-                resultStatusFilters, this.resultset.id, platformKey
-                );
+    };
+    var showHideJob = function(job, show) {
+        // Note: I was using
+        //    jobEl.style.display = "inline";
+        //    jobEl.className += " filter-shown";
+        // but that didn't work reliably with the jquery selectors
+        // when it came to hiding/showing platforms and groups.  Jquery
+        // couldn't detect that I'd added or removed ``filter-shown`` in
+        // all cases.  So, while this is a bit slower, it's reliable.
+        if (show) {
+            job.css("display", "inline");
+            job.addClass("filter-shown");
+        } else {
+            job.css("display", "none");
+            job.removeClass("filter-shown");
         }
+    };
 
+    var filterPlatform = function(platform) {
+        var showPlt = platform.find('.filter-shown').length !== 0;
+        var showGrp;
+
+        if (showPlt) {
+            platform.css("display", "table-row");
+            platform.find(".platform-group").each(function internalFilterGroup() {
+                var grp = $(this);
+                showGrp = grp.find('.filter-shown').length !== 0;
+                grp.css("display", showGrp? "inline": "none");
+            });
+
+        } else {
+            platform.css("display", "none");
+        }
     };
 
     var getPlatformName = function(name){

--- a/webapp/app/js/services/pinboard.js
+++ b/webapp/app/js/services/pinboard.js
@@ -58,6 +58,10 @@ treeherder.factory('thPinboard', [
             }
         },
 
+        pinJobs: function(jobsToPin) {
+            _.forEach(jobsToPin, api.pinJob);
+        },
+
         unPinJob: function(id) {
             delete pinnedJobs[id];
             api.count.numPinnedJobs = _.size(pinnedJobs);

--- a/webapp/app/partials/thFilterPanel.html
+++ b/webapp/app/partials/thFilterPanel.html
@@ -5,7 +5,7 @@
         <span class="pull-right">
             <span class="btn btn-default btn-xs"
                   title="pin all jobs that pass the global filters"
-                  ng-click="thJobFilters.pinAllShownJobs()"><i class="glyphicon glyphicon-pushpin"></i> pin all showing</span>
+                  ng-click="pinAllShownJobs()"><i class="glyphicon glyphicon-pushpin"></i> pin all showing</span>
             <span class="btn btn-default btn-xs"
                   title="show only coalesced jobs"
                   ng-click="thJobFilters.showCoalesced()">coalesced only</span>


### PR DESCRIPTION
fix bug 1033328: Class based filtering with jquery selectors now working

Also fixes bug 1033330 and bug 1043783 as they were related to the work for this perf improvement.
The speed improvements here may not be quite as fast as TBPL, but they should be at an acceptable level.

This changes our filtering mechanism to use JQuery selectors to set jobs, groups and platforms vislble or not.
This also contains some refactoring to make some functions more reusable and prevent circular references in our classes.
