### PR TITLE
Bug 1076980 - Provide landing text and related UI for log viewer

### DIFF
--- a/webapp/app/css/logviewer.css
+++ b/webapp/app/css/logviewer.css
@@ -105,24 +105,28 @@ body {
     margin: 0em 0.6em 0em 0em;
 }
 
-.lv-log-loading {
+.lv-log-msg {
     position: fixed;
-    top: 284px;
-    left: 50%;
-    background: #FFF;
-    color: #585858;
-    width: 150px;
-    margin-left: -75px;
-    font-size: 2em;
+    top: 530px;
+    left: 3%;
+    font-weight: bold;
+}
+
+.lv-log-msg-step {
+    padding: 2px 5px;
+    background: #fff;
+    border: solid #f0ad4e;
+    border-width: 4px 2px 2px;
+    border-radius: 2px;
+}
+
+.lv-log-overlay {
+    padding: 6px;
+    border: 2px solid #4cae4c;
+    border-radius: 3px;
+    background: #fff;
 }
 
 .lv-log-error {
-    position: fixed;
-    top: 284px;
-    left: 50%;
-    background: #FFF;
-    color: #585858;
-    width: 293px;
-    margin-left: -75px;
-    font-size: 2em;
+    border: 2px solid #ff0000;
 }

--- a/webapp/app/partials/logviewer/lvLogLines.html
+++ b/webapp/app/partials/logviewer/lvLogLines.html
@@ -1,7 +1,12 @@
-<div class="lv-log-loading"
+<div class="lv-log-msg"
+     ng-if="!loading && !logError && displayedLogLines.length == 0">
+     Click a <span class="lv-log-msg-step">log step</span> above to view
+</div>
+
+<div class="lv-log-msg lv-log-overlay"
      ng-if="loading"> Loading... </div>
 
-<div class="lv-log-error"
+<div class="lv-log-msg lv-log-overlay lv-log-error"
       ng-if="logError"> Log could not be found </div>
 
 <div ng-repeat="lv_line in displayedLogLines"


### PR DESCRIPTION
This work fixes Bugzilla bug [1076980](https://bugzilla.mozilla.org/show_bug.cgi?id=1076980).

The current log viewer contains no instructions for viewing the log on initial landing. This fix makes it obvious how to load the log contents. In the change we also move the new landing message slightly downwards and aligned left, so it doesn't overlay the upper elements at narrow browser widths. We also do the same for the loading and error messages.

So here is what we had before, which was nothing:

![logstepbefore](https://cloud.githubusercontent.com/assets/3660661/4692090/c1266800-574a-11e4-85c1-1176e89788bb.jpg)

Here is what we have after the fix:

![logsteplandingproposed](https://cloud.githubusercontent.com/assets/3660661/4692097/0f4fa050-574b-11e4-8d85-0d4367d89c9e.jpg)

Here is what the fix looks like at narrow browser widths:

![logsteplandingproposednarro](https://cloud.githubusercontent.com/assets/3660661/4692093/dc430058-574a-11e4-8cec-7f3b23737d60.jpg)

Similarly we now place the loading and error messages in the same location, so during the transition from idle to the loading state, the user sees the message clearly, and it doesn't jump to some other part of the page.

![logsteploadingproposed](https://cloud.githubusercontent.com/assets/3660661/4692100/14b5f6a2-574b-11e4-9363-4fbcbcda5db7.jpg)

I've removed the duplicated css properties (position, etc), and centralized them in `lv-log-msg`. The other classes are subsets which are shared as applicable across each of the elements.

Maybe down the road, we might consider transitioning the loading message to a spinner but for now it keeps it consistent with the error message (not pictured). That element's border is drawn red on an error.

I've tested it in a variety of workflows, loading and re-loading, turning on and off successful steps, successful step navigation, and everything seems to be working correctly. I haven't encountered a scenario where the `displayedLogLines` test accidentally draws it over stale loaded log content.

If you guys can let me know if it looks correct on OSX that would be cool, or we can check it out on dev.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **37.0.2062.124 m**

Adding @edmorley for feedback and @wlach for review.

Adding @jmaher for visibility.
