### PR TITLE
Bug 1074241 - Reset the internal job model position on a job clear

### DIFF
--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -22,10 +22,11 @@ treeherder.controller('MainCtrl', [
             return "[" + ufc + "] " + $rootScope.repoName;
         };
 
-        $scope.clearJob = function() {
-            // setting the selectedJob to null hides the bottom panel
+        $scope.closeJob = function() {
+            // setting the selectedJob to null closes the bottom panel
             $rootScope.selectedJob = null;
         };
+
         $scope.processKeyboardInput = function(ev){
 
             // If the user is in an editable element or the user is pressing
@@ -68,14 +69,18 @@ treeherder.controller('MainCtrl', [
                     }
 
                 } else if (ev.keyCode === 85) {
-                    //display only unclassified failures, keys:u
+                    // Display only unclassified failures, keys:u
                     $scope.toggleUnclassifiedFailures();
                 } else if (ev.keyCode === 27) {
-                    // escape key closes any open top-panel and clears selected job
+                    // Escape closes any open panels and clears the selected job
                     $scope.setFilterPanelShowing(false);
                     $scope.setSettingsPanelShowing(false);
                     $scope.setSheriffPanelShowing(false);
-                    $scope.clearJob();
+                    $scope.closeJob();
+                    $rootScope.$broadcast(thEvents.clearJobStyles, $rootScope.selectedJob);
+
+                    // Reset selected job to null to initialize nav position
+                    ThResultSetModel.setSelectedJob($rootScope.repoName);
                 }
             }
         };

--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -134,11 +134,12 @@ treeherder.directive('thCloneJobs', [
 
     });
 
-    $rootScope.$on(
-        thEvents.selectJob, function(ev, job){
+    $rootScope.$on(thEvents.selectJob, function(ev, job) {
+          selectJob(job);
+    });
 
-        selectJob(job);
-
+    $rootScope.$on(thEvents.clearJobStyles, function(ev, job) {
+          clearSelectJobStyles();
     });
 
     var selectJob = function(job){
@@ -172,7 +173,7 @@ treeherder.directive('thCloneJobs', [
 
     };
 
-    var clearSelectJobStyles = function(el) {
+    var clearSelectJobStyles = function() {
         var lastJobSelected = ThResultSetModel.getSelectedJob(
             $rootScope.repoName);
 
@@ -197,7 +198,11 @@ treeherder.directive('thCloneJobs', [
     };
 
     var clearJobCb = function(ev, el, job) {
-        clearSelectJobStyles(el);
+        clearSelectJobStyles();
+
+        // Reset selected job to null to initialize nav position
+        ThResultSetModel.setSelectedJob($rootScope.repoName);
+
         $rootScope.$broadcast(thEvents.jobClear, job);
     };
 

--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -202,6 +202,9 @@ treeherder.provider('thEvents', function() {
             // after loading a group of jobs
             jobsLoaded: "jobs-loaded-EVT",
 
+            // after deselecting a job via click outside/esc
+            clearJobStyles: "clear-job-styles-EVT",
+
             // fired when a global filter has changed
             globalFilterChanged: "status-filter-changed-EVT",
 

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -230,7 +230,7 @@
             </a>
           </li>
           <li>
-            <a prevent-default-on-left-click title="close panel" href="#" ng-click="clearJob()">
+            <a prevent-default-on-left-click title="close panel" href="#" ng-click="closeJob()">
               <span class="glyphicon glyphicon-remove"></span>
             </a>
           </li>


### PR DESCRIPTION
This work fixes Bugzilla bug [1074241](https://bugzilla.mozilla.org/show_bug.cgi?id=1074241).

The internal state of the last selected job was being preserved, so when you used the failure navigation keys they continued from where you last were. The Sheriffs want them to always start from the beginning via **n/j**, or start from the end via **k/p** after a job is deselected.

For an example, a ggc build selected at some mid-point in the resultset:

![resetjobmodelpositionscenario](https://cloud.githubusercontent.com/assets/3660661/4649501/227b0808-548b-11e4-978f-533602bd0004.jpg)

In production, if the user clicks away to deselect the job and then presses **n/j** we currently get:

![resetjobmodelbehaviorcurrent](https://cloud.githubusercontent.com/assets/3660661/4649522/6cdfa732-548b-11e4-83ba-055e41e6269c.jpg)

With the fix, we get:

![resetjobmodelbehaviorproposed](https://cloud.githubusercontent.com/assets/3660661/4649532/7e86f0c6-548b-11e4-97c5-321249e01bf4.jpg)

Most of the code changed, involved supporting Esc, which also closes the job panel.

I spoke with @jeads in channel about the correct implementation for this, creating an event listener and a new event for clearing selected job styles. Since they weren't accessible in controllers/main and otherwise would require replicating code there.

The code which resets the position is this bit below. It is used in two locations, in one spot for a click away workflow, and another for the Esc workflow.

`ThResultSetModel.setSelectedJob($rootScope.repoName);`

Everything seems to work fine with this change, closing the job panel manually, via Esc, via click-away, using the pinboard in conjunction with the job panel, looping backwards through the job failures via k/p.

There are other things we'd like to fix, like deselecting a job when the job panel is manually closed, which would also yield this effect, but that is a separate bug and lower priority.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @camd and @wlach for review.
