### PR TITLE
Bug 1074972 - Keep the job panel open on a classification save

### DIFF
--- a/webapp/app/plugins/pinboard.js
+++ b/webapp/app/plugins/pinboard.js
@@ -52,7 +52,6 @@ treeherder.controller('PinboardCtrl', [
                 var classification = $scope.classification;
                 thPinboard.save(classification);
                 $scope.classification = thPinboard.createNewClassification();
-                $rootScope.selectedJob = null;
             } else {
                 thNotify.send("must be logged in to classify jobs", "danger");
             }


### PR DESCRIPTION
This work fixes Bugzilla bug [1074972](https://bugzilla.mozilla.org/show_bug.cgi?id=1074972).

This little change keeps the job panel and pinboard open when the user is saving a classification.

Here is the appearance of the job panel with the fix, pre-save and post-save:

![classificationsavepresave](https://cloud.githubusercontent.com/assets/3660661/4669475/7b3ac5d0-556e-11e4-83bb-007d191c5a20.jpg)

![classificationsavepostsave](https://cloud.githubusercontent.com/assets/3660661/4669480/816a8fe4-556e-11e4-8089-2e335dee849f.jpg)

I spent a bit of the afternoon trying to get a local vagrant running to log in and do a save. Unfortunately there appears to be [no vagrant x86 support](https://bugzilla.mozilla.org/show_bug.cgi?id=1074972#c6) for windows. So I bypassed the `$scope.user.loggedin` during local testing to confirm the panel behavior.

This solves the 'flickering' that Ed alluded to in the bug. It should be noted the UI will shift left and right as the right hand pinboard UI is hidden/exposed with each save, but that seems minor relative to the original issue.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @camd for review and @edmorley for visibility.
