### PR TITLE
Bug 1043741 - Use the step result code for step failure determination

### DIFF
--- a/webapp/app/js/controllers/logviewer.js
+++ b/webapp/app/js/controllers/logviewer.js
@@ -33,21 +33,21 @@ logViewer.controller('LogviewerCtrl', [
 
         $scope.$watch('artifact', function () {
             if (!$scope.artifact) return;
-            if ($scope.totalErrors() > 0) {
-                $scope.showSuccessful = false;
-            } else {
-                $scope.showSuccessful = true;
-            }
+            $scope.showSuccessful = !$scope.hasFailedSteps();
         });
 
-        $scope.totalErrors = function () {
-            return $scope.artifact.step_data.steps.reduce(function (prev, curr) {
-                if (prev.errors) {
-                    return prev.errors.length;
+        $scope.hasFailedSteps = function () {
+            var steps = $scope.artifact.step_data.steps;
+            for (var i = 0; i < steps.length; i++) {
+                // We only recently generated step results as part of ingestion,
+                // so we have to check the results property is present.
+                // TODO: Remove this when the old data has expired, so long as
+                // other data submitters also provide a step result.
+                if ('result' in steps[i] && steps[i].result !== "success") {
+                    return true;
                 }
-
-                return prev + curr.errors.length;
-            });
+            }
+            return false;
         };
 
         $scope.loadMore = function(bounds, element) {

--- a/webapp/app/js/directives/log_viewer_steps.js
+++ b/webapp/app/js/directives/log_viewer_steps.js
@@ -39,7 +39,7 @@ treeherder.directive('lvLogSteps', ['$timeout', '$q', function ($timeout, $q) {
                 scope.showSuccessful = !scope.showSuccessful;
 
                 var firstError = scope.artifact.step_data.steps.filter(function(step){
-                    return step.errors && step.errors.length > 0;
+                    return step.result && step.result !== "success";
                 })[0];
 
                 if (!firstError) return;

--- a/webapp/app/partials/logviewer/lvLogSteps.html
+++ b/webapp/app/partials/logviewer/lvLogSteps.html
@@ -2,9 +2,9 @@
     <div ng-repeat="step in artifact.step_data.steps"
          ng-click="displayLog(step)"
          ng-class="{'selected': (displayedStep.order === step.order),
-                    'btn-success': (step.error_count === 0),
-                    'btn-warning': (step.error_count > 0)}"
-         ng-if="showSuccessful === true || step.error_count !== 0"
+                    'btn-success': (step.result === 'success'),
+                    'btn-warning': (step.result !== 'success')}"
+         ng-if="showSuccessful === true || step.result !== 'success'"
          class="btn btn-block logviewer-step clearfix"
          order="{{step.order}}">
         <span class="pull-left clearfix">
@@ -43,7 +43,7 @@
     </a>
 </div>
 
-<div ng-if="artifact && totalErrors() !== 0"
+<div ng-if="artifact && hasFailedSteps()"
      class="logviewer-stepbar">
     <input type="checkbox"
            ng-model="showSuccessful"


### PR DESCRIPTION
Previously only the presence of error lines found by the log parser
would cause the step to be marked as failing in the log viewer - even
if the step had a result value of !success. With this patch we use the
step result, thereby also handling cases where the log parser didn't
find a match.
