### PR TITLE
Suppress get-next UI on single resultset view (1056308)

### DIFF
--- a/webapp/app/partials/jobs.html
+++ b/webapp/app/partials/jobs.html
@@ -44,11 +44,13 @@
      ng-show="isLoadingRsBatch.appending">
     <div class="progress-bar"  role="progressbar" style="width: 100%"></div>
 </div>
-<div class="well">
-    get next: <div class="btn-group">
+
+<div class="well" ng-if="result_sets.length > 1">
+     get next:
+    <div class="btn-group">
         <div class="btn btn-default btn-sm"
              ng-click="fetchResultSets(count)"
              ng-repeat="count in [10, 20, 50]">{{count}}</div>
+        </div>
     </div>
-</div>
 </div>


### PR DESCRIPTION
This work fixes Bugzilla bug [1056308](https://bugzilla.mozilla.org/show_bug.cgi?id=1056308).

This shuts off the 'get next' footer UI when the user views a single result set, when clicking in on the _open resultset in new tab_ links on the main page, or similar workflows which drive you to a single result set view.

![getnextui](https://cloud.githubusercontent.com/assets/3660661/4002713/60059608-296f-11e4-841e-698d277cf80a.jpg)

Even with the fix, the percentage done bar and the 'get next' UI fleetingly appear during load, but that is the same as production. Maybe that can be improved upon later.

I've tested a variety of workflows I can think of, page reloads, tabs, opening results ets that contain a revision, and they seem fine.

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **36.0.1985.143 m**

Adding @maurodoglio for visibility.
