### PR TITLE
Update help with esc key shortcut

### DIFF
--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -56,6 +56,8 @@
             <div class="panel-heading"><h3>Keyboard shortcuts</h3></div>
             <div class="panel-body">
                 <table id="shortcuts">
+                    <tr><th>esc</th>
+                    <td>Close all open job or filter panels</td></tr>
                     <tr><th>spacebar</th>
                     <td>Add selected job to the pin board</td></tr>
                     <tr><th>j</th>
@@ -69,8 +71,8 @@
                     <tr><th>u</th>
                     <td>Show only unstarred failures</td></tr>
                     <tr><th>i</th>
-                    <td>toggle in-progress (running/pending) jobs</td></tr>
-                    <tr><th>Ctrl/Cmd-Click</th>
+                    <td>Toggle in-progress (running/pending) jobs</td></tr>
+                    <tr><th>Ctrl/Cmd click</th>
                     <td>Add job to the pinboard</td></tr>
                 </table>
             </div>


### PR DESCRIPTION
As described in `controllers/main.js` [here](https://github.com/mozilla/treeherder-ui/blob/4bf19f0d858a28e59f997c52ce812c4fbc2c8e0c/webapp/app/js/controllers/main.js#L71) the esc key closes any open job panel, repo filter panel, or main filter panel, so this is just a quick update to reflect that in the docs.

Regarding that code comment, the esc key event doesn't appear to 'clear the selected job' in that it doesn't change the selected class on the job element. Perhaps we might want to remove that part of the comment? In any case I will include this help update in bug [1033372](https://bugzilla.mozilla.org/show_bug.cgi?id=1033372) in case this existing esc functionality is sufficient to close that bug, without requiring a click outside of a toolbar to dismiss the repo/filter panels.

The help change below looks correct in my local server. I just used 'filter panels' in the wording for economy to cover both the repo and main filter panels.

![esckeyhelpupdate](https://cloud.githubusercontent.com/assets/3660661/4014942/fe4ff504-2a25-11e4-9bd8-e6a785e53094.jpg)

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **36.0.1985.143 m**

Adding @maurodoglio and @camd for visibility.
