### PR TITLE
Re-center the Treeherder logo in non-responsive bootstrap

### DIFF
--- a/webapp/app/css/bootstrap-non-responsive.css
+++ b/webapp/app/css/bootstrap-non-responsive.css
@@ -21,7 +21,8 @@
 }
 
 .navbar-brand {
-  margin-left: -15px;
+  margin-left: -8px;
+  margin-right: -7px;
 }
 
 /* Always apply the floated nav */


### PR DESCRIPTION
So in PR https://github.com/mozilla/treeherder-ui/pull/133 for Bugzilla bug [1042599](https://bugzilla.mozilla.org/show_bug.cgi?id=1042599) we introduced a new bootstrap file, `bootstrap-non-responsive.css` which I believe resulted in a shift of the main treeherder logo. It ended up clipping the page boundary.

Speaking with @wlach in channel, he suggested just modifying the bootstrap directly. So this PR does that, without moving the adjacent jobs container.

Here is the before and after:

![brandanchorcurrent](https://cloud.githubusercontent.com/assets/3660661/4137181/ad253ffa-3384-11e4-9da9-4397fb15ff8d.jpg)
![brandanchorproposed](https://cloud.githubusercontent.com/assets/3660661/4137183/b1972c56-3384-11e4-9764-fd0ba6e3a6ab.jpg)

We could alternately override it in treeherder.css if we preferred, via:

```
.navbar-brand {
    line-height: 2px;
    position: relative;
    left: 7px;
}
```

Note we may be replacing the text later with a real logo as part of bug [1042616](https://bugzilla.mozilla.org/show_bug.cgi?id=1042616), and this part of the bootstrap may undergo further change as a result.

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **37.0.2062.102 m**

Adding @wlach and @camd for review.
