### PR TITLE
Display logviewer start time in human readable form

### DIFF
--- a/webapp/app/js/controllers/logviewer.js
+++ b/webapp/app/js/controllers/logviewer.js
@@ -159,6 +159,13 @@ logViewer.controller('LogviewerCtrl', [
                         + "index.html#/jobs?repo="
                         + $scope.repoName + "&revision=" + revision;
 
+                    // Store the artifact epoch date string in a real date object for use
+                    var startTime = $scope.artifact.header.starttime;
+                    var startDate = new Date(0);
+                    startDate.setUTCSeconds(startTime);
+
+                    $scope.logDisplayDate = startDate.toString();
+
                     ThJobArtifactModel.get_list(
                         {job_id: $scope.job_id, name:'buildapi'})
                     .then(function(buildapiData){

--- a/webapp/app/logviewer.html
+++ b/webapp/app/logviewer.html
@@ -21,7 +21,8 @@
                                target="_blank"
                                class="repo-link">{{value}}</a>
                         </td>
-                        <td ng-if="label != 'revision'">{{value}}</td>
+                        <td ng-if="label == 'starttime'">{{logDisplayDate}}</td>
+                        <td ng-if="label != 'revision' && label != 'starttime'">{{value}}</td>
                     </tr>
                 </table>
             </div>


### PR DESCRIPTION
This fixes Bugzilla bug [1060477](https://bugzilla.mozilla.org/show_bug.cgi?id=1060477).

This converts the logviewer display of the job start time from unix epoch to human readable. As discussed with @edmorley the sheriffs prefer local time format rather than GMT/UTC, for ease of real-time failure recognition on the platform, and in collaboration with development.

Here's the before and after:

![logviewerstarttimecurrent](https://cloud.githubusercontent.com/assets/3660661/4325573/869cb4c4-3f66-11e4-88b9-7d30bb7e574b.jpg)

![logviewerstarttimeproposed](https://cloud.githubusercontent.com/assets/3660661/4325575/8afb7546-3f66-11e4-9dc7-afef5e1cfd00.jpg)

I iterated with Ed and @wlach in channel on the final format, and confirmed its length.

Please check to make sure my scoping on the new date object makes sense. I wasn't able to use the artifact start time as it presently exists, since it wasn't an angular date object. So it had to be converted into one in js, to be accessed and manipulated there if needed.

nb. if you have an angular date object, supposedly you can do this sort of thing in the markup.
`{{header.date | date:'yyyy-MM-dd HH:mm:ss Z'}}`

I've tested a variety of workflows I can think of, page reloads, tabs, opening the same log in multiple tabs, and they seem fine.

Tested on Windows:
FF Release **32.0.1**
Chrome Latest Release **37.0.2062.120 m**

Adding @camd and @wlach for review.
