### PR TITLE
Provide supplementary close icon for pinboard (1045099)

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -660,6 +660,16 @@ ul.failure-summary-list li .btn-xs{
     height: 40px;
 }
 
+#pinboard-controls-header {
+    position: absolute;
+    top: 2px;
+    right: 10px;
+}
+
+#pinboard-controls-header a {
+    color: #9fa3a5;
+}
+
 #pinboard-controls{
     position: absolute;
     top: 21px;

--- a/webapp/app/partials/thPinboardPanel.html
+++ b/webapp/app/partials/thPinboardPanel.html
@@ -44,6 +44,16 @@
         </div>
     </div>
 
+    <div id="pinboard-controls-header">
+        <div class="header">
+            <a href="" ng-click="togglePinboardVisibility()">
+                <span title="Close the pinboard"
+                      class="glyphicon glyphicon-remove">
+                </span>
+            </a>
+        </div>
+    </div>
+
     <div id="pinboard-controls" class="btn-group-vertical">
         <button class="btn btn-xs btn-default close-btn"
                 ng-show="hasPinnedJobs()"


### PR DESCRIPTION
This work fixes Bugzilla bug [1045099](https://bugzilla.mozilla.org/show_bug.cgi?id=1045099).

As requested this adds a supplementary close icon into the top right hand corner of the pin board to hide it, in addition to its existing expand/collapse (aka. show/hide) chevron visible underneath. Unlike adjacent containers I just created a discrete div wrapper for the header, rather than wrapping the other UI contents below it within that div.

I was going to try to leverage `navbar-nav` to utilize the existing grey anchor color, but that exists only within top level `li` elements - which this is not. So I just created its own css entry for this header to assign its color. Maybe there is a better way.

Here is the appearance after the fix:

![supplementarypinboardclose](https://cloud.githubusercontent.com/assets/3660661/3770706/ce18a1ae-18ed-11e4-950d-3bd0be0599c2.jpg)

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **36.0.1985.125 m**

Adding @jeads and @camd for visibility.
