### PR TITLE
Ensure that the unknown repository error is not shown on initial pageload

### DIFF
--- a/webapp/app/partials/jobs.html
+++ b/webapp/app/partials/jobs.html
@@ -45,7 +45,8 @@
   <span>
 </div>
 
-<div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending && !isLoadingJobs && !locationHasSearchParam('revision') && currentRepo.url">
+<div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending && !isLoadingJobs &&
+     !locationHasSearchParam('revision') && !locationHasSearchParam('repo') && currentRepo.url">
   <span>
     <div><b>No resultsets found.</b></div>
     <span>No commit information could be loaded for this repository. 
@@ -53,7 +54,8 @@
   <span>
 </div>
 
-<div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending && !isLoadingJobs && !locationHasSearchParam('revision') && !currentRepo.url">
+<div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending && !isLoadingJobs &&
+     !locationHasSearchParam('revision') && !locationHasSearchParam('repo') && !currentRepo.url">
   <span>
     <div><b>Unknown repository.</b></div>
     <span>This repository is either unknown to Treeherder or it doesn't exist. 


### PR DESCRIPTION
On the initial pageload of ui/#/jobs, there is no repo set in the URL, so the error for "Unknown repository" is shown briefly before it redirects to the default (mozilla-central) repo.

This adds a check that a repo is selected at all before showing the unknown repo error.
