### PR TITLE
Bug 1087314 - Preserve visible UI whitespace in grunt builds

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,6 +131,7 @@ module.exports = function(grunt) {
                     htmlmin: {
                         collapseBooleanAttributes:      true,
                         collapseWhitespace:             true,
+                        conservativeCollapse:           true,
                         removeAttributeQuotes:          true,
                         removeComments:                 true,
                         removeEmptyAttributes:          true,


### PR DESCRIPTION
This work fixes Bugzilla bug [1087314](https://bugzilla.mozilla.org/show_bug.cgi?id=1087314).

In it we prevent grunt minification from stripping trailing white space in the markup, observed in `result-set-title-left` in the "-".

Here's the before and after:

![resultsettitleleftcurrent](https://cloud.githubusercontent.com/assets/3660661/4780749/a30f1fe8-5c76-11e4-8fec-331933af74cd.jpg)

![resultsettitleleftproposed](https://cloud.githubusercontent.com/assets/3660661/4780750/a551f2ee-5c76-11e4-8162-97541a0b10f3.jpg)

I chose to make the change for only `treeherder:` and not `logviewer:`, in the Gruntfile, since logviewer didn't contain any known issues.

It introduces new single character white spaces between other markup tags, but diffing the before and after minified index files it seems benign. I have attached those with the bug for reference.

nb. I noticed my filters lost their white space separation in my local grunt dist, but I checked with a rebuild of master and it was the same (so I think that is just some oddity of viewing the index locally, not through a server).

Tested on Windows:
FF Release **33.0**
Chrome Latest Release **38.0.2125.104 m**

Adding @camd for review and @edmorley for visibility.
