### PR TITLE
Improve the message shown when log parsing is not complete.

### DIFF
--- a/webapp/app/plugins/failure_summary/main.html
+++ b/webapp/app/plugins/failure_summary/main.html
@@ -61,7 +61,7 @@
         </li>
         <li ng-if="!tabs.failureSummary.is_loading && !jobLogsAllParsed">
             <div class="failure-summary-line-empty">
-                <span>Log parsing not complete</span>
+                <span>Log parsing is not yet complete</span>
             </div>
         </li>
         <li ng-if="!tabs.failureSummary.is_loading && !job_log_urls.length">


### PR DESCRIPTION
Really minor tweak to the string shown when the log parser has not finished parsing a log.
