### PR TITLE
Bug 1084107 - Make consistent width pinboard jobs for faster closure

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -805,9 +805,10 @@ ul.failure-summary-list li .btn-xs {
     width: 70px;
 }
 
-
 .pinned-job {
-    padding: 1px 7px;
+    margin-bottom: 2px;
+    padding: 1px 2px;
+    width: 3.5em;
 }
 
 .pinned-job-close-btn {


### PR DESCRIPTION
This fixes Bugzilla bug [1084107](https://bugzilla.mozilla.org/show_bug.cgi?id=1084107).

Nothing big here, we just enforce a consistent width for all pinned jobs, so they look tidy and can be closed rapidly (one by one) without having to move the mouse. Since with the change the mouse down target doesn't move.

While I was there I added a bit of white space between the rows by putting a margin on each of the job+close-icon element pairs.

Here's the before and after:

![pinjobswidthcurrent](https://cloud.githubusercontent.com/assets/3660661/4720769/7e3d0996-5933-11e4-89f5-c2800ae1f551.jpg)

![pinjobswidthproposed](https://cloud.githubusercontent.com/assets/3660661/4720771/837dd854-5933-11e4-89d3-2907867d7819.jpg)

There is an edge case for longer job names, where greater than 5 characters will be truncated when selected.

![pinjobswidthedgecase](https://cloud.githubusercontent.com/assets/3660661/4720916/b51f3a1e-5934-11e4-89ba-3b277b07fa6e.jpg)

I checked in channel and Ed and Wes are ok with that. It should be noted we consume more space with this change, but that is acknowledged also.

Everything appears fine on Windows on Firefox and Chrome. If someone could check on OSX that would be cool, or we can have a look on dev when landed.

Tested on Windows:
FF Release **32.0.3**
Chrome Latest Release **38.0.2125.104 m**

Adding @wlach for review.
