### PR TITLE
Bug 1079650 - Give the Initials buttons consistent size and spacing

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1482,10 +1482,13 @@ fieldset[disabled] .btn-repo.active {
 }
 
 .label-initials {
+  display: inline-block;
+  margin-right: 0.2em;
+  padding: 0.2em 0.3em;
+  width: 2.5em;
   border: 1px solid #999999;
   background-color: white;
   color: #999999;
-  padding: 0.1em 0.5em;
 }
 
 .white, .white a {


### PR DESCRIPTION
This fixes Bugzilla bug [1079650](https://bugzilla.mozilla.org/show_bug.cgi?id=1079650).

Nothing dramatic here, just a tweak to the Initials buttons, to be a consistent size and spacing. So both their appearance, and the negative space around them is no longer ragged.

Here is the before and after:

![initiallabelscurrent](https://cloud.githubusercontent.com/assets/3660661/4553756/f1c22390-4e9f-11e4-91a1-64541a5c43fe.jpg)

![initiallabelsproposed](https://cloud.githubusercontent.com/assets/3660661/4553758/fe98676e-4e9f-11e4-9cda-86853b9d2a3a.jpg)

Everything appears to be fine in both Firefox and Chrome, with both the regular repo view, and individual resultset view. I did a lot of testing to ensure the change consumes no more additional line width. Let me know if this looks correct on your platforms.

There didn't seem to be any flexbox approach required in this particular case.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @wlach and @camd for review.
