### PR TITLE
(bug 1050765) fix persona getting out of sync

### DIFF
--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -244,9 +244,6 @@ treeherder.controller('MainCtrl', [
         $scope.pinboardCount = thPinboard.count;
         $scope.pinnedJobs = thPinboard.pinnedJobs;
 
-        $scope.user = angular.fromJson(localStorageService.get("user")) || {};
-        $scope.user.loggedin = angular.isDefined($scope.user.email) && $scope.user.email !== null;
-
         // get a cached version of the exclusion profiles
         ThExclusionProfileModel.get_list({}, true).then(function(profiles){
             $scope.exclusion_profiles = profiles;

--- a/webapp/app/js/directives/persona.js
+++ b/webapp/app/js/directives/persona.js
@@ -10,28 +10,55 @@ treeherder.directive('personaButtons', [
     return {
         restrict: "E",
         link: function(scope, element, attrs) {
-            scope.user = scope.user
-                || angular.fromJson(localStorageService.get('user'))
-                || {};
-            // check if already know who the current user is
-            // if the user.email value is null, it means that he's not logged in
-            scope.user.email = scope.user.email || null;
-            scope.user.loggedin = scope.user.email == null ? false : true;
+            BrowserId.info.then(function(response){
+                $rootScope.user = {};
+                // if the user.email value is null, it means that he's not logged in
+                $rootScope.user.email = response.data.userEmail || null
+                $rootScope.user.loggedin = $rootScope.user.email === null ? false : true;
+            }).then(function(){
+                navigator.id.watch({
+                    /*
+                    * loggedinUser is all that we know about the user before
+                    * the interaction with persona. This value could come from a cookie to persist the authentication
+                    * among page reloads. If the value is null, the user is considered logged out.
+                    */
+                    loggedInUser: $rootScope.user.email,
+                    /*
+                    * We need a watch call to interact with persona.
+                    * onLogin is called when persona provides an assertion
+                    * This is the only way we can know the assertion from persona,
+                    * so we resolve BrowserId.requestDeferred with the assertion retrieved
+                    */
+                    onlogin: function(assertion){
+                        if (BrowserId.requestDeferred) {
+                            BrowserId.requestDeferred.resolve(assertion);
+                        }
+                    },
+                    /*
+                    * Resolve BrowserId.logoutDeferred once the user is logged out from persona
+                    */
+                    onlogout: function(){
+                        if (BrowserId.logoutDeferred) {
+                            BrowserId.logoutDeferred.resolve();
+                        }
+                    }
+                });
+            })
+
 
             scope.login = function(){
                 /*
-* BrowserID.login returns a promise of the verification.
-* If successful, we will find the user email in the response
-*/
+                * BrowserID.login returns a promise of the verification.
+                * If successful, we will find the user email in the response
+                */
                 BrowserId.login()
                 .then(function(response){
-                    scope.user.loggedin = true;
-                    scope.user.email = response.data.email;
+                    $rootScope.user.loggedin = true;
+                    $rootScope.user.email = response.data.email;
                     // retrieve the current user's info from the api
                     // including the exclusion profile
                     ThUserModel.get().then(function(user){
-                        angular.extend(scope.user, user);
-                        localStorageService.add('user', angular.toJson(scope.user));
+                        angular.extend($rootScope.user, user);
                     }, null);
                 },function(){
                     // logout if the verification failed
@@ -40,41 +67,9 @@ treeherder.directive('personaButtons', [
             };
             scope.logout = function(){
                 BrowserId.logout().then(function(response){
-                    scope.user = {loggedin: false, email:null};
-                    localStorageService.remove('user');
+                    $rootScope.user = {loggedin: false, email:null};
                 });
             };
-
-
-            navigator.id.watch({
-                /*
-* loggedinUser is all that we know about the user before
-* the interaction with persona. This value could come from a cookie to persist the authentication
-* among page reloads. If the value is null, the user is considered logged out.
-*/
-
-                loggedInUser: scope.user.email,
-                /*
-* We need a watch call to interact with persona.
-* onLogin is called when persona provides an assertion
-* This is the only way we can know the assertion from persona,
-* so we resolve BrowserId.requestDeferred with the assertion retrieved
-*/
-                onlogin: function(assertion){
-                    if (BrowserId.requestDeferred) {
-                        BrowserId.requestDeferred.resolve(assertion);
-                    }
-                },
-
-                /*
-* Resolve BrowserId.logoutDeferred once the user is logged out from persona
-*/
-                onlogout: function(){
-                    if (BrowserId.logoutDeferred) {
-                        BrowserId.logoutDeferred.resolve();
-                    }
-                }
-            });
         },
         templateUrl: 'partials/persona_buttons.html'
     };


### PR DESCRIPTION
The login status doesn't persist anymore on the client. A check is instead done via ajax on page load.
