### PR TITLE
Bug 1079989 - Lower contrast and visually separate the revision block

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -280,6 +280,10 @@ th-watched-repo {
     text-overflow: ellipsis;
 }
 
+.revision-comment {
+    color: #777;
+}
+
 .platform {
     font-size: 12px;
     padding-left: 0;

--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -121,7 +121,11 @@
                title="open revision {{revision}} on {{currentRepo.url}}"
                >{{revision}}</a>
             <span title="{{name}}: {{email}}">{{name|initials}}</span>
-            <span title="{{escaped_comment}}"><em>{{comments_bug_link}}</em></span>
+            <span title="{{escaped_comment}}">
+                <span class="revision-comment">
+                    <em>{{comments_bug_link}}</em>
+                </span>
+            </span>
         </span>
     </li>
 


### PR DESCRIPTION
This fixes proposed Bugzilla bug [1079989](https://bugzilla.mozilla.org/show_bug.cgi?id=1079989).

Another little tweak here. In it, we de-emphasize the left hand resultset block, by harmonizing the revision comments with approximately the same color of the user Initials button. In doing so, we cue the user their first point of contact with the platform is the job results. It also reduces some of the awkward negative space at the boundary edge between the two competing blocks, since the former is often ragged. 

The user initials are `#999`, and I went slightly darker with `#919191` (145 grey) for the comments, since the text is italicized and more 'porous' for lack of a better word.

Here is a before and after:

![revisioncommentscurrent](https://cloud.githubusercontent.com/assets/3660661/4563842/9058f3f4-4f12-11e4-8b9d-b1f053098154.jpg)

![revisioncommentsproposed](https://cloud.githubusercontent.com/assets/3660661/4563851/a3bc15fc-4f12-11e4-9f4f-ebd9a6011e1a.jpg)

It looks pretty nice to me on both Firefox and Chrome, but I'm not a Sheriff :) If it's not an improvement for you guys, no problems we don't have to merge. We do also have existing bugs for potential removal of overflow clipping, multi-line comments, and so forth. This change wouldn't need to be backed out for those other improvements, should they happen.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @edmorley and @rvandermeulen for feedback.

Adding @wlach and @camd for potential review and/or merge.
