### PR TITLE
Bug 1073050 - Clear previously entered bug number

### DIFF
--- a/webapp/app/plugins/pinboard.js
+++ b/webapp/app/plugins/pinboard.js
@@ -88,6 +88,7 @@ treeherder.controller('PinboardCtrl', [
             $log.debug("new bug number to be saved: ", $scope.newEnteredBugNumber);
             thPinboard.addBug({id:$scope.newEnteredBugNumber});
             $scope.toggleEnterBugNumber();
+            $scope.newEnteredBugNumber = "";
         };
 
         $scope.viewJob = function(job) {


### PR DESCRIPTION
This fixes Bugzilla bug [1073050](https://bugzilla.mozilla.org/show_bug.cgi?id=1073050).

The last entered bug number in the pin board was not getting cleared, so when you clicked on the '[+]' symbol the old bug number was still present. Everything seems to work fine with this change, multiple bug entries, different jobs, pinboard closures, etc.

Here is the appearance before and after the fix:

![newbugcurrent](https://cloud.githubusercontent.com/assets/3660661/4596232/60e22632-50a1-11e4-971f-46f013d5bd06.jpg)

![newbugfixed](https://cloud.githubusercontent.com/assets/3660661/4596234/645821cc-50a1-11e4-9c1f-9f72574fa075.jpg)

My only questions are:
- the form class switches from `ng-pristine` to `ng-dirty` after initial submission. Should we be switching it back to pristine on bug addition? I checked the main Filter input form at the top right of Treeherder for comparison, and it doesn't reset ng-pristine there either. So perhaps that isn't necessary here
- did I set the internal value correctly (as a string)

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @camd for review.
