### PR TITLE
fix repo-menu disappear on click-away and esc.

### DIFF
--- a/webapp/app/js/controllers/repository.js
+++ b/webapp/app/js/controllers/repository.js
@@ -9,34 +9,5 @@ treeherder.controller('RepositoryMenuCtrl', [
 
         $scope.closeable = true;
 
-        $('.dropdown.keep-open').on({
-            "shown.bs.dropdown": function(ev) {
-                $scope.closeable = false;
-            },
-            "click":             function(ev) {
-                $scope.closeable = true;
-            },
-            "hide.bs.dropdown":  function(ev) {
-                var closeable = $scope.closeable;
-                $scope.closeable = true;
-                return closeable;
-            }
-        });
-
-        $('.repo-dropdown-menu').on({
-            "shown.bs.dropdown": function(ev) {
-                $scope.closeable = false;
-            },
-            "click":             function(ev) {
-                $scope.closeable = true;
-            },
-            "mouseup":             function(ev) {
-                $scope.closeable = false;
-            },
-            "hide.bs.dropdown":  function(ev) {
-                return $scope.closeable;
-            }
-        });
-
     }
 ]);

--- a/webapp/app/js/directives/top_nav_bar.js
+++ b/webapp/app/js/directives/top_nav_bar.js
@@ -92,31 +92,39 @@ treeherder.directive('thWatchedRepo', [
     };
 }]);
 
-treeherder.directive('thRepoDropDown', [
-    'ThLog', 'ThRepositoryModel', 'treeStatus',
-    function (ThLog, ThRepositoryModel, treeStatus) {
+treeherder.directive('thRepoDropdownContainer', [
+    'ThLog', '$rootScope', 'thEvents',
+    function (ThLog, $rootScope, thEvents) {
 
-    var $log = new ThLog("thRepoDropDown");
+    var $log = new ThLog("thRepoDropdownContainer");
 
     return {
-        restrict: "E",
-        replace: true,
+        restrict: "A",
         link: function(scope, element, attrs) {
 
-            scope.name = attrs.name;
-            scope.treeStatus = treeStatus.getTreeStatusName(attrs.name);
-            var repo_obj = ThRepositoryModel.getRepo(attrs.name);
-            scope.pushlog = repo_obj.url +"/pushloghtml";
-
-            scope.$watch('repoData.treeStatus', function(newVal) {
-                if (newVal) {
-                    $log.debug("updated treeStatus", repo_obj, newVal);
-                    scope.reason = newVal.reason;
-                    scope.message_of_the_day = newVal.message_of_the_day;
+            scope.closeable = true;
+            $(element).on({
+                "hide.bs.dropdown": function(ev) {
+                    $log.debug("repo menu container", "hide.bs.dropdown", scope.closeable, ev.target.className);
+                    var closeable = scope.closeable;
+                    scope.closeable = true;
+                    return closeable;
                 }
-            }, true);
+            });
 
-        },
-        templateUrl: 'partials/thRepoDropDown.html'
+            $('.repo-dropdown-menu').on({
+                "click": function(ev) {
+                    if ($(ev.target).hasClass(".repo-link") || $(ev.target).hasClass(".repo-checkbox")) {
+                        scope.closeable = false;
+                    }
+                    $log.debug("repo menu dropdown", "click", scope.closeable, ev.target.className);
+                },
+                "mouseup": function(ev) {
+                    scope.closeable = false;
+                    $log.debug("repo menu dropdown", "mouseup", scope.closeable, ev.target.className);
+                }
+            });
+
+        }
     };
 }]);

--- a/webapp/app/partials/thGlobalTopNavPanel.html
+++ b/webapp/app/partials/thGlobalTopNavPanel.html
@@ -29,7 +29,7 @@
 
             <span ng-controller="RepositoryMenuCtrl" >
                 <!--<span class="repo-menu dropdown keep-open">-->
-                <span class="repo-menu dropdown keep-open">
+                <span th-repo-dropdown-container class="repo-menu dropdown">
                     <!-- Repo Button -->
                     <button id="repoLabel" role="button" href="#" data-toggle="dropdown" data-target="#" class="btn btn-view-nav">
                         Repos <b class="fa fa-caret-down lightgray"></b>
@@ -38,18 +38,18 @@
                     <!-- Repo Menu -->
                     <ul class="dropdown-menu repo-dropdown-menu" role="menu" aria-labelledby="repoLabel">
                         <span ng-repeat="(group_order, group) in groupedRepos()"
-                              ng-click="$event.stopPropagation();">
+                              >
                             <li role="presentation" class="divider" ng-hide="$first"></li>
                             <li role="presentation" class="dropdown-header">{{group.name}}</li>
-                            <li ng-repeat="repo in group.repos | orderBy : 'name'" ng-click="$event.stopPropagation();">
+                            <li ng-repeat="repo in group.repos | orderBy : 'name'" >
                                 <input type="checkbox"
+                                       class="repo-checkbox"
                                        ng-checked="repoModel.watchedRepos[repo.name]"
-                                       ng-click="repoModel.toggleWatched(repo.name); $event.stopPropagation()"
+                                       ng-click="repoModel.toggleWatched(repo.name)"
                                        title="toggle watching this repo"
                                        ng-disabled="repo.name == repoName">
                                     <a ng-href="./#/jobs?repo={{repo.name}}"
                                        title="open repo"
-                                       ng-click="$event.stopPropagation()"
                                        class="repo-link">{{repo.name}}</a>
                             </li>
                         </span>


### PR DESCRIPTION
- fix handling events so the menu persists when right-clicking and clicking the check boxes, but goes away when clicking away.
- fix the padding on the repo menu.  and make it a bit wider for long repos some still wrap, but I didn't want to make the min-width TOO large for small screens.
- re-purposed the old directive for event handling.
