### PR TITLE
Bug 1074858 - Make the cancel all jobs button prompt before doing anything

### DIFF
--- a/webapp/app/js/controllers/jobs.js
+++ b/webapp/app/js/controllers/jobs.js
@@ -218,6 +218,9 @@ treeherder.controller('ResultSetCtrl', [
 
 
         $scope.cancelAllJobs = function(revision) {
+            if (!window.confirm('This will cancel all pending and running jobs for revision ' + revision + '!\n\nAre you sure?')) {
+                return;
+            }
             thBuildApi.cancelAll($scope.repoName, revision).then(function() {
                 thResultSets.cancelAll($scope.resultset.id, $scope.repoName);
             });


### PR DESCRIPTION
Adds a prompt when you click the "cancel all jobs" button before proceeding to cancel all jobs.
