### PR TITLE
Bug 1084116 - Remove nav on logo and jobs button to preserve user state

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -37,9 +37,16 @@ body {
 }
 
 .navbar-brand {
+    margin-bottom: 0px;
     line-height: 2px;
     height: 32px;
+    font-weight: normal;
 }
+
+.navbar-inverse .navbar-brand:hover {
+    color: #777;
+}
+
 .navbar .dropdown-menu {
     max-height: 600px;
     overflow: auto;

--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -210,7 +210,7 @@ treeherder.controller('MainCtrl', [
         // others, such as filtering, just re-filter without reload.
         $rootScope.$on('$locationChangeSuccess', function(ev, newUrl, oldUrl) {
 
-            // used to test for display of watched-repo-navbar and jobs menu
+            // used to test for display of watched-repo-navbar
             $rootScope.locationPath = $location.path().replace('/', '');
 
             // used to avoid bad urls when the app redirects internally

--- a/webapp/app/partials/main/thGlobalTopNavPanel.html
+++ b/webapp/app/partials/main/thGlobalTopNavPanel.html
@@ -1,18 +1,9 @@
 <nav class="navbar navbar-inverse">
     <div class="navbar-header">
-        <a class="navbar-brand" href="#">Treeherder</a>
+        <label class="navbar-brand">Treeherder</label>
     </div>
     <div class="navbar-collapse collapse th-global-navbar">
         <!-- nav begin -->
-        <span class="nav navbar-nav">
-            <!-- 'timeline' and 'machines' currently removed from viewOption -->
-            <span class="btn-group"
-                  ng-repeat="viewOption in ['jobs']">
-                <a class="btn btn-view-nav"
-                   ng-class="{'active': (locationPath===viewOption)}"
-                   href="#/{{viewOption}}">{{viewOption}}</a>
-            </span>
-        </span>
         <span class="navbar-right">
             <span ng-show="user.is_staff">
                 <span class="btn btn-view-nav"


### PR DESCRIPTION
This fixes Bugzillla bug [1084116](https://bugzilla.mozilla.org/show_bug.cgi?id=1084116).

In it, we remove the link off the main Treeherder logo, and remove the remaining menu (jobs), since the behavior of both are destructive - unless the user happens to be on mozilla-central with no filters applied.

Like _timelines_ and _machines_ removed in https://github.com/mozilla/treeherder-ui/pull/94, _jobs_ is not presently being used.

Here is the before and after:

![thbrandnavbarcurrent](https://cloud.githubusercontent.com/assets/3660661/4764869/27c52e4c-5b2f-11e4-97ee-d57ce601d96d.jpg)

![thbrandnavbarproposed](https://cloud.githubusercontent.com/assets/3660661/4764873/2b9ceb7c-5b2f-11e4-9ac5-297fecd1402c.jpg)

Tested on Windows:
FF Release **33.0**
Chrome Latest Release **38.0.2125.104 m**

Adding @wlach for review and @edmorley for visibility.
