### PR TITLE
bug 1092339 - fixed logviewer infinite scrolling

### DIFF
--- a/webapp/app/js/directives/log_viewer_infinite_scroll.js
+++ b/webapp/app/js/directives/log_viewer_infinite_scroll.js
@@ -9,10 +9,9 @@ treeherder.directive('lvInfiniteScroll', ['$timeout', '$parse', function ($timeo
         element.bind('scroll', function () {
             var raw = element[0];
             var sh = raw.scrollHeight;
-            var onLoadMore = $parse(attr.onLoadMore);
 
             if (raw.scrollTop <= 100) {
-                onLoadMore(scope, {bounds: {top: true}, element: raw}).then(function(haltScrollTop) {
+                scope.loadMore({top: true}, raw).then(function(haltScrollTop) {
                     if (!haltScrollTop) {
                         $timeout(function() {
                             raw.scrollTop = raw.scrollHeight - sh;
@@ -20,7 +19,7 @@ treeherder.directive('lvInfiniteScroll', ['$timeout', '$parse', function ($timeo
                     }
                 });
             } else if (raw.scrollTop >= (raw.scrollHeight - $(element).height() - 100)) {
-                onLoadMore(scope, {bounds: {bottom: true}, element: raw});
+                scope.loadMore({bottom: true}, raw);
             }
         });
     };

--- a/webapp/app/logviewer.html
+++ b/webapp/app/logviewer.html
@@ -35,7 +35,6 @@
         </div>
 
         <div class="lv-log-container"
-             on-load-more="loadMore(bounds, element)"
              lv-infinite-scroll
              lv-log-lines="displayedLogLines">
         </div>


### PR DESCRIPTION
looks like angular 1.3 is more strict about this kind of thing.  The usage of the `on-load-more` was considered unsafe here: https://docs.angularjs.org/error/$parse/isecdom.

but the function was available to scope anyway, so I just referenced it from there.
