### PR TITLE
Bug 1080669 - Clean up resultset boundary and optimize page space

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -304,21 +304,23 @@ th-watched-repo {
     white-space: normal;
     width: 100%;
     border-top: 1px solid lightgrey;
-    padding-left: 15px;
-    padding-right: 15px;
     position: relative;
+}
+
+.result-set-body {
+    padding-left: 15px;
+    padding-right: 25px;
 }
 
 .result-set-title-left, .result-set-buttons, .result-counts {
     flex: none;
     -webkit-flex: none;
-    padding-left: 10px;
     padding-right: 10px;
 }
 
 .result-set-title {
     border-top: 1px solid black;
-    padding: 2px 0px 0px 0px;
+    padding: 2px 0px 0px 14px;
     white-space: nowrap;
     display: flex;
     display: -webkit-flex;
@@ -346,6 +348,7 @@ th-watched-repo {
 
 .revision-button {
     flex: 0 0 60px;
+    margin-right: 2px;
 }
 
 .revision-list {
@@ -838,10 +841,6 @@ ul.failure-summary-list li .btn-xs {
  * RESULT STATUS COUNTS
  */
 
-.result-counts {
-    margin-left: -11px;
-}
-
 #result-status-pane div {
     display: inline-block;
 }
@@ -870,7 +869,7 @@ ul.failure-summary-list li .btn-xs {
     cursor: pointer;
 }
 .result-status-total-count {
-    width: 60px;
+    width: 64px;
 }
 .result-status-count-min-width {
     width: 28px;

--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -45,7 +45,7 @@
             title="show revisions"><i class="fa fa-code-fork fa-lg"></i> {{resultset.revision_count}}</span>
       <th-result-counts class="result-counts"/>
     </div>
-    <div th-clone-jobs ></div>
+    <div class="result-set-body" th-clone-jobs ></div>
 </div>
 
 <div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending && !isLoadingJobs && locationHasSearchParam('revision')">


### PR DESCRIPTION
This fixes Bugzilla bug [1080669](https://bugzilla.mozilla.org/show_bug.cgi?id=1080669).

The current resultset boundary was indented twice, due to several pieces of markup which both inherit the `.result-set` class.

![resultsetmargins](https://cloud.githubusercontent.com/assets/3660661/4582011/f9973592-4fe4-11e4-9979-3f040c915324.jpg)

So instead we remove the padding and lay out the elements so they are more visually aligned with the adjacent UI above (watched repo, Treeherder main logo). This has the additional benefit of giving us a little more page space for revisions and jobs in each resultset.

![resultsetmarginsproposed](https://cloud.githubusercontent.com/assets/3660661/4582026/30b9951a-4fe5-11e4-8db0-02d1638d0784.jpg)

While I was there, I did a little tweaking to the resultset row, trying to clean up some buttons.
- making the toggle revisions and total job count buttons not abut each other
- making the total job count button accommodate 1,000+ job counts

Here is the final look in full:

![resultsetmarginsproposedfull](https://cloud.githubusercontent.com/assets/3660661/4582180/53bed498-4fe6-11e4-8316-de9f0668f12a.jpg)

My only question, is should we remove [this now unused class](https://github.com/mozilla/treeherder-ui/blob/909334b191321a093101aa56e4933f7d904a6a08/webapp/app/partials/main/jobs.html#L46) or leave it in for potentially changes later? As I've noticed a few other orphans in the markup with no connected css.

Everything looks reasonable on Firefox and Chrome at various browser widths, single resultset views, toggled job states, and similar workflows. If you guys can check it on OSX that would be great.

Tested on Windows:
FF Release 32.0.3
Chrome Latest Release 37.0.2062.124 m

Adding @camd and @wlach for review and @edmorley for visibility.
