### PR TITLE
Bug 1062827 - Change job result names for more clarity

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -856,9 +856,9 @@ ul.failure-summary-list li .btn-xs {
 }
 
 .result-status-shading-success {background-color: rgba(2, 131, 44, 0.24);}
-.result-status-shading-testfailed {background-color: rgba(221, 102, 2, 0.25);}
-.result-status-shading-busted {background-color: rgba(144, 0, 0, 0.25);}
-.result-status-shading-exception {background-color: rgba(61, 2, 85, 0.25);}
+.result-status-shading-warnings {background-color: rgba(221, 102, 2, 0.25);}
+.result-status-shading-failure {background-color: rgba(144, 0, 0, 0.25);}
+.result-status-shading-infra-failure {background-color: rgba(61, 2, 85, 0.25);}
 .result-status-shading-retry {background-color: rgba(38, 63, 195, 0.25);}
 .result-status-shading-usercancel {background-color: rgba(250, 115, 172, 0.25);}
 .result-status-shading-pending {background-color: rgba(160, 160, 160, 0.2);}
@@ -886,10 +886,10 @@ ul.failure-summary-list li .btn-xs {
 .result-status-count-retry {
     width: 52px;
 }
-.result-status-count-busted {
+.result-status-count-failure {
     width: 70px;
 }
-.result-status-count-testfailed {
+.result-status-count-warnings {
     width: 61px;
 }
 .result-status-count-unknown {
@@ -898,7 +898,7 @@ ul.failure-summary-list li .btn-xs {
 .result-status-count-usercancel {
     width: 75px;
 }
-.result-status-count-exception {
+.result-status-count-infra-failure {
     width: 85px;
 }
 .result-status-count-running {

--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -66,22 +66,22 @@
                     <td>Green, success</td>
                   </tr>
                   <tr>
-                    <th class="testfailed">
+                    <th class="warnings">
                       <button class="btn btn-orange help-btn help-btn-orange">Th</button>
                     </th>
-                    <td>Orange, tests failed</td>
+                    <td>Orange, warnings</td>
                   </tr>
                   <tr>
-                    <th class="exception">
+                    <th class="infra-failure">
                       <button class="btn btn-purple help-btn help-btn-purple">Th</button>
                     </th>
-                    <td>Purple, infrastructure exception</td>
+                    <td>Purple, infrastructure failure</td>
                   </tr>
                   <tr>
-                    <th class="busted">
+                    <th class="failed">
                       <button class="btn btn-red help-btn help-btn-red">Th</button>
                     </th>
-                    <td>Red, build error</td>
+                    <td>Red, failure</td>
                   </tr>
                   <tr>
                     <th class="retry">

--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -15,9 +15,9 @@ treeherder.directive('thCloneJobs', [
     var $log = new ThLog("thCloneJobs");
 
     var classificationRequired = {
-        "busted":1,
-        "exception":1,
-        "testfailed":1
+        "failed":1,
+        "infra-failure":1,
+        "warnings":1
         };
 
     // CSS classes

--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -12,15 +12,15 @@ treeherder.provider('thServiceDomain', function() {
 
 treeherder.provider('thResultStatusList', function() {
     var all = function() {
-        return ['success', 'testfailed', 'busted', 'exception', 'retry', 'usercancel', 'running', 'pending', 'coalesced'];
+        return ['success', 'warnings', 'failed', 'infra-failure', 'retry', 'usercancel', 'running', 'pending', 'coalesced'];
     };
 
     var counts = function() {
-        return ['success', 'testfailed', 'busted', 'exception', 'retry', 'running', 'pending', 'coalesced'];
+        return ['success', 'warnings', 'failed', 'infra-failure', 'retry', 'running', 'pending', 'coalesced'];
     };
 
     var defaultFilters = function() {
-        return ['success', 'testfailed', 'busted', 'exception', 'retry', 'usercancel', 'running', 'pending'];
+        return ['success', 'warnings', 'failed', 'infra-failure', 'retry', 'usercancel', 'running', 'pending'];
     };
 
     this.$get = function() {
@@ -50,9 +50,9 @@ treeherder.provider('thResultStatusObject', function() {
     var getResultStatusObject = function(){
         return {
             'success':0,
-            'testfailed':0,
-            'busted':0,
-            'exception':0,
+            'warnings':0,
+            'failed':0,
+            'infra-failure':0,
             'retry':0,
             'running':0,
             'pending':0,
@@ -78,28 +78,28 @@ treeherder.provider('thResultStatusInfo', function() {
             };
 
             switch (resultState) {
-                case "busted":
+                case "failed":
                     resultStatusInfo = {
                         severity: 1,
                         btnClass: "btn-red",
                         jobButtonIcon: "glyphicon glyphicon-fire",
-                        countText: "busted"
+                        countText: "failed"
                     };
                     break;
-                case "exception":
+                case "infra-failure":
                     resultStatusInfo = {
                         severity: 2,
                         btnClass: "btn-purple",
                         jobButtonIcon: "glyphicon glyphicon-fire",
-                        countText: "exception"
+                        countText: "infra-failure"
                     };
                     break;
-                case "testfailed":
+                case "warnings":
                     resultStatusInfo = {
                         severity: 3,
                         btnClass: "btn-orange",
                         jobButtonIcon: "glyphicon glyphicon-warning-sign",
-                        countText: "failed"
+                        countText: "warnings"
                     };
                     break;
                 case "unknown":

--- a/webapp/app/js/services/jobfilters.js
+++ b/webapp/app/js/services/jobfilters.js
@@ -128,7 +128,7 @@ treeherder.factory('thJobFilters', [
     //            resultset_id1: {
     //                counts: {
     //                    "success": 4,
-    //                    "testfailed": 6,
+    //                    "warnings": 6,
     //                    "total": 10
     //                    ...
     //                },

--- a/webapp/app/js/values.js
+++ b/webapp/app/js/values.js
@@ -34,7 +34,7 @@ treeherder.value("thPlatformNameMap", {
     "other": "Other"
 });
 
-treeherder.value("thFailureResults", ["testfailed", "busted", "exception"]);
+treeherder.value("thFailureResults", ["warnings", "failed", "infra-failure"]);
 
 treeherder.value("thFavicons", {
     "closed": "img/tree_closed.png",

--- a/webapp/test/unit/models/resultsets.tests.js
+++ b/webapp/test/unit/models/resultsets.tests.js
@@ -99,14 +99,14 @@ describe('ThResultSetModel', function(){
         var rs =  {
             "repository_id": 4,
             "job_counts": {
-                "exception": 0,
+                "infra-failure": 0,
                 "retry": 0,
                 "success": 2,
                 "unknown": 0,
                 "usercancel": 0,
                 "running": 0,
-                "busted": 0,
-                "testfailed": 0,
+                "failed": 0,
+                "warnings": 0,
                 "total": 4,
                 "pending": 0
             },


### PR DESCRIPTION
This is the UI side change to fix Bugzilla bug [1062827](https://bugzilla.mozilla.org/show_bug.cgi?id=1062827).

In it we've agreed on these three result name changes:

* success
* testfailed -> **warnings**
* busted -> **failed**
* skipped
* exception -> **infra-failure**
* retry
* usercancel

For ease of grokking I still wonder if 'intrastructure-failure' might fit in the UI?

There is parallel work still to be done in treeherder-service and DB changes required for this commit to be landed. If I can get a local service running, I may investigate the server side. Otherwise one of the folks with full powers and access may need to do that part :)

But hopefully this saves a few minutes for you guys poking around on the UI side.

Running in its current state with no back end changes shuts off all the filter counts, to me that is expected since there are no matches.

(not fully) tested on Windows:
FF Release **33.0**
Chrome Latest Release **38.0.2125.104 m**

Adding @edmorley and @maurodoglio for review and general expertise.