### PR TITLE
No bug - Fix stray tag in global top navbar

### DIFF
--- a/webapp/app/partials/main/thGlobalTopNavPanel.html
+++ b/webapp/app/partials/main/thGlobalTopNavPanel.html
@@ -28,8 +28,7 @@
 
                     <!-- Repo Menu -->
                     <ul class="dropdown-menu repo-dropdown-menu" role="menu" aria-labelledby="repoLabel">
-                        <span ng-repeat="(group_order, group) in groupedRepos()"
-                              >
+                        <span ng-repeat="(group_order, group) in groupedRepos()">
                             <li role="presentation" class="divider" ng-hide="$first"></li>
                             <li role="presentation" class="dropdown-header">{{group.name}}</li>
                             <th-repo-menu-item ng-repeat="repo in group.repos | orderBy : 'name'" ></th-repo-menu-item>


### PR DESCRIPTION
Nothing exciting, I happened across this stray tag in the global nav bar during other work. I had a quick look around to see if there were more but I didn't see any.

Perhaps some occasional regex will catch these cases, I'll see if I can check from time to time.

Tested on Windows:
FF Release **33.0**
Chrome Latest Release **38.0.2125.111 m**

Adding @camd for review.
