### PR TITLE
Bug 1059279 - Improve resultset menu bar clarity and cancel access

### DIFF
--- a/webapp/app/css/bootstrap.css
+++ b/webapp/app/css/bootstrap.css
@@ -2769,7 +2769,7 @@ fieldset[disabled] .btn {
   opacity: .65;
 }
 .btn-default {
-  color: #333;
+  color: #666;
   background-color: #fff;
   border-color: #ccc;
 }

--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -333,6 +333,11 @@ th-watched-repo {
     padding-left: 0;
 }
 
+/* Cancel all jobs custom icon size */
+.glyphicon-minus-sign {
+    font-size: 85%;
+}
+
 .revision-text {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -28,7 +28,15 @@
               ng-click="pinAllShownJobs()">
           <span class="glyphicon glyphicon-pushpin"></span>
         </span>
+
         <th-action-button ng-hide="isLoadingJobs"></th-action-button>
+
+        <span class="btn btn-default btn-sm"
+              tabindex="0" role="button"
+              title="cancel all jobs in this resultset"
+              ng-click="cancelAllJobs(resultset.revision)">
+          <span class="glyphicon glyphicon-minus-sign"></span>
+        </span>
       </span>
 
       <span class="btn btn-default btn-sm revision-button"

--- a/webapp/app/partials/main/thActionButton.html
+++ b/webapp/app/partials/main/thActionButton.html
@@ -1,12 +1,10 @@
     <span class="dropdown">
         <a class="btn btn-default btn-sm dropdown-toggle" data-hover="dropdown" data-delay="1000" href="#">
-            <i class="fa fa-external-link fa-lg"></i>
             <b class="caret"></b>
         </a>
         <ul class="dropdown-menu pull-left">
             <li><a target="_blank" href="https://tbpl.mozilla.org/mcmerge/?cset={{resultset.revision}}&tree={{repoName}}">mcMerge</a></li>
             <li><a target="_blank" href="https://secure.pub.build.mozilla.org/buildapi/self-serve/{{repoName}}/rev/{{resultset.revision}}">BuildAPI</a></li>
             <li><a target="_blank" href="" prevent-default-on-left-click  ng-click="openRevisionListWindow()">Revision URL List</a></li>
-            <li><a href="" prevent-default-on-left-click  ng-click="cancelAllJobs(resultset.revision)">Cancel All Jobs</a></li>
         </ul>
     </span>


### PR DESCRIPTION
This fixes Bugzilla bug [1059279](https://bugzilla.mozilla.org/show_bug.cgi?id=1059279).

This improves access to the frequently used "cancel all" jobs, by breaking it out into a separate button. And at the same time retiring the existing icon for the mcMerge menu, so it is consistent with similar drop downs in the upper navbar - which also only have a down-arrow/chevron.

Net, it adds roughly 1/2 a button width to the entire bar, since we remove part of the width of one (the mcMerge menu icon), and add one for cancel all jobs. A by product we end up with three nice and fairly consistently sized buttons.

Here is a before and after:

![resultsetbuttonscurrent](https://cloud.githubusercontent.com/assets/3660661/4431574/a174e894-466d-11e4-9e70-21ae8eb34f01.jpg)
![resultsetbuttonsproposed](https://cloud.githubusercontent.com/assets/3660661/4431575/a396a3ec-466d-11e4-8e9e-b1f52566a65e.jpg)

We also have a suitable tooltip:

![resultsetcanceltooltip](https://cloud.githubusercontent.com/assets/3660661/4431577/adbdf15e-466d-11e4-8f03-4e3067eac10a.jpg)

I took the opportunity to decrease the contrast of all these glyph icons in the bootstrap, increasing the glyph color grey to `#666` so they compete less with the jobs. It differentiates on hover and looks nice on Windows but let me know if it seems too light on OSX. I understand from @wlach we can update the bootstrap and not risk it getting stepped on by bootstrap version updates.

The default proportions for glyph `minus-sign` were a bit powerful, so I reduced its size by 15% so it better matches its neighbors.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @camd, @wlach and @edmorley for feedback and review.
