### PR TITLE
Update lower-left job details content with consistent linespace

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -501,6 +501,7 @@ div#bottom-panel.with-pinboard #bottom-center-panel{
 
 #bottom-left-panel ul li label{
     padding: 0;
+    margin: 2px 0px;
 }
 
 #bottom-left-panel em.testfail{ color:red;}


### PR DESCRIPTION
This issue was referenced in PR https://github.com/mozilla/treeherder-ui/pull/125.

Basically we have a strange upward shift of the contents in the lower left job panel. It appears to be driven by a default bootstrap css value of `margin-bottm: 5px` for all labels [here](https://github.com/mozilla/treeherder-ui/blob/master/webapp/app/css/bootstrap.css#L1645).

I assume we want to just override that value on this panel element in treeherder.css, so this is that change. We apply a top and bottom margin instead. I've included a before and after you can quickly flip between them and see the difference. It's subtle, but much better.

![leftjobpanel_current](https://cloud.githubusercontent.com/assets/3660661/3894363/7cb95a2e-2243-11e4-8721-bc06806a4b9e.jpg)
![leftjobpanel_proposed](https://cloud.githubusercontent.com/assets/3660661/3894364/80b31a52-2243-11e4-81cb-299f911c25e3.jpg)

It also takes up less net space for given content, since we are consuming 4px of margin rather than 5.

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **36.0.1985.125 m**

Adding @camd for visibility.
