### PR TITLE
Css js versioning

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function(grunt) {
 
     grunt.initConfig({
@@ -32,13 +34,46 @@ module.exports = function(grunt) {
 
         usemin:{ html:['dist/index.html', 'dist/help.html', 'dist/logviewer.html'] },
 
+        'cache-busting': {
+            indexjs: {
+                replace: ['dist/**/*.html'],
+                replacement: 'index.min.js',
+                file: 'dist/js/index.min.js',
+                cleanup: true //Remove previously generated hashed files.
+            },
+            logviewerjs: {
+                replace: ['dist/**/*.html'],
+                replacement: 'logviewer.min.js',
+                file: 'dist/js/logviewer.min.js',
+                cleanup: true
+            },
+            indexcss: {
+                replace: ['dist/**/*.html'],
+                replacement: 'index.min.css',
+                file: 'dist/css/index.min.css',
+                cleanup: true
+            },
+            logviewercss: {
+                replace: ['dist/**/*.html'],
+                replacement: 'logviewer.min.css',
+                file: 'dist/css/logviewer.min.css',
+                cleanup: true
+            },
+            helpcss: {
+                replace: ['dist/**/*.html'],
+                replacement: 'help.min.css',
+                file: 'dist/css/help.min.css',
+                cleanup: true
+            }
+        },
+
         copy:{
 
             main: {
                 files: [
                     { src:'webapp/app/index.html', dest:'dist/index.html', nonull: true },
                     { src:'webapp/app/help.html', dest:'dist/help.html', nonull: true },
-                    { src:'webapp/app/logviewer.html', dest:'dist/logviewer.html', nonull: true },
+                    { src:'webapp/app/logviewer.html', dest:'dist/logviewer.html', nonull: true }
                 ]
             },
             // Copy img dir
@@ -93,6 +128,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-cssmin');
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-usemin');
+    grunt.loadNpmTasks('grunt-cache-busting');
 
     // Default tasks
     grunt.registerTask('build', [
@@ -106,7 +142,8 @@ module.exports = function(grunt) {
         'concat',
         'cssmin',
         'uglify',
-        'usemin'
+        'usemin',
+        'cache-busting'
         ]);
 
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "grunt-contrib-cssmin": "^0.9.0",
     "grunt-contrib-uglify": "^0.4.0",
     "grunt-contrib-clean": "^0.5.0",
-    "grunt-filerev": "^0.2.1"
+    "grunt-filerev": "^0.2.1",
+    "grunt-cache-busting": "0.0.10"
   },
   "scripts": {
     "test": "karma start webapp/config/karma.conf.js --single-run --browsers Firefox"

--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -5,6 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+        <meta http-equiv="cache-control" content="max-age=60" />
         <link id="favicon" type="image/png" rel="shortcut icon" href="img/tree_open.png"/>
         <th-favicon-link></th-favicon-link>
 


### PR DESCRIPTION
Add version md5 to all minified css and js files created by our grunt build.  This will ensure that the new version of the files are loaded rather than fetching from cache.
