### PR TITLE
Bug 1078985 - Vertically align resultset bar contents

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -324,10 +324,7 @@ th-watched-repo {
     display: -webkit-flex;
     -webkit-flex-flow: row wrap;
     flex-flow: row wrap;
-}
-
-.result-set-title-left {
-    padding-top: 5px;
+    align-items: center;
 }
 
 .result-set .revision-list {


### PR DESCRIPTION
This fixes Bugzilla bug [1078985](https://bugzilla.mozilla.org/show_bug.cgi?id=1078985).

The contents of the resultset container weren't completely aligned. As per the screen grab below, it's just one of those small layout/polish things. It's subtle, but like looking at a picture frame that isn't level, it's kind of distracting.

Here is the current, at 2:1 res:

![resultsetalignment](https://cloud.githubusercontent.com/assets/3660661/4537118/ef7d12a0-4dd4-11e4-9943-ba8087917714.jpg)

Here is the fix, at 1:1 res:

![resultsetproposed](https://cloud.githubusercontent.com/assets/3660661/4537147/a82c85ec-4dd5-11e4-83bd-b6d73d79fcee.jpg)

I had a look at the other items in the row and everything else seemed ok, just the Date/Id was off. So this tweak makes the flexbox change.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @wlach for review as our flexbox mentor.
