### PR TITLE
Wrap overflowing job status content on Chrome

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -498,9 +498,10 @@ div#bottom-panel .navbar-nav.pull-right li a:focus{
     border-top: 1px solid #AAAAAA;
 }
 
-#bottom-left-panel ul li{
+#bottom-left-panel ul li {
     padding: 0px 0px 0px 5px;
     line-height: 15px;
+    word-wrap: break-word;
 }
 
 #bottom-left-panel ul li label{


### PR DESCRIPTION
This improves the displayable content in the bottom left job panel (no Bugzilla bug posted).

The latest state of the front end doesn't wrap a lot of the new (longer) job status data recently added. This results in a horizontal scrollbar, which consumes space in an already limited, fixed container.

This change wraps any non-label line data. The [MDN spec](https://developer.mozilla.org/en-US/docs/Web/CSS/word-wrap) says that `overflow-wrap` is the current draft, but at present that property does not work with this value. So we will use the alternate `word-wrap` for now.

Here's the before and after:

![leftjobpanebefore](https://cloud.githubusercontent.com/assets/3660661/4168118/081876e4-3519-11e4-9ca3-fab68de71b80.jpg)

![leftjobpaneafter](https://cloud.githubusercontent.com/assets/3660661/4168121/0cb7b174-3519-11e4-8b9d-6c208df2abe0.jpg)

Tested on Windows:
FF Release **32.0**
Chrome Latest Release **37.0.2062.103 m**

Adding @wlach and @camd for review.
