### PR TITLE
Update the readme to make it more comprehensive (1046639)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,34 @@
 treeherder-ui
 =============
 
+#### Description
+<strong><a href="https://treeherder.mozilla.org" target=_newtab>Treeherder</a></strong> is a reporting dashboard for Mozilla checkins. It allows users to see the results of automatic builds and their respective tests. It is comprised of this repo for the front end, and several other component repos.
 
-Please visit our ``readthedocs`` page at:
+A <a href="https://github.com/mozilla/treeherder-service" target=_newtab>treeherder-service</a> repo for backend services.
+
+A <a href="https://github.com/mozilla/treeherder-client" target=_newtab>treeherder-client</a> for data submission.
+
+A <a href="https://github.com/lightsofapollo/treeherder-node" target=_newtab>treeherder-node</a> NodeJS interface.
+
+
+#### Instances
+Treeherder exists on three instances, <a href="http://treeherder-dev.allizom.org" target=_newtab>dev</a> for treeherder development, <a href="https://treeherder.allizom.org" target=_newtab>stage</a> for pre-deployment validation, and <a href="https://treeherder.mozilla.org" target=_newtab>production</a> for actual use.
+
+
+#### Development
+The easiest way to run treeherder-ui locally is to simply clone this repo, make a copy of the config described <a href="https://treeherder-ui.readthedocs.org/en/latest/installation.html#configuration" target=_newtab>here</a> which will pull in production result data, and start your local server:
+
+```
+cd webapp
+./scripts/web-server.js
+```
+
+#### Links
+
+Visit our project tracking Wiki at:  
+https://wiki.mozilla.org/Auto-tools/Projects/Treeherder
+
+Visit our **readthedocs** page for setup and other configuration at:  
 https://treeherder-ui.readthedocs.org/en/latest/index.html
+
+File any bugs you may encounter [here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree+Management&component=Treeherder).


### PR DESCRIPTION
This work fixes item 1 of Bugzilla bug [1046639](https://bugzilla.mozilla.org/show_bug.cgi?id=1046639).

This updates the readme with all the requested content. I iterated with jeads on it in-channel yesterday, and we are both reasonably happy with it. The only question in my mind is should .MD content have forced line breaks, or should the content line wrap? I am assuming the latter.

We have consciously chosen to use links with `_newtab` redirects to preserve the user's readme page.

Viewed on Windows in Github:
FF Release **31.0**
Chrome Latest Release **36.0.1985.125 m**

Adding @camd and @maurodoglio for visibility.
