### PR TITLE
Bug 1080408 - Adjust wording for 'Unknown revision ID' page

### DIFF
--- a/webapp/app/js/controllers/jobs.js
+++ b/webapp/app/js/controllers/jobs.js
@@ -39,6 +39,18 @@ treeherder.controller('JobsCtrl', [
             return _.has($scope.searchParams, prop);
         };
 
+        $scope.getSearchParamValue = function(param) {
+            var params = $location.search();
+            var searchParamValue = params[param];
+                // in the event the user manually strips off the search
+                // parameter and its = sign, which would return true
+                if (searchParamValue == true) {
+                    return "";
+                } else {
+                    return searchParamValue;
+                }
+        };
+
         // determine how many resultsets to fetch.  default to 10.
         var count = ThResultSetModel.defaultResultSetCount;
         if ((_.has($scope.searchParams, "startdate") || _.has($scope.searchParams, "fromchange")) &&

--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -48,16 +48,27 @@
     <div th-clone-jobs ></div>
 </div>
 
-<div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending && !isLoadingJobs && locationHasSearchParam('revision')">
-  <span>
+<div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending &&
+              !isLoadingJobs && locationHasSearchParam('revision')"
+              class="result-set">
+  <span ng-init="revision=getSearchParamValue('revision')">
     <div><b>Unknown revision ID.</b></div>
-    <span>This could be because your push has not been processed yet, or the revision ID could be invalid.
-      This page will refresh occasionally, so your push should show up within a few minutes if it does exist.</span>
+    <span>Waiting for a result set matching revision</span>
+      <a href="{{currentRepo.url}}/pushloghtml?changeset={{revision}}"
+         target="_blank"
+         title="open revision {{revision}} on {{currentRepo.url}}">{{revision}}</a>
+    <span class="fa fa-refresh fa-spin"></span>
+    <div>Your push has either not been processed yet or the revision is invalid.
+      This page will refresh automatically, and your jobs will show up within
+      a few minutes of the push if it exists.
+    </div>
   </span>
 </div>
 
-<div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending && !isLoadingJobs &&
-     !locationHasSearchParam('revision') && !locationHasSearchParam('repo') && currentRepo.url">
+<div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending &&
+              !isLoadingJobs && !locationHasSearchParam('revision') &&
+              !locationHasSearchParam('repo') && currentRepo.url"
+              class="result-set">
   <span>
     <div><b>No resultsets found.</b></div>
     <span>No commit information could be loaded for this repository.
@@ -65,8 +76,10 @@
   </span>
 </div>
 
-<div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending && !isLoadingJobs &&
-     !locationHasSearchParam('revision') && locationHasSearchParam('repo') && !currentRepo.url">
+<div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending &&
+              !isLoadingJobs && !locationHasSearchParam('revision') &&
+              locationHasSearchParam('repo') && !currentRepo.url"
+              class="result-set">
   <span>
     <div><b>Unknown repository.</b></div>
     <span>This repository is either unknown to Treeherder or it doesn't exist.


### PR DESCRIPTION
This work fixes Bugzilla bug [1080408](https://bugzilla.mozilla.org/show_bug.cgi?id=1080408).

This updates the unknown revision ID message, as requested by Ed.

Here is a screen grab of the fix (minus the unknown revision which would precede the spinner).

![unknownrevidmsg](https://cloud.githubusercontent.com/assets/3660661/4652746/9e8f08f6-54a7-11e4-8532-b0cc166f6440.jpg)

I added a div to open up a full line for the revision, for clarity. A couple of minor word tweaks, and I tidied up the code block wrap. In doing so it seemed to make sense to make the adjacent code blocks for _No resultset_ and _Unknown repository_ to the same indent style for `ng-show`. let me know if I've missed something in that indent style. It seems easier to read anyway.

I left the text as 2-space indent to its parent tag, the same as the others.

The spinner is supported on Firefox only, but I had a look at the behavior on Chrome and it seems fine.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @camd for review and @edmorley for visibility.
