### PR TITLE
Support lower res with responsive logviewer (1042466)

### DIFF
--- a/webapp/app/css/logviewer.css
+++ b/webapp/app/css/logviewer.css
@@ -1,8 +1,11 @@
 body {
-    padding: 20px;
-    padding-top: 284px;
-    white-space: nowrap;
-    float: left;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    min-width: 240px;
+    padding-top: 15px;
 }
 
 /*Log Viewer*/
@@ -22,20 +25,17 @@ body {
 }
 
 .lv-log-container {
-    height: auto;
+    height: 100%;
     width: 100%;
-    position: absolute;
     overflow: auto;
-    right: 0px;
-    top: 284px;
-    left: 0px;
-    bottom: 0px;
-    padding: 20px;
+    bottom: 0;
+    padding: 20px 15px 0;
+    white-space: nowrap;
     background: #EFEFEF;
 }
 
 .lv-log-line {
-    width: auto;
+    width: 100%;
 }
 
 .lv-line-number {
@@ -56,18 +56,14 @@ body {
 }
 
 .run-data {
-    height: 284px;
     width: 100%;
-    position: fixed;
-    top: 0px;
-    left: 0px;
     background-color: #FFF;
-    padding: 20px;
-    border-bottom: 1px solid #EFEFEF;
+    padding: 20px 5px 4px;
+    display: table-row;
 }
 
 .run-data .steps-data {
-    height: 210px;
+    max-height: 210px;
     overflow: auto;
     border-color: #dddddd;
     border-width: 1px;

--- a/webapp/app/js/directives/log_viewer_steps.js
+++ b/webapp/app/js/directives/log_viewer_steps.js
@@ -23,14 +23,14 @@ treeherder.directive('lvLogSteps', ['$timeout', '$parse', function ($timeout) {
                     $timeout(function () {
                         var raw = $('.lv-log-container')[0];
                         var line = $('.lv-log-line[line="' + linenumber + '"]');
-                        raw.scrollTop += line.offset().top - $('.run-data').outerHeight(); 
+                        raw.scrollTop += line.offset().top - $('.run-data').outerHeight() - 15 ;
                     });
                 });
 
                 if (scope.displayedStep && scope.displayedStep.order === step.order) {
                     $event.stopPropagation();
                 }
-            }; 
+            };
 
             scope.toggleSuccessfulSteps = function() {
                 scope.showSuccessful = !scope.showSuccessful;
@@ -57,7 +57,7 @@ treeherder.directive('lvLogSteps', ['$timeout', '$parse', function ($timeout) {
                     $timeout(function () {
                         var raw = $('.lv-log-container')[0];
                         var line = $('.lv-log-line[line="' + step.started_linenumber + '"]');
-                        raw.scrollTop += line.offset().top - $('.run-data').outerHeight(); 
+                        raw.scrollTop += line.offset().top - $('.run-data').outerHeight() - 15 ;
                     });
                 });
             };


### PR DESCRIPTION
This work fixes Bugzilla bug [1042466](https://bugzilla.mozilla.org/show_bug.cgi?id=1042466).

Thanks to @camd's stellar work which I am just facilitating by this branch and PR. This allows the user to view the structured log and all its contents and functionality with browser dimensions well below the implied/requested 960px. The one minor issue is the left hand run-data content not 'sliding over' as nicely as it could and log steps being clipped _if_ successful steps are displayed, but that is the only minor downside I've seen. I haven't yet figured out that mystery or if it is even possible to address it given the existing functionality requirements.

This is a screen grab of the support it provides

![flowingstructuredlog_aug27_](https://cloud.githubusercontent.com/assets/3660661/4065477/087a0210-2e1b-11e4-9b33-262cc1cbcb2f.jpg)

I've tested a variety of workflows throughout the work, and other than the issue mentioned above, everything seems fine.

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **36.0.1985.143 m**

Adding @camd @jeads and @maurodoglio for visibility.
