### PR TITLE
Bug 1032193 - Disable the checkbox for the currently loaded repo

### DIFF
--- a/webapp/app/partials/thRepoPanel.html
+++ b/webapp/app/partials/thRepoPanel.html
@@ -15,7 +15,8 @@
                   class="th-repo-group-items">
                 <input type="checkbox"
                        ng-checked="repoModel.repos[repo.name].isWatched"
-                       ng-click="repoModel.toggleWatched(repo.name)">
+                       ng-click="repoModel.toggleWatched(repo.name)"
+                       ng-disabled="repo.name == repoName">
                 <a ng-href="./#/jobs?repo={{repo.name}}"
                    title="open repo"
                    class="repo-link">{{repo.name}}</a>


### PR DESCRIPTION
This prevents us from being able to get into the weird state where you can remove the currently selected repo from the list of watched repos, but that repo's results are still shown in the page.

The currently selected repo is unable to be unchecked, and you can't uncheck it until you select a different repo, in which case that newly selected repo is not uncheckable but the previously selected repo is.
