### PR TITLE
Bug 1077635 - Improve readability of platform job rows

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -287,6 +287,7 @@ th-watched-repo {
     width: 14.5em;
     min-width: 14.5em;
     overflow: hidden;
+    vertical-align: top;
 }
 
 .job-row {
@@ -358,6 +359,14 @@ th-watched-repo {
 .result-set .job-list-pad-left {
     padding-left: 8;
     padding-right: 0;
+}
+
+.job-list-pad-left table tr {
+    border-bottom: 1px dotted lightgrey;
+}
+
+.job-list-pad-left table tr:nth-child(even) {
+    background: #f8f8f8;
 }
 
 .result-set .job-list-nopad {


### PR DESCRIPTION
This work fixes Bugzilla bug [1077635](https://bugzilla.mozilla.org/show_bug.cgi?id=1077635).

The change improves readability of the job content, by aligning the platform name with its adjacent job block like TPBL, and enhancing beyond TBPL with a platform row color, to help quickly grok the content when Sheriffs are glancing at it.

Here is current production (centered platform name, all white):

![jobrowcurrent](https://cloud.githubusercontent.com/assets/3660661/4518903/68f44634-4ca5-11e4-8a8a-c3c1d460d6f7.jpg)

Here is the proposed appearance (aligned platform name, `#f8f8f8` alternate grey):

![jobrowproposed](https://cloud.githubusercontent.com/assets/3660661/4518929/7d03b802-4ca6-11e4-81e5-1b9d4dd7c3c1.jpg)

Here the same change with pending jobs, which looks very nice:

![pendingexampleproposed](https://cloud.githubusercontent.com/assets/3660661/4518908/906d7dc0-4ca5-11e4-960b-080b1a62e690.jpg)

I also did another alternate, which adds a 1px subtle row border as an option. However it cumulatively adds about 20-30px vertically to a given result set.

![jobrowalternate](https://cloud.githubusercontent.com/assets/3660661/4518931/903bb302-4ca6-11e4-977f-166c08ab150e.jpg)

I've checked on a couple of different monitors with different amounts of luminance and display quality, and the `#f8f8f8` background seems to show up well, without interfering with the pending job color. By not going too dark, it also still keeps the overall feel of a unified result set block.

We may want to darken the hover color slightly for more differentiation, when hovering over an already grey row, but it seemed ok on my local server.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @edmorley and @rvandermeulen  for evaluation and @camd for review.
