### PR TITLE
Improve Repo/Filter dropdowns with smaller chevrons

### DIFF
--- a/webapp/app/partials/thGlobalTopNavPanel.html
+++ b/webapp/app/partials/thGlobalTopNavPanel.html
@@ -18,9 +18,9 @@
                 <span class="btn btn-view-nav"
                       ng-class="{'active': (isSheriffPanelShowing)}"
                       ng-click="setSheriffPanelShowing(!isSheriffPanelShowing)"><span>Sheriffing</span>
-                    <i class="glyphicon glyphicon-chevron-down lightgray"
+                    <i class="fa fa-caret-down lightgray"
                        ng-hide="isSheriffPanelShowing"></i>
-                    <i class="glyphicon glyphicon-chevron-up lightgray"
+                    <i class="fa fa-caret-up lightgray"
                        ng-show="isSheriffPanelShowing"></i>
                 </span>
             </span>
@@ -28,17 +28,17 @@
                 <span class="btn btn-view-nav"
                       ng-class="{'active': (isRepoPanelShowing)}"
                       ng-click="setRepoPanelShowing(!isRepoPanelShowing)"><span>Repos</span>
-                    <i class="glyphicon glyphicon-chevron-down lightgray"
+                    <i class="fa fa-caret-down lightgray"
                        ng-hide="isRepoPanelShowing"></i>
-                    <i class="glyphicon glyphicon-chevron-up lightgray"
+                    <i class="fa fa-caret-up lightgray"
                        ng-show="isRepoPanelShowing"></i>
                 </span>
                 <span class="btn btn-view-nav"
                       ng-class="{'active': (isFilterPanelShowing)}"
                       ng-click="setFilterPanelShowing(!isFilterPanelShowing)"><span>Filters</span>
-                    <i class="glyphicon glyphicon-chevron-down lightgray"
+                    <i class="fa fa-caret-down lightgray"
                        ng-hide="isFilterPanelShowing"></i>
-                    <i class="glyphicon glyphicon-chevron-up lightgray"
+                    <i class="fa fa-caret-up lightgray"
                        ng-show="isFilterPanelShowing"></i>
                 </span>
                 <a class="btn btn-view-nav" href="help.html" target="_blank">Help</a>
@@ -47,9 +47,9 @@
                 <span ng-show="false" class="btn btn-view-nav"
                       ng-class="{'active': (isSettingsPanelShowing)}"
                       ng-click="setSettingsPanelShowing(!isSettingsPanelShowing)"><span>Settings</span>
-                    <i class="glyphicon glyphicon-chevron-down lightgray"
+                    <i class="fa fa-caret-down lightgray"
                        ng-hide="isSettingsPanelShowing"></i>
-                    <i class="glyphicon glyphicon-chevron-up lightgray"
+                    <i class="fa fa-caret-up lightgray"
                        ng-show="isSettingsPanelShowing"></i>
                 </span>
                 <persona-buttons></persona-buttons>


### PR DESCRIPTION
This improves the visual consistency of the top navbar (no Bugzilla bug posted).

I hadn't got around to the change until now. Basically we have a compact drop-down icon for the collapse/expand revisions/job menu (2nd row), and some really _large_ drop down chevron icons for the Repo and Filter menus (top row). They aren't consistent.

![navbarchevronsdiscrepant](https://cloud.githubusercontent.com/assets/3660661/4125163/80b74e7c-32df-11e4-9e8b-913925d896d4.jpg)

I propose they be the same size, and compact. I think it's reasonable the existing (large) `chevron-down` continue to be used in the lower job panel - since it has a sibling 'x' close icon from the same family and that bar is not graphically busy like the top main one.

So here's the before and after.

![navbarchevronscurrent](https://cloud.githubusercontent.com/assets/3660661/4125230/fd31a5d8-32df-11e4-80c0-7d3e818b6b42.jpg)
![navbarchevronsproposed](https://cloud.githubusercontent.com/assets/3660661/4125231/ffa8eb00-32df-11e4-9d34-3a992fc6530e.jpg)

It also helps reduce the width of each Repo and Filter element, but there's still lots of target area.

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **37.0.2062.102 m**

Adding @camd and @edmorley for review.
