### PR TITLE
Bug 1077635 - Draw low-count job rows with consistent table appearance

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -361,6 +361,10 @@ th-watched-repo {
     padding-right: 0;
 }
 
+.job-list-pad-left table {
+    width: 100%;
+}
+
 .job-list-pad-left table tr {
     border-bottom: 1px dotted lightgrey;
 }


### PR DESCRIPTION
This is supplementary to already landed work in Bugzilla bug [1077635](https://bugzilla.mozilla.org/show_bug.cgi?id=1077635).

I noticed an edge case this morning, where a newly building resultset may not have enough job elements to fill the parent container, at certain browser widths. This change addresses that, ensuring all low-count job rows are consistent and their resultsets don't look 'ragged' in the UI.

Here's the before and after:

![lowjobcountcurrent](https://cloud.githubusercontent.com/assets/3660661/4530118/ccb23aae-4d7d-11e4-94f8-c3eb4cd0ed00.jpg)

![lowjobcountproposed](https://cloud.githubusercontent.com/assets/3660661/4530120/d1ffc184-4d7d-11e4-80eb-7029a0fc637c.jpg)

I think we should only land this tweak once we know the alternate colors in the previous PR https://github.com/mozilla/treeherder-ui/pull/216 has been signed off by the sheriffs on dev. It does look nice though :)

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @edmorley for visibility and @camd for review.
