### PR TITLE
Further improve the layout in bottom left job status panel

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -491,10 +491,14 @@ div#bottom-panel .navbar-nav.pull-right li a:focus{
     overflow-y: auto;
 }
 
-#bottom-left-bottom > ul{
+#bottom-left-bottom > ul {
     margin: 0px;
     padding: 0px;
     line-height:12px;
+}
+
+#bottom-left-panel ul:nth-child(2) {
+    padding-top: 4px;
     border-top: 1px solid #AAAAAA;
 }
 
@@ -751,7 +755,7 @@ ul.failure-summary-list li .btn-xs{
 }
 
 #result-status-pane div:first-child {
-    width: 11.75em;
+    width: 11.25em;
 }
 
 .result-status-shading-success {background-color: rgba(2, 131, 44, 0.24);}

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -96,7 +96,7 @@
         </li>
       </ul>
       <ul>
-        <li><h6><a href="{{ buildbotJobnameHref }}" target="_blank" prevent-default-on-left-click th-filter-by-buildername>{{ buildbotJobname }}</a></h6></li>
+        <li><a href="{{ buildbotJobnameHref }}" target="_blank" prevent-default-on-left-click th-filter-by-buildername>{{ buildbotJobname }}</a></li>
         <li class="small">
           <label>Machine name:</label>
           <a title="Open Buildbot Slave Health Report" target="_blank"


### PR DESCRIPTION
This further improves the displayable content in the bottom left job panel (no Bugzilla bug posted).

In it we:
- reduce the overall space consumption by the buildbot job name
- preserve the existing line spacing
- shift the State: field inwards to accommodate the now-frequent vertical scrollbar

Here's the before and after:

![bottomleftbottomcurrent](https://cloud.githubusercontent.com/assets/3660661/4171081/db270936-3539-11e4-9695-dac187c651cb.jpg)

![bottomleftbottomproposed](https://cloud.githubusercontent.com/assets/3660661/4171083/de6686d0-3539-11e4-986b-1f45f72c40d2.jpg)

Net vertical gain is about 1-1/2 lines.

It's kind of weird in my applying the 1px border to the top row of data, rather than the bottom of the colored result-set-row, but it eliminates a few undesired results due other ul markup stuff going on. Where applying it the other way propagates that border elsewhere in lower data blocks that were recently added.

Tested on Windows:
FF Release **32.0**
Chrome Latest Release **37.0.2062.103 m**

@edmorley has signed off on the appearance in channel.

Adding @wlach and @camd for review.
