### PR TITLE
Bug 1068532 - Ignore keyboard shortcuts if modifiers used

### DIFF
--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -36,7 +36,9 @@ treeherder.controller('MainCtrl', [
                 return;
             }
 
-            if (!ev.metaKey) {
+            // test for key modifiers to allow browser shortcuts eg.
+            // console, new/private browsing window, history, print
+            if (!ev.metaKey && !ev.shiftKey && !ev.ctrlKey) {
                 if ((ev.keyCode === 73)) {
                     // toggle display in-progress jobs(pending/running), key:i
                     $scope.toggleInProgress();


### PR DESCRIPTION
This fixes Bugzilla bug [1068532](https://bugzilla.mozilla.org/show_bug.cgi?id=1068532).

This allows users to invoke various browser-native keyboard shortcuts, and not have treeherder interpret them as treeherder shortcuts.

For example:
- (p) - previous failure, (**Ctrl** +p) - print
- (j) - next failure, (**Shft+Ctrl** +j) - console
- (p) - previous failure, (**Shift+Ctrl** +p) - new private browsing window

...and so forth with each of the variations on Firefox and Chrome.

Originally I was anticipating needing to create special tests for each set of treeherder keyboard shortcuts, but it seems we get the desired behavior for all the shortcuts I've looked at, if we test for the key modifier at the top of the entire block. I've tested pretty extensively on Firefox and Chrome and both seem to be behaving fine.

Page down and page up via spacebar and Shift+spacebar continue to work correctly.

I've also tested:
- print
- history sidebar
- bookmark sidebar
- console
- new window
- new private browsing window

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @camd and @maurodoglio for review.
