### PR TITLE
Bug 1048043 - Add message for when revision not found.

### DIFF
--- a/webapp/app/partials/jobs.html
+++ b/webapp/app/partials/jobs.html
@@ -37,6 +37,14 @@
     <div th-clone-jobs ></div>
 </div>
 
+<div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending">
+  <span><br \>
+    <span><b>Unknown revision ID.</b></span>
+    <span>This could be because your push has not been processed yet, or the revision ID could be wrong.
+    This page will refresh occasionally, so your push should show up within a few minutes.</span>
+  <span>
+</div>
+
 <!-- END Revision clone target -->
 
 <div class="progress progress-striped active"


### PR DESCRIPTION
When treeherder doesn't know about a revision (either because it's not a legitimate revision or because that push just hasn't been processed yet), it just bails out completely, leaving a completely empty page aside from Treeherder's header UI. 

This adds a message for when no job info is found for the given revision, so it at least doesn't look like the page is just broken.
