### PR TITLE
Update help page link from TBPL to Treeherder (1033241)

### DIFF
--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -12,8 +12,8 @@
 <div class="panel-heading">
     <h1>Treeherder Help</h1>
 
-    <h5>More documentation available at <a href="https://wiki.mozilla.org/Sheriffing/TBPL">
-        https://wiki.mozilla.org/Sheriffing/TBPL
+    <h5>More documentation available at <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder">
+        https://wiki.mozilla.org/Auto-tools/Projects/Treeherder
     </a></h5>
 </div>
 <div class="panel-body">


### PR DESCRIPTION
This work fixes Bugzilla bug [1033241](https://bugzilla.mozilla.org/show_bug.cgi?id=1033241).

This corrects the help page link, pointing the Help page from the legacy TBPL Wiki to the new Treeherder Wiki.

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **36.0.1985.125 m**

Adding @camd for visibility.
