### PR TITLE
Bug 1075473 - Hide the cancel all button for all repos that don't have 'try' in the repo name

### DIFF
--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -34,6 +34,7 @@
         <span class="btn btn-default btn-sm btn-resultset"
               tabindex="0" role="button"
               title="cancel all jobs in this resultset"
+              ng-show="currentRepo.repository_group.name == 'try'"
               ng-click="cancelAllJobs(resultset.revision)">
           <span class="glyphicon glyphicon-minus-sign"></span>
         </span>


### PR DESCRIPTION
I've clicked the cancel all jobs on this push button far too many times while trying to get to the mc-merge or self-serve buttons in the menu to the left of it.

Bug 1074858 suggested to make it prompt or something, and bug 1075473 suggests to let is_staff users still click "cancel all" for all repos, but there's been no activity in those bugs to do anything to make accidental clicks less destructive.

Until that happens, lets just hide the cancel all buttons on non-try repos to save us all from ourselves?
