### PR TITLE
Bug 1090689 - Add MPL2.0 headers to the repo

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 module.exports = function(grunt) {

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+#
 # Makefile for Sphinx documentation
 #
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+#
 # -*- coding: utf-8 -*-
 #
 # treeherder documentation build configuration file, created by

--- a/webapp/app/css/logviewer.css
+++ b/webapp/app/css/logviewer.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 body {
     position: fixed;
     top: 0;

--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 html, body {
     height: 100%;
     overflow: hidden;

--- a/webapp/app/js/app.js
+++ b/webapp/app/js/app.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 var treeherder = angular.module('treeherder',

--- a/webapp/app/js/config/sample.local.conf.js
+++ b/webapp/app/js/config/sample.local.conf.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 /* window.thServiceDomain holds a reference to a backend service

--- a/webapp/app/js/controllers/filters.js
+++ b/webapp/app/js/controllers/filters.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 treeherder.controller('FilterPanelCtrl', [

--- a/webapp/app/js/controllers/jobs.js
+++ b/webapp/app/js/controllers/jobs.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 treeherder.controller('JobsCtrl', [

--- a/webapp/app/js/controllers/logviewer.js
+++ b/webapp/app/js/controllers/logviewer.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 logViewer.controller('LogviewerCtrl', [

--- a/webapp/app/js/controllers/machines.js
+++ b/webapp/app/js/controllers/machines.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 treeherder.controller('MachinesCtrl', [

--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 treeherder.controller('MainCtrl', [

--- a/webapp/app/js/controllers/repository.js
+++ b/webapp/app/js/controllers/repository.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 treeherder.controller('RepositoryMenuCtrl', [

--- a/webapp/app/js/controllers/settings.js
+++ b/webapp/app/js/controllers/settings.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 treeherder.controller('SettingsCtrl', [
     '$scope', '$log',

--- a/webapp/app/js/controllers/sheriff.js
+++ b/webapp/app/js/controllers/sheriff.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 treeherder.controller('SheriffCtrl', [
     '$scope', '$rootScope', 'ThBuildPlatformModel', 'ThJobTypeModel',

--- a/webapp/app/js/controllers/timeline.js
+++ b/webapp/app/js/controllers/timeline.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 treeherder.controller('TimelineCtrl', [

--- a/webapp/app/js/directives/bottom_nav_panel.js
+++ b/webapp/app/js/directives/bottom_nav_panel.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 

--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 /* Directives */

--- a/webapp/app/js/directives/log_viewer_infinite_scroll.js
+++ b/webapp/app/js/directives/log_viewer_infinite_scroll.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.directive('lvInfiniteScroll', ['$timeout', '$parse', function ($timeout, $parse) {

--- a/webapp/app/js/directives/log_viewer_lines.js
+++ b/webapp/app/js/directives/log_viewer_lines.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.directive('lvLogLines', ['$timeout', '$parse', function ($timeout) {

--- a/webapp/app/js/directives/log_viewer_steps.js
+++ b/webapp/app/js/directives/log_viewer_steps.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.directive('lvLogSteps', ['$timeout', '$q', function ($timeout, $q) {

--- a/webapp/app/js/directives/main.js
+++ b/webapp/app/js/directives/main.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.directive('ngRightClick', [

--- a/webapp/app/js/directives/persona.js
+++ b/webapp/app/js/directives/persona.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.directive('personaButtons', [

--- a/webapp/app/js/directives/resultsets.js
+++ b/webapp/app/js/directives/resultsets.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.directive('thActionButton', [

--- a/webapp/app/js/directives/top_nav_bar.js
+++ b/webapp/app/js/directives/top_nav_bar.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.directive('thFilterCheckbox', [

--- a/webapp/app/js/filters.js
+++ b/webapp/app/js/filters.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 /* Filters */

--- a/webapp/app/js/models/bug_job_map.js
+++ b/webapp/app/js/models/bug_job_map.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('ThBugJobMapModel', [

--- a/webapp/app/js/models/build_platform.js
+++ b/webapp/app/js/models/build_platform.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('ThBuildPlatformModel', [

--- a/webapp/app/js/models/classification.js
+++ b/webapp/app/js/models/classification.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('ThJobClassificationModel', [

--- a/webapp/app/js/models/exclusion_profile.js
+++ b/webapp/app/js/models/exclusion_profile.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('ThExclusionProfileModel', [

--- a/webapp/app/js/models/job.js
+++ b/webapp/app/js/models/job.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('ThJobModel', [

--- a/webapp/app/js/models/job_artifact.js
+++ b/webapp/app/js/models/job_artifact.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('ThJobArtifactModel', [

--- a/webapp/app/js/models/job_exclusion.js
+++ b/webapp/app/js/models/job_exclusion.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('ThJobExclusionModel', [

--- a/webapp/app/js/models/job_log_url.js
+++ b/webapp/app/js/models/job_log_url.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('ThJobLogUrlModel', [

--- a/webapp/app/js/models/job_type.js
+++ b/webapp/app/js/models/job_type.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('ThJobTypeModel', [

--- a/webapp/app/js/models/log_slice.js
+++ b/webapp/app/js/models/log_slice.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('ThLogSliceModel', [

--- a/webapp/app/js/models/option.js
+++ b/webapp/app/js/models/option.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('ThOptionModel', [

--- a/webapp/app/js/models/repository.js
+++ b/webapp/app/js/models/repository.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('ThRepositoryModel', [

--- a/webapp/app/js/models/resultsets.js
+++ b/webapp/app/js/models/resultsets.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('ThResultSetModel', [

--- a/webapp/app/js/models/user.js
+++ b/webapp/app/js/models/user.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('ThUserModel', [

--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 treeherder.provider('thServiceDomain', function() {

--- a/webapp/app/js/services/buildapi.js
+++ b/webapp/app/js/services/buildapi.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('thBuildApi', [

--- a/webapp/app/js/services/classifications.js
+++ b/webapp/app/js/services/classifications.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('thClassificationTypes', [

--- a/webapp/app/js/services/jobfilters.js
+++ b/webapp/app/js/services/jobfilters.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 /**

--- a/webapp/app/js/services/log.js
+++ b/webapp/app/js/services/log.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('ThLog', [

--- a/webapp/app/js/services/main.js
+++ b/webapp/app/js/services/main.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 /* Services */

--- a/webapp/app/js/services/pinboard.js
+++ b/webapp/app/js/services/pinboard.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('thPinboard', [

--- a/webapp/app/js/services/resultsets.js
+++ b/webapp/app/js/services/resultsets.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 

--- a/webapp/app/js/services/treestatus.js
+++ b/webapp/app/js/services/treestatus.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('treeStatus', [

--- a/webapp/app/js/values.js
+++ b/webapp/app/js/values.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.value("thPlatformNameMap", {

--- a/webapp/app/plugins/annotations/controller.js
+++ b/webapp/app/plugins/annotations/controller.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 treeherder.controller('AnnotationsPluginCtrl', [

--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 treeherder.controller('PluginCtrl', [

--- a/webapp/app/plugins/failure_summary/controller.js
+++ b/webapp/app/plugins/failure_summary/controller.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 treeherder.controller('BugsPluginCtrl', [

--- a/webapp/app/plugins/pinboard.js
+++ b/webapp/app/plugins/pinboard.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 treeherder.controller('PinboardCtrl', [

--- a/webapp/app/plugins/similar_jobs/controller.js
+++ b/webapp/app/plugins/similar_jobs/controller.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 treeherder.controller('SimilarJobsPluginCtrl', [

--- a/webapp/app/plugins/tabs.js
+++ b/webapp/app/plugins/tabs.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 treeherder.factory('thTabs', [

--- a/webapp/config/karma-e2e.conf.js
+++ b/webapp/config/karma-e2e.conf.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 module.exports = function (config) {
     config.set({
         frameworks: ['ng-scenario'],

--- a/webapp/config/karma.conf.js
+++ b/webapp/config/karma.conf.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 // NOTE:  IF TESTS WON'T RUN

--- a/webapp/test/e2e/scenarios.js
+++ b/webapp/test/e2e/scenarios.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 /* http://docs.angularjs.org/guide/dev_guide.e2e-testing */

--- a/webapp/test/unit/controllers/jobs.tests.js
+++ b/webapp/test/unit/controllers/jobs.tests.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 /* jasmine specs for controllers go here */

--- a/webapp/test/unit/controllersSpec.js
+++ b/webapp/test/unit/controllersSpec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 /* jasmine specs for controllers go here */

--- a/webapp/test/unit/directivesSpec.js
+++ b/webapp/test/unit/directivesSpec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 /* jasmine specs for directives go here */

--- a/webapp/test/unit/filtersSpec.js
+++ b/webapp/test/unit/filtersSpec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 /* jasmine specs for filters go here */

--- a/webapp/test/unit/models/resultsets.tests.js
+++ b/webapp/test/unit/models/resultsets.tests.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 describe('ThResultSetModel', function(){

--- a/webapp/test/unit/servicesSpec.js
+++ b/webapp/test/unit/servicesSpec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 'use strict';
 
 /* jasmine specs for services go here */


### PR DESCRIPTION
This work fixes part1 of Bugzilla bug [1090689](https://bugzilla.mozilla.org/show_bug.cgi?id=1090689).

This adds MPL2.0 headers to all the relevant files in the treeherder-ui repo. The outliers in the list were done manually, and are the first five in the commit:

Gruntfile.js
docs/Makefile
docs/conf.py
webapp/app/css/logviewer.css
webapp/app/css/treeherder.css

The .bat and .sh scripts in `webapp/scripts` I did not include, since they did not look directly created by us.

Other than those, the remainder were added via a list agreed on in the bug with @edmorley and injected en masse.

Cursorily tested on Windows:
FF Release **33.0.2**
Chrome Latest Release **38.0.2125.111 m**

Adding @edmorley and/or @wlach for review.
