### PR TITLE
Bug 1076040, 1075301- Ensure watched repo navbar appears on initial page load, open resultset in new tab

### DIFF
--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -201,16 +201,15 @@ treeherder.controller('MainCtrl', [
             return triggerParams;
         };
 
-        // this is to avoid bad urls showing up
-        // when the app redirects internally
-        $rootScope.urlBasePath = $location.absUrl().split('?')[0];
-
         // reload the page if certain params were changed in the URL.  For
         // others, such as filtering, just re-filter without reload.
         $rootScope.$on('$locationChangeSuccess', function(ev, newUrl, oldUrl) {
 
             // used to test for display of watched-repo-navbar and jobs menu
             $rootScope.locationPath = $location.path().replace('/', '');
+
+            // used to avoid bad urls when the app redirects internally
+            $rootScope.urlBasePath = $location.absUrl().split('?')[0];
 
             $log.debug("check for reload", "newUrl=", newUrl, "oldUrl=", oldUrl);
 


### PR DESCRIPTION
This fixes Bugzilla bug [1076040](https://bugzilla.mozilla.org/show_bug.cgi?id=1076040).

In it we ensure we set `locationPath` only after `locationChangeSuccess` has occurred. Otherwise its value on initial page load can be null, instead of `/jobs`. Which it needs to be, for a successful ng-show in its particular partial.

Here's the before and after the fix, on initial load:

![initialloadcurrent](https://cloud.githubusercontent.com/assets/3660661/4532258/4335d574-4d91-11e4-89fc-bdc991815e2b.jpg)

![initialloadfixed](https://cloud.githubusercontent.com/assets/3660661/4532259/46ca8450-4d91-11e4-990d-5f4d782eb868.jpg)

The display state of the jobs menu was also impacted by the bug.

Chrome didn't show the same problem in dev/stage/prod, but it did show the problem in a local server. Firefox appeared to show the problem in all.

A note, the initial work which orphaned that value appear to be about a month ago, in case there's investigation or more context needed. It is https://github.com/mozilla/treeherder-ui/commit/b413f839545ac12368187fba680dd9c447973429#diff-4168352fd16d2e6758c883cc406005abL206

Everything seems to appear correctly on both browsers I've tested with a local server.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @wlach and @camd for review.
