### PR TITLE
Bug 1075473 - Allow is_staff users to see the cancell all button

### DIFF
--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -34,7 +34,7 @@
         <span class="btn btn-default btn-sm btn-resultset"
               tabindex="0" role="button"
               title="cancel all jobs in this resultset"
-              ng-show="currentRepo.repository_group.name == 'try'"
+              ng-show="currentRepo.repository_group.name == 'try' || user.is_staff"
               ng-click="cancelAllJobs(resultset.revision)">
           <span class="glyphicon glyphicon-minus-sign"></span>
         </span>


### PR DESCRIPTION
This should show the cancel all jobs button on all trees if the user is logged in with an is_staff account, and show it for everyone on try group trees. 

I couldn't figure out how to conditionally change the appearance of the button for non-staff users on non-try trees. I wanted to do something like set "cursor: 'not-allowed'" and reject the click's action for that case, but I'm not sure I understand how ng-class works, or if there's some other way to do that.
