### PR TITLE
Bug 1082353 - Improve the job notation in the help panel

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1512,6 +1512,36 @@ fieldset[disabled] .btn-repo.active {
     padding: 5px;
 }
 
+.help-btn {
+    margin: 2px;
+    border: 2px solid;
+}
+
+.help-btn-comment {
+    border: none;
+    background-color: #fff;
+}
+
+.help-btn-orange {
+    border-color: #dd6602;
+}
+
+.help-btn-purple {
+    border-color: #6f0296;
+}
+
+.help-btn-red {
+    border-color: #a1020e;
+}
+
+.help-btn-black {
+    border-color: #000000;
+}
+
+.help-btn-bg {
+    background-color: #fff;
+}
+
 .waiter-small{ background: url("../img/waiter16.png") no-repeat center center; width: 16px; height: 16px; display: inline-block;}
 .waiter-medium{ background: url("../img/waiter32.png") no-repeat center center; width: 32px; height: 32px; display: inline-block;}
 .waiter-large{ background: url("../img/waiter64.png") no-repeat center center; width: 64px; height: 64px; display: inline-block;}

--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -27,26 +27,72 @@
             </div>
             <div class="panel-body">
                 <table id="legend-other">
-                    <tr><th>..*</th>
-                    <td>commented</td></tr>
-                    <tr><th class="pending"><button class="btn btn-ltgray">light gray</button></th>
-                    <td>pending</td></tr>
-                    <tr><th class="running"><button class="btn btn-dkgray">gray</button></th>
-                    <td>running</td></tr>
-                    <tr><th class="success"><button class="btn btn-green">green</button></th>
-                    <td>success</td></tr>
-                    <tr><th class="testfailed"><button class="btn btn-orange">orange</button></th>
-                    <td>tests failed</td></tr>
-                    <tr><th class="exception"><button class="btn btn-purple">purple</button></th>
-                    <td>infrastructure exception</td></tr>
-                    <tr><th class="busted"><button class="btn btn-red">red</button></th>
-                    <td>build error</td></tr>
-                    <tr><th class="retry"><button class="btn btn-dkblue">blue</button></th>
-                    <td>build has been restarted</td></tr>
-                    <tr><th class="usercancel"><button class="btn btn-pink">pink</button></th>
-                    <td>build was cancelled</td></tr>
-                    <tr><th class="unknown"><button class="btn btn-black">black</button></th>
-                    <td>unknown error</td></tr>
+                  <tr>
+                    <th class="jobgroup">
+                      <button class="btn btn-dkgray help-btn help-btn-comment">Th( )</button>
+                    </th>
+                    <td>Wrapped job group</td>
+                  </tr>
+                  <tr>
+                    <th class="annotation">
+                      <button class="btn btn-dkgray help-btn help-btn-comment">Th*</button>
+                    </th>
+                    <td>Asterisk, annotation</td>
+                  </tr>
+                  <tr>
+                    <th class="pending">
+                      <button class="btn btn-ltgray help-btn help-btn-bg">Th</button>
+                    </th>
+                    <td>Light gray, pending</td>
+                  </tr>
+                  <tr>
+                    <th class="running">
+                      <button class="btn btn-dkgray help-btn help-btn-bg">Th</button>
+                    </th>
+                    <td>Gray, running</td>
+                  </tr>
+                  <tr>
+                    <th class="success">
+                      <button class="btn btn-green help-btn help-btn-bg">Th</button>
+                    </th>
+                    <td>Green, success</td>
+                  </tr>
+                  <tr>
+                    <th class="testfailed">
+                      <button class="btn btn-orange help-btn help-btn-orange">Th</button>
+                    </th>
+                    <td>Orange, tests failed</td>
+                  </tr>
+                  <tr>
+                    <th class="exception">
+                      <button class="btn btn-purple help-btn help-btn-purple">Th</button>
+                    </th>
+                    <td>Purple, infrastructure exception</td>
+                  </tr>
+                  <tr>
+                    <th class="busted">
+                      <button class="btn btn-red help-btn help-btn-red">Th</button>
+                    </th>
+                    <td>Red, build error</td>
+                  </tr>
+                  <tr>
+                    <th class="retry">
+                      <button class="btn btn-dkblue help-btn help-btn-bg">Th</button>
+                    </th>
+                    <td>Blue, build restarted</td>
+                  </tr>
+                  <tr>
+                    <th class="usercancel">
+                      <button class="btn btn-pink help-btn help-btn-bg">Th</button>
+                    </th>
+                    <td>Pink, build cancelled</td>
+                  </tr>
+                  <tr>
+                    <th class="unknown">
+                      <button class="btn btn-black help-btn help-btn-black">Th</button>
+                    </th>
+                    <td>Black, unknown error</td>
+                  </tr>
                 </table>
             </div>
         </div>


### PR DESCRIPTION
This work fixes Bugzilla bug [1082353](https://bugzilla.mozilla.org/show_bug.cgi?id=1082353).

This improves the layout and appearance of the job notations in the Help panel. Specifically, we:
- use a consistent character for all buttons
- include a statement of color rather than embed the color as the button label
- override a few of the default btn classes to paint all the buttons consistently
- add a job group button

Here's the before and after:

![jobnotationcurrent](https://cloud.githubusercontent.com/assets/3660661/4633763/4fe8fe10-53ca-11e4-82ca-c825a8b796d7.jpg)

![jobnotationproposed](https://cloud.githubusercontent.com/assets/3660661/4633759/4819af22-53ca-11e4-92e7-aa8be42df95c.jpg)

I've also switched the changed markup to use 2-space indentation, since we've agreed in channel to migrate all html in the repo from 4-space to 2-space indent. I figured I might as well integrate that change even if the file temporarily has a hybrid of both spacings. Let me know if it should be 4-space and I can switch it.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

@edmorley has signed off on the appearance in channel.

Adding @camd and @maurodoglio for review.
