### PR TITLE
Bug 1065541 - Fix the unknown revision ID message along with a few other related fixes.

### DIFF
--- a/webapp/app/js/controllers/jobs.js
+++ b/webapp/app/js/controllers/jobs.js
@@ -34,11 +34,15 @@ treeherder.controller('JobsCtrl', [
         $scope.job_map = ThResultSetModel.getJobMap($scope.repoName);
         $scope.statusList = thResultStatusList.counts();
 
+        $scope.searchParams = $location.search();
+        $scope.locationHasSearchParam = function(prop) {
+            return _.has($scope.searchParams, prop);
+        }
+
         // determine how many resultsets to fetch.  default to 10.
         var count = 10;
-        var searchParams = $location.search();
-        if ((_.has(searchParams, "startdate") || _.has(searchParams, "fromchange") &&
-            (_.has(searchParams, "enddate")) || _.has(searchParams, "tochange"))) {
+        if ((_.has($scope.searchParams, "startdate") || _.has($scope.searchParams, "fromchange") &&
+            (_.has($scope.searchParams, "enddate")) || _.has($scope.searchParams, "tochange"))) {
             // just fetch all (up to 1000) the resultsets if an upper AND lower range is specified
 
             count = 1000;

--- a/webapp/app/partials/jobs.html
+++ b/webapp/app/partials/jobs.html
@@ -37,11 +37,30 @@
     <div th-clone-jobs ></div>
 </div>
 
-<div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending">
-  <span><br \>
-    <span><b>Unknown revision ID.</b></span>
-    <span>This could be because your push has not been processed yet, or the revision ID could be wrong.
-    This page will refresh occasionally, so your push should show up within a few minutes.</span>
+<div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending && !isLoadingJobs && locationHasSearchParam('revision')">
+  <span>
+    <div><b>Unknown revision ID.</b></div>
+    <span>This could be because your push has not been processed yet, or the revision ID could be invalid.
+      This page will refresh occasionally, so your push should show up within a few minutes if it does exist.</span>
+  <span>
+</div>
+
+<div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending && !isLoadingJobs && !locationHasSearchParam('revision') && currentRepo.url">
+  <span>
+    <div><b>No resultsets found.</b></div>
+    <span>No commit information could be loaded for this repository. 
+      More information about this repository can be found <a href="{{currentRepo.url}}">here</a>.</span>
+  <span>
+</div>
+
+<div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending && !isLoadingJobs && !locationHasSearchParam('revision') && !currentRepo.url">
+  <span>
+    <div><b>Unknown repository.</b></div>
+    <span>This repository is either unknown to Treeherder or it doesn't exist. 
+      If this repository does exist, please 
+      <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree%20Management&component=Treeherder">
+      file a bug against the Treeherder product in Bugzilla</a> to get it added to the system.
+    </span>
   <span>
 </div>
 


### PR DESCRIPTION
The "unknown revision ID" message was occasionally being briefly displayed on Treeherder's initial page load, along with being shown for any repository where no resultsets were being returned.

This pull request adds a function to $scope to expose underscore's _.has() function for searching $location.search's various parameters. 

This lets us tell in the HTML file whether or not a revision was specified. 

If a revision was specified, we show the unknown revision ID.

If a revision was not specified, but treeherder knows about the specified repository, it shows a message saying that no resultsets were found, and gives a link to the repository's url as set in treeherder-service's repository model.

If no revision was specified and treeherder doesn't know about the specified repository, it shows a message saying that the repository is unknown, and prompts the user to file a bug to get the repository added to treeherder-service if the repository really does exist and just needs to get added to the model.
