### PR TITLE
Provide padding on navbar drop down menus

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -43,6 +43,8 @@ body {
     max-height: 600px;
     overflow: auto;
     margin-top: 10px;
+    padding-left: 8px;
+    padding-bottom: 8px;
 }
 
 .th-global-navbar {


### PR DESCRIPTION
This improves the layout in all drop down menus, by providing some breathing space for the listed items (no Bugzilla bug posted).

Here's the before and after:

![repomenudropdowncurrent](https://cloud.githubusercontent.com/assets/3660661/4278917/7d9012be-3d1c-11e4-8a18-1744283d59ce.jpg)

![repomenudropdownproposed](https://cloud.githubusercontent.com/assets/3660661/4278920/862eff52-3d1c-11e4-9bd2-e3e6f5d41ea9.jpg)

The bottom padding doesn't appear to have effect on Firefox, but it is recognized in Chrome, so there appeared to be some benefit in including it. More work may occur in bug [1066377](https://bugzilla.mozilla.org/show_bug.cgi?id=1066377) but it improves it for now.

Tested on Windows:
FF Release **32.0**
Chrome Latest Release **37.0.2062.120 m**

Adding @camd for visibility.
