### PR TITLE
Bug 1059331 - Reftest analyzer links now actually opens up visualization

### DIFF
--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -59,10 +59,10 @@
               <span class="fa fa-play"></span>
             </a>
           </li>
-          <li ng-show="isReftest()">
+          <li ng-show="isReftest()" ng-repeat="job_log_url in job_log_urls">
             <a title="Launch the Reftest Analyser in a new page"
                target="_blank"
-               href="https://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml">
+               href="https://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml#logurl={{ job_log_url.url }}&only_show_unexpected=1">
               <span class="fa fa-bar-chart-o"></span>
             </a>
           </li>


### PR DESCRIPTION
Note that this implementation is somewhat suboptimal in that it loads the
entire log and does the filtering client side afterwards. Ideally in the
future we would preparse the log on the treeherder end of things beforehand
for faster loading times.
