### PR TITLE
Bug 1075272 - Highlight jobs using scale transform to reduce line shift

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -377,7 +377,8 @@ th-watched-repo {
 }
 
 .selected-job {
-    border: 5px solid;
+    border: 4px solid;
+    background-color: #fff;
 }
 
 .job-group {
@@ -937,6 +938,7 @@ ul.failure-summary-list li .btn-xs {
   border-top: 0;
   border-left: 0;
 }
+
 .btn-view-nav:hover,
 .btn-view-nav:focus,
 .btn-view-nav:active,
@@ -1023,11 +1025,17 @@ fieldset[disabled] .btn-unclassified-failures.active {
   border-color: #e0e0e0;
 }
 
-
-
+/* Transformed job buttons for main job block */
+.btn-lg-xform {
+    margin: -2px !important;
+    border: 2px solid;
+    border-radius: 3px;
+    font-size: 12px;
+    transform: scale(1.7, 1.7);
+}
 
 .btn-orange {
-  background-color: rgba(221, 102, 2, 0.56);
+  background-color: #eba870;
   border-color: #dd6602;
   color: white;
 }
@@ -1068,7 +1076,7 @@ fieldset[disabled] .btn-orange.active {
 }
 
 .btn-red {
-  background-color: rgba(144, 0, 0, 0.60);
+  background-color: #b86262;
   border-color: #a1020e;
   color: white;
 }
@@ -1174,7 +1182,7 @@ fieldset[disabled] .btn-green.active {
 }
 
 .btn-purple {
-  background-color: rgba(61, 2, 85, 0.50);
+  background-color: #9a7da6;
   border-color: #6f0296;
   font-weight: bold;
   color: white;
@@ -1346,7 +1354,7 @@ fieldset[disabled] .btn-dkgray.active {
 }
 
 .btn-black {
-  background-color: rgba(0, 0, 0, 0.71);
+  background-color: #4a4a4a;
   border-color: #000000;
   color: white;
 }

--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -23,7 +23,7 @@ treeherder.directive('thCloneJobs', [
     // CSS classes
     var btnCls = 'btn-xs';
     var selectedBtnCls = 'selected-job';
-    var largeBtnCls = 'btn-lg';
+    var largeBtnCls = 'btn-lg-xform';
 
     var col5Cls = 'col-xs-5';
     var col7Cls = 'col-xs-7';


### PR DESCRIPTION
This work fixes Bugzilla bug [1075272](https://bugzilla.mozilla.org/show_bug.cgi?id=1075272).

In it, we decouple the styling of large buttons on the job panel, and draw them with a scale transform, rather than font size.

This stops the vertical line shift that occurrs during job selection, and it reduces horizontal line shift and last-character wrapping. I was unable to completely eliminate the latter because of the border thickness change that occurs during job selection. But in many cases the jobs seem to 'drop down' to a new line less frequently.

That is an issue that can be looked at in a separate fix, I think.

Some of the selected job buttons used alpha transparency. When scaled this resulted in adjacent jobs showing through the scaled job. For affected jobs (eg. orange) I have replaced the background color with an opaque equivalent to the color+page-blend, so they look exactly the same. @edmorley and @rvandermeulen have signed off on the use of an opaque selected job. In some edge cases it obscures adjacent jobs, but they are ok with that.

The job size styling was 'decoupled' from the pinboard, by adding a new `btn-lg-xform` which the pinboard doesn't inherit. So the pinboard selected jobs draw the same as they always have. **nb.** I spent about a full day trying to implement the same scale transforms in the pinboard but hit a variety of issues because of the way the job is comprised of two elements - the job and the close icon, and they scale differently and from different centers. There was also some crazy z-depth stuff going on, that I did not investigate in detail, but was also a problem.

The only change in the pinboard here was to reduce the border width on selection by 1px, to 4px. This makes the appearance of the jobs in both locations more consistent.

So here is a job, before and after:

![jobselectedcurrent](https://cloud.githubusercontent.com/assets/3660661/4637703/80f282cc-53ef-11e4-99df-7b919bd65e42.jpg)

![jobselectedxformproposed](https://cloud.githubusercontent.com/assets/3660661/4637691/5cfc4344-53ef-11e4-8eff-c3e04685e633.jpg)

Here is the look with a pinned job.:

![jobselectedxformpinned](https://cloud.githubusercontent.com/assets/3660661/4637331/42283bc6-53eb-11e4-9954-156383d1865b.jpg)

I've spent a bunch of time on Firefox and Chrome on Windows, and it appears to be behaving pretty nicely. It also saves a bunch of vertical real estate when a job is selected, as you can see above. If you guys can try it on OSX that would be great.

I had to override the bootstrap margin with an `!important` to stop line shift, and I apologize for that. Maybe there is a better way, but I seemed unable override the inheritance without it.

Apologies this is long, but I wanted to track the reasoning for my changes, mostly for my benefit :)

Tested on Windows:
FF Release 32.0.3
Chrome Latest Release 37.0.2062.124 m

Adding @edmorley for visibility.

Adding @wlach and @camd for review and/or merge.
