### PR TITLE
Correct empty manual pin board bugs (1045774)

### DIFF
--- a/webapp/app/plugins/pinboard.js
+++ b/webapp/app/plugins/pinboard.js
@@ -85,7 +85,6 @@ treeherder.controller('PinboardCtrl', [
         $scope.saveEnteredBugNumber = function() {
             $log.debug("new bug number to be saved: ", $scope.newEnteredBugNumber);
             thPinboard.addBug({id:$scope.newEnteredBugNumber});
-            $scope.newEnteredBugNumber = null;
             $scope.toggleEnterBugNumber();
         };
 


### PR DESCRIPTION
This work fixes Bugzilla bug [1045774](https://bugzilla.mozilla.org/show_bug.cgi?id=1045774) and replicates previous PR[110](https://github.com/mozilla/treeherder-ui/pull/110).

As described in the bug, when creating bugs sequentially by clicking the little "+" icon on the pin board and manually typing/pasting their values - the 2nd-to-N-th bugs after hitting enter, all have empty UI. It appears that `newEnteredBugNumber` was being set to `null` after its first pass (which perhaps explains why the 1st attempt worked).

Here is the appearance before and after the fix, using two bug numbers, "123" and "456":

![currentbehavior](https://cloud.githubusercontent.com/assets/3660661/3742491/fe4f8688-1769-11e4-9211-d851acbb0270.jpg)
![correctbehavior](https://cloud.githubusercontent.com/assets/3660661/3742492/023a50ac-176a-11e4-928b-e3db9ebd8863.jpg)

Looking at the repo, it appears the fix is limited to just this file. But as a newbie I don't know if I am missing anything else in the implications of the change. I have tested the UI pretty extensively with the change, manual bug entry, pasted bug entry, regular bug pinning, removals, illegal characters, etc.

@camd asked on IRC if the input field caches the last entered bug number, and it does (whether or not that is desired). But that behavior is true in the repo and on dev/stage/prod, and that behavior is independent of this fix.

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **36.0.1985.125 m**

Adding @jeads and @camd for visibility.
