### PR TITLE
Make job panel property names case-consistent (1049543)

### DIFF
--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -28,7 +28,7 @@ treeherder.controller('PluginCtrl', [
                 $scope.job = newValue;
 
                 $scope.visibleFields = {
-                    "Job Name": $scope.job.job_type_name,
+                    "Job name": $scope.job.job_type_name,
                     "Start time": "",
                     "Duration":  "",
                     "Machine ": "",
@@ -62,7 +62,7 @@ treeherder.controller('PluginCtrl', [
                         _.forEach(data, function(item) {
                             $scope.artifacts[item.name] = item;
                         });
-                        $scope.visibleFields["Buildbot Job Name"] = $scope.artifacts.buildapi.blob.buildername;
+                        $scope.visibleFields["Buildbot job name"] = $scope.artifacts.buildapi.blob.buildername;
                         $log.debug("buildapi artifacts", $scope.artifacts);
                     }
                 });
@@ -85,11 +85,11 @@ treeherder.controller('PluginCtrl', [
                 // fields that will show in the job detail panel
                 var duration = ($scope.job.end_timestamp-$scope.job.start_timestamp)/60;
                 if (duration) {
-                    duration = numberFilter(duration, 0) + " minutes";
+                    duration = numberFilter(duration, 0) + " minute(s)";
                 }
 
                 $scope.visibleFields = {
-                    "Job Name": $scope.job.job_type_name || undef,
+                    "Job name": $scope.job.job_type_name || undef,
                     "Start time": dateFilter($scope.job.start_timestamp*1000, 'short') || undef,
                     "Duration":  duration || undef,
                     "Machine ": $scope.job.machine_platform_architecture + " " +
@@ -99,7 +99,7 @@ treeherder.controller('PluginCtrl', [
                              $scope.job.build_os || undef
                 };
                 if (_.has($scope.artifacts, "buildapi")) {
-                    $scope.visibleFields["Buildbot Job Name"] = $scope.artifacts.buildapi.blob.buildername;
+                    $scope.visibleFields["Buildbot job name"] = $scope.artifacts.buildapi.blob.buildername;
                 }
         };
 

--- a/webapp/app/plugins/similar_jobs/controller.js
+++ b/webapp/app/plugins/similar_jobs/controller.js
@@ -115,7 +115,7 @@ treeherder.controller('SimilarJobsPluginCtrl', [
                     $scope.similar_job_selected.end_timestamp - $scope.similar_job_selected.start_timestamp
                  )/60;
                 if (duration) {
-                    duration = numberFilter(duration, 0) + " minutes";
+                    duration = numberFilter(duration, 0) + " minute(s)";
                 }
                 $scope.similar_job_selected.duration = duration;
                 $scope.similar_job_selected.start_time = $scope.similar_job_selected.start_timestamp !== 0 ? dateFilter(


### PR DESCRIPTION
This work fixes Bugzilla bug [1049543](https://bugzilla.mozilla.org/show_bug.cgi?id=1049543).

The formatting of the left-hand side job panel property names and attributes are all now `Upper case`, so they are consistent. I also added @maurodoglio's suggestion to pluralize the duration suffix. I am assuming _similar jobs_ requires the same change below.

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **36.0.1985.125 m**

Adding @camd for visibility.
