### PR TITLE
Bug 1077679 -  Update the resultset icon colors post-bootstrap 3.2

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1303,6 +1303,10 @@ fieldset[disabled] .btn-mdgray.active {
   color: #6f6d70;
 }
 
+.btn-resultset {
+    color: #666;
+}
+
 .btn-dkgray {
   color: #7c7a7d;
 }

--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -22,7 +22,7 @@
       </span>
       <span class="result-set-buttons">
         <span class="revision-text">{{resultset.revision}}</span>
-        <span class="btn btn-default btn-sm"
+        <span class="btn btn-default btn-sm btn-resultset"
               tabindex="0" role="button"
               title="pin all visible jobs in this resultset"
               ng-click="pinAllShownJobs()">
@@ -31,7 +31,7 @@
 
         <th-action-button ng-hide="isLoadingJobs"></th-action-button>
 
-        <span class="btn btn-default btn-sm"
+        <span class="btn btn-default btn-sm btn-resultset"
               tabindex="0" role="button"
               title="cancel all jobs in this resultset"
               ng-click="cancelAllJobs(resultset.revision)">
@@ -39,7 +39,7 @@
         </span>
       </span>
 
-      <span class="btn btn-default btn-sm revision-button"
+      <span class="btn btn-default btn-sm btn-resultset revision-button"
             tabindex="0" role="button"
             ng-click="toggleRevisions()"
             title="show revisions"><i class="fa fa-code-fork fa-lg"></i> {{resultset.revision_count}}</span>

--- a/webapp/app/partials/main/thActionButton.html
+++ b/webapp/app/partials/main/thActionButton.html
@@ -1,5 +1,5 @@
     <span class="dropdown">
-        <a class="btn btn-default btn-sm dropdown-toggle" data-hover="dropdown" data-delay="1000" href="#">
+        <a class="btn btn-default btn-sm btn-resultset dropdown-toggle" data-hover="dropdown" data-delay="1000" href="#">
             <b class="caret"></b>
         </a>
         <ul class="dropdown-menu pull-left">

--- a/webapp/app/partials/main/thResultCounts.html
+++ b/webapp/app/partials/main/thResultCounts.html
@@ -1,4 +1,4 @@
-    <span class="btn btn-default btn-sm result-status-total-count"
+    <span class="btn btn-default btn-sm btn-resultset result-status-total-count"
           tabindex="0" role="button"
           ng-click="toggleJobs()"
           title="total job count - toggle jobs">


### PR DESCRIPTION
This fixes Bugzilla bug [1077679](https://bugzilla.mozilla.org/show_bug.cgi?id=1077679).

In it we re-implement the desired glyph color for the resultset icons and do so in a way that insulates them from future bootstrap updates. We already had a `btn-dkgray` at `7c7a7d` (124,122,125) we could have theoretically used. But the landed color for the resultset icons was different enough at (102,102,102), that it seemed to make sense to stick with Ed's approved color - which is `#666`.

There is a `result-set-buttons` parent class which encompasses some of these icons which need the change, but not all. So it seemed to make sense to create another child btn class, `btn-resultset`.

Here is a before and after:

![resultseticonscurrent](https://cloud.githubusercontent.com/assets/3660661/4513012/22b7d028-4b47-11e4-8341-f2e7885ea396.jpg)

![resultseticonscorrected](https://cloud.githubusercontent.com/assets/3660661/4513014/24bf6cb4-4b47-11e4-862b-0999e6e37987.jpg)

Everything seems to appear correctly on both browsers I've tested with a local server.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @wlach and @camd for review.
