### PR TITLE
Minor spelling correction in resultsets.js

### DIFF
--- a/webapp/app/js/services/resultsets.js
+++ b/webapp/app/js/services/resultsets.js
@@ -151,7 +151,7 @@ treeherder.factory('thResultSets', [
                             // Send notification with response.status to
                             // UI here
                             thNotify.send(
-                                "Error retrieing job data! response status " + response.status,
+                                "Error retrieving job data! response status " + response.status,
                                 "danger",
                                 true);
                         }


### PR DESCRIPTION
Nothing exciting here, but I happened across this in an unrelated investigation and figured I should fix it.

Adding @camd for visibility.
