### PR TITLE
Close job panel and unselect job when clicking empty area (1042711)

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -337,7 +337,7 @@ body {
 }
 
 .revision-list {
-    overflow: auto;
+    overflow: hidden;
     white-space: nowrap;
 }
 

--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -168,9 +168,25 @@ treeherder.directive('thCloneJobs', [
 
     };
 
+    var clearSelectJobStyles = function(el) {
+        var lastJobSelected = ThResultSetModel.getSelectedJob(
+            $rootScope.repoName);
+
+        if (!_.isEmpty(lastJobSelected.el)) {
+            lastJobSelected.el.removeClass(selectedBtnCls);
+            lastJobSelected.el.removeClass(largeBtnCls);
+            lastJobSelected.el.addClass(btnCls);
+        }
+    };
+
     var clickJobCb = function(ev, el, job){
         setSelectJobStyles(el);
         $rootScope.$broadcast(thEvents.jobClick, job);
+    };
+
+    var clearJobCb = function(ev, el, job) {
+        clearSelectJobStyles(el);
+        $rootScope.$broadcast(thEvents.jobClear, job);
     };
 
     var togglePinJobCb = function(ev, el, job){
@@ -330,6 +346,12 @@ treeherder.directive('thCloneJobs', [
             }
 
             ThResultSetModel.setSelectedJob($rootScope.repoName, el, job);
+
+        } else {
+            // If user didn't select a job or anchor clear the selected job
+            if (el.prop("tagName") !== "A") {
+                _.bind(clearJobCb, this, ev, el, job)();
+            }
         }
     };
 

--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -181,6 +181,9 @@ treeherder.provider('thEvents', function() {
             // fired (surprisingly) when a job is clicked
             jobClick: "job-click-EVT",
 
+            // fired on click outside a job element
+            jobClear: "job-clear-EVT",
+
             // fired when the job details are loaded
             jobDetailLoaded: "job-detail-loaded-EVT",
 

--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -170,6 +170,11 @@ treeherder.controller('PluginCtrl', [
             $rootScope.selectedJob = job;
         });
 
+        $rootScope.$on(thEvents.jobClear, function(event, job) {
+            $rootScope.selectedJob = null;
+            $scope.$digest();
+        });
+
         $rootScope.$on(thEvents.jobsClassified, function(event, job) {
             $scope.updateClassifications();
         });


### PR DESCRIPTION
This work fixes Bugzilla bug [1042711](https://bugzilla.mozilla.org/show_bug.cgi?id=1042711).

If the user clicks in any empty space in the job panel that _isn't_ another job, filter UI, result set link or other anchors, the job panel is closed and the selected job reverts to its unselected state. This mirrors TBPL's behavior. To support this, the overflow is hidden in the result set container, as it is in TBPL. This bypasses the problem [described here in the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1042711#c2) by eliminating the result set scroll bar altogether. Ed has signed off on that .

For historical reference, this was [the only example](http://stackoverflow.com/questions/10045423/determine-whether-user-clicking-scrollbar-or-content-onclick-for-native-scroll) I could find of addressing that scroll bar issue, suppressing a scroll bar mouse event, using jQuery. It seemed involved for the added complexity and unknowns vs. functionality gain.

I pose we'd be better served by presenting the information in the result set container in a more compact way, or with improved layout, so that it would never overflow or require a scroll bar to begin with. But that's a separate topic. So, here is the new behavior:

Job selected, hover over a result set still shows the overflowing content

![jobselected](https://cloud.githubusercontent.com/assets/3660661/4013900/3f0c24ec-2a1b-11e4-9d33-12d999fcdd90.jpg)

Click event outside the job, deselects the job and closes the panel

![emptyspaceselected](https://cloud.githubusercontent.com/assets/3660661/4013912/62b93c22-2a1b-11e4-83a7-1217d0fd343f.jpg)

If you click on a link in the result set or elsewhere, the job selection is preserved and the job details panel remains open. As always, you just get your link opened in a new tab.

I've spent some time testing the various workflows, and I can't find any bad behaviors introduced by the change. I am not sure if I have done everything correctly w.r.t. the internal state of the job in the model or elsewhere, that would need to be checked. Sorry I am a newbie in that area, among many others :)

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **36.0.1985.143 m**

Adding @maurodoglio and @camd for visibility.
