### PR TITLE
Add job status to job panel properties (1050078)

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -734,14 +734,22 @@ ul.failure-summary-list li .btn-xs{
     margin-left: -11px;
 }
 
+#result-status-pane div {
+    display: inline-block;
+}
+
+#result-status-pane div:first-child {
+    width: 11.75em;
+}
+
 .result-status-shading-success {background-color: rgba(2, 131, 44, 0.24);}
 .result-status-shading-testfailed {background-color: rgba(221, 102, 2, 0.25);}
 .result-status-shading-busted {background-color: rgba(144, 0, 0, 0.25);}
 .result-status-shading-exception {background-color: rgba(61, 2, 85, 0.25);}
 .result-status-shading-retry {background-color: rgba(38, 63, 195, 0.25);}
-.result-status-shading-usercancel {background-color: rgba(250, 115, 172, 0.25)}
-.result-status-shading-pending {background-color: white;}
-.result-status-shading-running {background-color: white;}
+.result-status-shading-usercancel {background-color: rgba(250, 115, 172, 0.25);}
+.result-status-shading-pending {background-color: rgba(160, 160, 160, 0.2);}
+.result-status-shading-running {background-color: rgba(70, 70, 70, 0.25);}
 .result-status-shading-coalesced {background-color: white;}
 
 .result-status-count-group {

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -126,9 +126,15 @@
         <li>by <em>{{classifications[0].who}}</em> on {{ classifications[0].note_timestamp*1000|date:'medium' }}</li>
     </ul>
     <ul class="list-unstyled">
-        <li class="small {{resultStatusShading}}">
-            <label>Result:</label>
-            <span>{{ job.result }}</span>
+        <li id="result-status-pane" class="small {{resultStatusShading}}">
+            <div>
+                <label>Result:</label>
+                <span>{{ job.result }}</span>
+            </div>
+            <div>
+                <label>State:</label>
+                <span>{{ job.state }}</span>
+            </div>
         </li>
     </ul>
     <ul>


### PR DESCRIPTION
This work fixes Bugzilla bug [1050078](https://bugzilla.mozilla.org/show_bug.cgi?id=1050078).

This updates the top line of the job details panel (now ID'd as `result-status-pane` for css targeting), adding the job state to that line. It provides complimentary information to the job result, preventing any ambiguity for pending and running jobs - since their result values, are 'unknown'.

The label(s) have been placed in containers with a consistent white space, regardless of the length of the result value loaded. So when you click on various jobs, the State label doesn't shift around.

Two new greys have been added for `pending` and `running` per conversation with @jeads in channel. I approximated them from the job colors as best I could, keeping them in the flavor of the other 'light' colors used for testfailed, busted, success, in the same panel. I used the existing rgba css format and left coalesced untouched at this time. Let me know how you like them, my monitor is not ideal so I was putting them up in PShop after each adjustment to validate the rendered changes.

I've included a screen grab of one of the new results, _running_:

![jobresultstatus_aug11_rev2](https://cloud.githubusercontent.com/assets/3660661/3885878/95d605d2-21cd-11e4-8d86-2e33b47fc1e7.jpg)

Unrelated - I also noticed a distracting upward horizontal line shift in this panel (visible above), but I intend to fix that as a separate commit in the bootstrap, later. Since it's not really part of this change.

Let me know if anything here needs to be adjusted.

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **36.0.1985.125 m**

Adding @camd for visibility.
