### PR TITLE
bug 1076720 - accidental removal of setting display inline on job show

### DIFF
--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -600,12 +600,14 @@ treeherder.directive('thCloneJobs', [
     };
     var showHideJob = function(job, show) {
         // Note: I was using
-        //    jobEl.className += " filter-shown";
+        //     jobEl.style.display = "inline";
+        //     jobEl.className += " filter-shown";
         // but that didn't work reliably with the jquery selectors
         // when it came to hiding/showing platforms and groups.  Jquery
         // couldn't detect that I'd added or removed ``filter-shown`` in
         // all cases.  So, while this is a bit slower, it's reliable.
         if (show) {
+            job.css("display", "inline");
             job.addClass("filter-shown");
         } else {
             job.css("display", "none");


### PR DESCRIPTION
these lines were accidentally removed.  they cause no jobs to show when toggling unclassified failures
