### PR TITLE
Bug 1068685 - Replace missing scrollbar in help

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1476,9 +1476,18 @@ fieldset[disabled] .btn-repo.active {
     color: lightgray;
 }
 
-#help.dt, #help.dd { text-align: center;}
-#help.panel {padding:5px;}
-#help{padding-top:10px;}
+#help {
+    padding: 10px 10px 0px;
+    overflow: auto;
+}
+
+#help.dt, #help.dd {
+    text-align: center;
+}
+
+#help.panel {
+    padding: 5px;
+}
 
 .waiter-small{ background: url("../img/waiter16.png") no-repeat center center; width: 16px; height: 16px; display: inline-block;}
 .waiter-medium{ background: url("../img/waiter32.png") no-repeat center center; width: 32px; height: 32px; display: inline-block;}

--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -7,7 +7,7 @@
     <link href="css/treeherder.css" rel="stylesheet" media="screen">
     <!-- endbuild -->
 </head>
-<body class="container" id="help">
+<body id="help">
 <div class="panel panel-default">
 <div class="panel-heading">
     <h1>Treeherder Help</h1>


### PR DESCRIPTION
This fixes Bugzilla bug [1068685](https://bugzilla.mozilla.org/show_bug.cgi?id=1068685).

This returns the scroll bar to the help window, which went missing during recent changes in bug 1063732, which added `overflow: hidden` to all top level html tags to improve the main platform experience. It seemed reasonable in the course of fixing the regression to use more of the available page for content, rather than constraining it to the `.container` class width of 970px.

Here is a before and after:

![helpappearancecurrent](https://cloud.githubusercontent.com/assets/3660661/4429785/784b2aa2-4602-11e4-835a-14ef26d9892b.jpg)
![helpappearanceproposed](https://cloud.githubusercontent.com/assets/3660661/4429786/7d1a1296-4602-11e4-95e6-338adcdecafc.jpg)

Everything seems to be behaving properly at various widths and scroll positions.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @camd and @wlach for review.
