### PR TITLE
Improve failure/bug separation in failure summary panel (1059375)

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -550,6 +550,8 @@ div#bottom-panel .navbar-nav.pull-right li a:focus{
 
 ul.failure-summary-list li {
     padding: 0px 0px 0px 2px;
+    font-size: 11px;
+    background: #ccfaff;
 }
 
 ul.failure-summary-list li .btn-xs {
@@ -558,24 +560,30 @@ ul.failure-summary-list li .btn-xs {
 
 .failure-summary-line-empty {
     padding: 2px 2px 0px;
+    background: #ffffff;
 }
 
 .failure-summary-line {
     padding: 2px 2px 0px;
-    color: #b94a48;
-    background: #efefef;
 }
 
 .failure-summary-bugs {
     padding: 0px 0px 0px 14px;
 }
 
+/* We override global anchor color to replicate TBPL here */
+.failure-summary-bugs a {
+    color: #0000ee;
+}
+
 .failure-summary-bugs button {
     padding: 2px 3px 1px 3px;
 }
 
+/* We override global anchor color to replicate TBPL here */
 .show-hide-more {
-    padding: 0px 0px 0px 34px;
+    padding: 0px 0px 0px 35px;
+    color: #0000ee;
 }
 
 .shadowed-panel {

--- a/webapp/app/plugins/failure_summary/main.html
+++ b/webapp/app/plugins/failure_summary/main.html
@@ -6,7 +6,8 @@
                 <span ng-bind="suggestion.search"></span>
             </div>
             <!--Open recent bugs-->
-            <ul ng-if="! suggestion.bugs.open_recent_hidden" class="list-unstyled failure-summary-bugs">
+            <ul ng-if="! suggestion.bugs.open_recent_hidden"
+                class="list-unstyled failure-summary-bugs">
                 <li ng-repeat="bug in suggestion.bugs.open_recent">
                     <button class="btn btn-xs btn-default"
                             ng-click="pinboard_service.addBug(bug, selectedJob)"
@@ -14,12 +15,13 @@
                         <i class="glyphicon glyphicon-pushpin"></i>
                     </button>
                     <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{bug.id}}"
-                       ng-class="{'deleted': bug.resolution != ''}">{{bug.id}}</a>
-                    <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:suggestion.search"
-                          title="{{bug.summary}}"
-                          ng-class="{'deleted': bug.resolution != ''}">
-                        {{bug.summary}}
-                    </span>
+                       target="_blank"
+                       ng-class="{'deleted': bug.resolution != ''}">{{bug.id}}
+                        <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:suggestion.search"
+                              title="{{bug.summary}}"
+                              ng-class="{'deleted': bug.resolution != ''}">{{bug.summary}}
+                        </span>
+                    </a>
                 </li>
             </ul>
 
@@ -38,12 +40,13 @@
                         <i class="glyphicon glyphicon-pushpin"></i>
                     </button>
                     <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{bug.id}}"
-                       ng-class="{'deleted': bug.resolution != ''}">{{bug.id}}</a>
-                    <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:suggestion.search"
-                          title="{{bug.summary}}"
-                          ng-class="{'deleted': bug.resolution != ''}">
-                        {{bug.summary}}
-                    </span>
+                       target="_blank"
+                       ng-class="{'deleted': bug.resolution != ''}">{{bug.id}}
+                        <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:suggestion.search"
+                              title="{{bug.summary}}"
+                              ng-class="{'deleted': bug.resolution != ''}">{{bug.summary}}
+                        </span>
+                    </a>
                 </li>
             </ul>
 


### PR DESCRIPTION
This work fixes Bugzilla bug [1059375](https://bugzilla.mozilla.org/show_bug.cgi?id=1059375).

In it we:
- get rid of some unnecessary padding and utilize the space better
- reduce the size of the pin icon for the same reason
- leverage the color/style of the structured log failure line to separate the content better
- indent show/hide for readability

These changes save roughly one extra line of displayable space to the panel, and also 3-4 characters per line, before line wrap occurs. The use of the color/style of the structured log, while not totally color-blind accessible, provides readability and cues the user they are reading the same content in both parts of the platform. This seemed the most logical UI solution.

Here's a before and after:

![grokfailuresummarycurrent](https://cloud.githubusercontent.com/assets/3660661/4223002/2e2d9cc6-3918-11e4-926b-48d89ece6062.jpg)

![grokfailuresummaryproposed](https://cloud.githubusercontent.com/assets/3660661/4223005/357e5844-3918-11e4-931a-2e6edab57174.jpg)

I've added a new class for the show/hide ui to specifically target it for indentation.  We may replace show/hide with a language independent (and more compact) chevron, up one line adjacent to the last pin element to save space, as a non-blocker task.

Tested on Windows:
FF Release **32.0**
Chrome Latest Release **37.0.2062.103 m**

@edmorley has signed off in channel on the appearance in general.

Adding @wlach and @camd for review.
