### PR TITLE
Bug 1066989 - Fix the treestatus and clobberer URLs for Thunderbird

### DIFF
--- a/webapp/app/js/directives/top_nav_bar.js
+++ b/webapp/app/js/directives/top_nav_bar.js
@@ -105,8 +105,6 @@ treeherder.directive('thRepoDropDown', [
 
             scope.name = attrs.name;
             scope.treeStatus = treeStatus.getTreeStatusName(attrs.name);
-            var clobberer = scope.treeStatus.split('-');
-            scope.clobberer = clobberer[0] + "-" + clobberer[1];
             var repo_obj = ThRepositoryModel.getRepo(attrs.name);
             scope.pushlog = repo_obj.url +"/pushloghtml";
 

--- a/webapp/app/js/services/treestatus.js
+++ b/webapp/app/js/services/treestatus.js
@@ -9,13 +9,9 @@ treeherder.factory('treeStatus', [
     var getTreeStatusName = function(name) {
         // the thunderbird names in treestatus.mozilla.org don't match what
         // we use, so translate them.  pretty hacky, yes...
-        if (name.indexOf("thunderbird") >= 0) {
-            if (name === "thunderbird-trunk") {
-                return "comm-central-thunderbird";
-            } else {
-                var tokens = name.split("-");
-                return "comm-" + tokens[1] + "-" + tokens[0];
-            }
+        // TODO: Move these to the repository fixture in the service.
+        if (name.indexOf("comm-") >= 0 && name !== "try-comm-central") {
+            return name + "-thunderbird";
         }
         return name;
     };

--- a/webapp/app/partials/thRepoDropDown.html
+++ b/webapp/app/partials/thRepoDropDown.html
@@ -20,7 +20,7 @@
         </li>
 
         <li class="watched-repo-dropdown-item">
-            <a href="https://secure.pub.build.mozilla.org/clobberer/?branch={{clobberer}}" target="_blank">clobberer</a>
+            <a href="https://secure.pub.build.mozilla.org/clobberer/?branch={{name}}" target="_blank">clobberer</a>
         </li>
 
     </ul>


### PR DESCRIPTION
Now that bug 1035222 has corrected the base repo name, the clobberer
workaround added by bug 1035220 must be removed - and the treestatus
name generation tweaked.
