### PR TITLE
Bug 1083780 - Update help links

### DIFF
--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -13,10 +13,17 @@
 <div class="panel-heading">
     <h1>Treeherder Help</h1>
 
-    <h5>More documentation available at <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder">
-        https://wiki.mozilla.org/Auto-tools/Projects/Treeherder
-    </a></h5>
-    Want to contribute? <a href="https://github.com/mozilla/treeherder-ui" target="_blank">Source code</a> / <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder#Hacking" target="_blank">Hacking</a> / <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree+Management&component=Treeherder" target="_blank">Bug report</a>
+    <h5>
+      Want to contribute?
+      <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree+Management&component=Treeherder" target="_blank">File a bug</a> /
+      <a href="https://github.com/mozilla/treeherder-ui" target="_blank">UI source</a> /
+      <a href="https://github.com/mozilla/treeherder-service" target="_blank">Backend source</a> /
+      <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder#Contributing" target="_blank">Contributing</a>
+    </h5>
+    For anything else visit our
+    <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder" target="_blank">Project Wiki</a>
+    or ask us on IRC in
+    <a href="irc://irc.mozilla.org/treeherder">#treeherder</a>
 </div>
 <div class="panel-body">
 <div class="row">


### PR DESCRIPTION
This fixes Bugzilla bug [1083780](https://bugzilla.mozilla.org/show_bug.cgi?id=1083780).

Per Ed's suggestion I've updated the links at the top of the help page. In it I've:
- put them all inline which saves space
- referenced the Wiki as the first of those links
- added a 'Source and Docs' link (referenced anchor points to all 3 mozilla hosted repos)

I figure if we ever consolidate the treeherder-[service,ui,client] repos, we might only need to update the Wiki, and not necessarily this Help page.

Here's a before and after:

![helplinkscurrent](https://cloud.githubusercontent.com/assets/3660661/4689982/1e89617a-56d6-11e4-80dd-225463965399.jpg)

![helplinksproposed](https://cloud.githubusercontent.com/assets/3660661/4689983/23359860-56d6-11e4-9799-dc973c8eab34.jpg)

Maybe there are more we could add? If so let me know and I'll include them.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @edmorley for review.
