### PR TITLE
Bug 1092702 - Fix logviewer angular template flicker on page load

### DIFF
--- a/webapp/app/css/logviewer.css
+++ b/webapp/app/css/logviewer.css
@@ -12,6 +12,11 @@ body {
     padding-top: 15px;
 }
 
+/* Suppress selected angular templates until they compile */
+[ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
+    display: none !important;
+}
+
 /*Log Viewer*/
 
 .lv-line-no {

--- a/webapp/app/logviewer.html
+++ b/webapp/app/logviewer.html
@@ -15,15 +15,18 @@
             <div class="col-md-6">
                 <table class="table table-condensed">
                     <tr ng-repeat="(label, value) in artifact.header">
-                        <th>{{label}}</th>
+                        <th ng-cloak>{{label}}</th>
                         <td ng-if="label == 'revision'">
                             <a href="{{logRevisionFilterUrl}}"
                                title="open resultset in new tab"
                                target="_blank"
-                               class="repo-link">{{value}}</a>
+                               class="repo-link"
+                               ng-cloak>{{value}}</a>
                         </td>
-                        <td ng-if="label == 'starttime'">{{logDisplayDate}}</td>
-                        <td ng-if="label != 'revision' && label != 'starttime'">{{value}}</td>
+                        <td ng-if="label == 'starttime'"
+                            ng-cloak>{{logDisplayDate}}</td>
+                        <td ng-if="label != 'revision' && label != 'starttime'"
+                            ng-cloak>{{value}}</td>
                     </tr>
                 </table>
             </div>


### PR DESCRIPTION
This work fixes Bugzilla bug [1092702](https://bugzilla.mozilla.org/show_bug.cgi?id=1092702).

This adds the [ngCloak](https://docs.angularjs.org/api/ng/directive/ngCloak) directive to selected elements of the logviewer, which were flickering on page load prior to compile. I'm not sure about super fast machines but it was occurring on mine :).

The css included is boilerplate from the API reference, and I've confirmed the 'x-' is what also supports and fixes the behavior on Chrome.

Here's the before and after during page load:

![logviewerpageloadtransitioncurrent](https://cloud.githubusercontent.com/assets/3660661/4884496/5532b170-636c-11e4-9dd8-ff78a8b7143e.jpg)

![logviewerpageloadtransitionproposed](https://cloud.githubusercontent.com/assets/3660661/4884497/591808bc-636c-11e4-957a-16377763952e.jpg)

And of course here is the appearance on page load completion:

![logviewerpageloadlanding](https://cloud.githubusercontent.com/assets/3660661/4884500/6457c6d6-636c-11e4-95ad-5fad8d22895a.jpg)

Tested on Windows:
FF Release **33.0.2**
Chrome Latest Release **38.0.2125.111 m**

Adding @camd and/or @maurodoglio for review.
