### PR TITLE
Correct double-height watched repo navbar on Chrome

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -45,6 +45,11 @@ body {
     min-width: 970px;
 }
 
+th-watched-repo {
+    display: block;
+    float: left;
+}
+
 .watched-repo-main-btn {
     border-right: 0;
     padding-right: 5px;


### PR DESCRIPTION
This fixes a regression in the watched repo navbar on Google Chrome (no Github Issue or Bugzilla bug posted). The navbar by default was unnecessarily double height and obscuring the global filters on Chrome.

So in this work in May/14 we made the watched repos navbar appearance correct on Chrome
https://github.com/mozilla/treeherder-ui/commit/3a6dc6067230e49f654e1f56ffdce8f60ec76c4f

And in this work in Aug/14 we removed the fix in the course of other work
https://github.com/mozilla/treeherder-ui/commit/2a5c028a3730e2d254ab71c3583e45eabeeb6893

I spoke with @camd and the August work was to correct some flow/wrapping issues in the navbar. I re-introduced the change into my local repo and tested all the behaviors I am aware of, and it appears to be fine. Caveat I am a newbie and may have totally missed the key behavior it had been removed to address.

Here is the current appearance on Chrome and after with my branch and the code returned. It looks correct, the watched repo containers appear to flow properly, the adjacent menus and their containers similarly update. I tried from 1, to 2-4, and up to 15-20 repos simultaneously. I also re-tested on Firefox and it appears correct also.

Current
![navbarcurrentchrome](https://cloud.githubusercontent.com/assets/3660661/4077383/9cad6e8e-2ec2-11e4-91f1-4c3615ebcac9.jpg)

Proposed
![navbarfixchrome](https://cloud.githubusercontent.com/assets/3660661/4077391/adbfe9c2-2ec2-11e4-944f-71079a390642.jpg)

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **37.0.2062.94 m**

Adding @camd for visibility and comparative testing.
