### PR TITLE
Bug 1042501 - Remove all use of min-width in treeherder's CSS

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1,6 +1,5 @@
 body {
     padding-top: 61px;
-    min-width: 768px;
     line-height: inherit; /* override bootstrap */
 }
 
@@ -14,11 +13,9 @@ body {
 }
 
 .th-navbar {
-    min-width: 768px;
 }
 
 .navbar {
-    min-width: 768px;
     min-height: 36px;
 }
 
@@ -36,7 +33,6 @@ body {
 
 .th-global-navbar {
     border-bottom: 1px solid black;
-    min-width: 768px;
 }
 
 th-watched-repo {
@@ -81,7 +77,6 @@ th-watched-repo {
 
 .th-context-navbar {
     background-color: #354048;
-    min-width: 768px;
     overflow: visible;
 }
 
@@ -110,7 +105,6 @@ th-watched-repo {
 .th-content {
     display: inline-block;
     overflow: hidden;
-    min-width: 768px;
     width: 100%;
     margin-bottom: 301px;
     white-space: nowrap;


### PR DESCRIPTION
It doesn't really help anything and causes (at least) the repo panel
to not scroll properly if the screen size is below a certain threshold.
