### PR TITLE
Bug 1075474 - Replace 'structured log' with 'log viewer' in job panel tooltip

### DIFF
--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -16,7 +16,7 @@
 
           <li ng-repeat="job_log_url in job_log_urls">
             <a ng-if="job_log_url.parse_status == 'parsed'"
-               title="Open the structured log in a new window"
+               title="Open the log viewer in a new window"
                target="_blank"
                href="{{ lvUrl }}"
                class="">


### PR DESCRIPTION
This work fixes Bugzilla bug [1075474](https://bugzilla.mozilla.org/show_bug.cgi?id=1075474).

This updates the tooltip wording as requested by Ed.

![updatelogviewertooltip](https://cloud.githubusercontent.com/assets/3660661/4650368/fcfc316c-5492-11e4-927e-3a7ac5364d04.jpg)

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @camd for review and @edmorley for visibility.
