### PR TITLE
Bug 1089835 - Improve readability of Builds/Tests/Shortcuts in Help

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1531,6 +1531,27 @@ fieldset[disabled] .btn-repo.active {
     padding: 5px;
 }
 
+.panel-spacing table {
+    width: 100%;
+}
+
+.panel-spacing tr th:first-child {
+    padding-right: 2em;
+}
+
+.panel-spacing tr:nth-child(even) {
+    background-color: #f8f8f8;
+}
+
+.panel-spacing table tr {
+    border-bottom: 1px dotted lightgrey;
+}
+
+/* override th bold */
+#shortcuts tr th span {
+    font-weight: normal;
+}
+
 .help-btn {
     margin: 2px;
     border: 2px solid;

--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -110,25 +110,21 @@
     <div class="col-xs-6">
         <div class="panel panel-default">
             <div class="panel-heading"><h3>Keyboard shortcuts</h3></div>
-            <div class="panel-body">
+            <div class="panel-body panel-spacing">
                 <table id="shortcuts">
                     <tr><th>esc</th>
                     <td>Close all open job or filter panels</td></tr>
                     <tr><th>spacebar</th>
                     <td>Add selected job to the pin board</td></tr>
-                    <tr><th>j</th>
+                    <tr><th>j<span> or </span>n</th>
                     <td>Highlight next unstarred failure</td></tr>
-                    <tr><th>k</th>
-                    <td>Highlight previous unstarred failure</td></tr>
-                    <tr><th>n</th>
-                    <td>Highlight next unstarred failure</td></tr>
-                    <tr><th>p</th>
+                    <tr><th>k<span> or </span>p</th>
                     <td>Highlight previous unstarred failure</td></tr>
                     <tr><th>u</th>
                     <td>Show only unstarred failures</td></tr>
                     <tr><th>i</th>
                     <td>Toggle in-progress (running/pending) jobs</td></tr>
-                    <tr><th>Ctrl/Cmd click</th>
+                    <tr><th>ctrl/cmd click</th>
                     <td>Add job to the pinboard</td></tr>
                 </table>
             </div>
@@ -141,7 +137,7 @@
 <div class="col-xs-6">
     <div class="panel panel-default">
         <div class="panel-heading"><h3>Builds</h3></div>
-        <div class="panel-body">
+        <div class="panel-body panel-spacing">
             <table id="legend-builds">
                 <tr><th>B</th>
                 <td>Build</td></tr>
@@ -268,7 +264,7 @@
 <div class="col-xs-6">
     <div class="panel panel-default">
         <div class="panel-heading"><h3>Tests</h3></div>
-        <div class="panel-body">
+        <div class="panel-body panel-spacing">
             <table id="legend-tests">
                 <tr><th>M</th>
                 <td>Mochitest</td></tr>


### PR DESCRIPTION
This work fixes Bugzilla bug [1089835](https://bugzilla.mozilla.org/show_bug.cgi?id=1089835).

Nothing major, but I made some minor readability tweaks for the Help page. In it we provide some white space between the header item and its description, for the three text-based tables. While I was there I adopted the alternate row coloring in Treeherder itself, to help readability.

Here's the before:

![helpcurrent](https://cloud.githubusercontent.com/assets/3660661/4799703/be848a84-5e1e-11e4-8f50-6ff6175d7eaa.jpg)

And here is the after:

![helpproposed](https://cloud.githubusercontent.com/assets/3660661/4799709/c612e304-5e1e-11e4-8518-1693c130159d.jpg)

Similarly the shortcuts gets the same treatment, and the next/previous are unified on to a single line each. It was actually my initial goal and I got carried away :)

![helpproposedshortcuts](https://cloud.githubusercontent.com/assets/3660661/4799565/7a1c9a86-5e1d-11e4-888e-b4cb318a5ed9.jpg)

Tested on Windows:
FF Release **33.0**
Chrome Latest Release **38.0.2125.104 m**

Adding @wlach for review and @edmorley for visibility.
