### PR TITLE
Bug 1059283 - Delay loading new job information very slightly when switching between jobs

### DIFF
--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -183,9 +183,17 @@ treeherder.directive('thCloneJobs', [
         }
     };
 
+    var broadcastJobChangedTimeout = null;
     var clickJobCb = function(ev, el, job){
         setSelectJobStyles(el);
-        $rootScope.$broadcast(thEvents.jobClick, job);
+        // delay switching right away, in case the user is switching rapidly
+        // between jobs
+        if (broadcastJobChangedTimeout) {
+          window.clearTimeout(broadcastJobChangedTimeout);
+        }
+        broadcastJobChangedTimeout = window.setTimeout(function() {
+          $rootScope.$broadcast(thEvents.jobClick, job);
+        }, 200);
     };
 
     var clearJobCb = function(ev, el, job) {


### PR DESCRIPTION
This is pretty much imperceivable when clicking on jobs, but when switching
rapidly between them it improves performance quite a bit since we no longer
load stuff that we're no longer going to use.
