### PR TITLE
Bug 1067486 - Fix unwanted job wrap when space is available

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -377,6 +377,7 @@ th-watched-repo {
 .job-btn {
   padding: 0 2px 0 2px;
   vertical-align: 0;
+  line-height: 1.32;
 }
 
 .table-super-condensed thead > tr > th,
@@ -914,7 +915,7 @@ ul.failure-summary-list li .btn-xs {
  .job-btn.btn-red,
  .job-btn.btn-orange,
  .job-btn.btn-purple {
-    margin: 0 -3px 0 0;
+    margin: 0 -3px 1px 0;
  }
 
 .btn-view-nav {

--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -600,14 +600,12 @@ treeherder.directive('thCloneJobs', [
     };
     var showHideJob = function(job, show) {
         // Note: I was using
-        //    jobEl.style.display = "inline";
         //    jobEl.className += " filter-shown";
         // but that didn't work reliably with the jquery selectors
         // when it came to hiding/showing platforms and groups.  Jquery
         // couldn't detect that I'd added or removed ``filter-shown`` in
         // all cases.  So, while this is a bit slower, it's reliable.
         if (show) {
-            job.css("display", "inline");
             job.addClass("filter-shown");
         } else {
             job.css("display", "none");


### PR DESCRIPTION
This fixes Bugzilla bug [1067486](https://bugzilla.mozilla.org/show_bug.cgi?id=1067486).

This corrects sporadic unwanted wrapping of jobs, when there is available space on the existing job row. This impacted Firefox (maybe other OS browsers I don't have access to), but not Chrome. After much experimentation and iterating I've managed to distill it down to only this change. We remove the inline style on the job element, a 1px hairlne margin to keep the jobs separated, and apply a compensating line height scale to the job to preserve the current line spacing in production.

I have matched the line spacing presently in master. It is virtually identical as far as I can tell, side by side. Perhaps 1 or 2 pixels smaller with the change, with about 30 rows of data.

Here is the before and after:

![jobwrapfirefoxcurrent](https://cloud.githubusercontent.com/assets/3660661/4477533/d80160a4-497e-11e4-9e35-4b0df47b3cef.jpg)

![jobwrapfirefoxproposedfix](https://cloud.githubusercontent.com/assets/3660661/4477536/dc3774ba-497e-11e4-8cc1-ed125082e935.jpg)

One by product of this fix for Sheriffs, is the selected job element is slightly taller. It opens up a bit more line space on the selected row, but only during selection.

Before and after:

![btn-selected-current](https://cloud.githubusercontent.com/assets/3660661/4477602/40277768-497f-11e4-98bd-395f7c3ba11d.jpg)

![btn-selected-proposed](https://cloud.githubusercontent.com/assets/3660661/4477605/43219778-497f-11e4-88f4-4acf320a8bf6.jpg)

It's pretty subtle. I checked with @KWierso in channel and he was ok with that.

I've looked at a lot of resultsets and variations on Firefox and Chrome, and I can't see any side effects of the change elsewhere in the platform.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @jeads, @camd and @edmorley for feedback and review.
