### PR TITLE
Bug 1085030 - Refocus bug entry on subsequent additions

### DIFF
--- a/webapp/app/js/directives/main.js
+++ b/webapp/app/js/directives/main.js
@@ -28,11 +28,12 @@ treeherder.directive('focusMe', [
   return {
     link: function(scope, element, attrs) {
       scope.$watch(attrs.focusMe, function(value) {
-        if(value === true) {
+        if (value) {
           $timeout(function() {
             element[0].focus();
-            scope[attrs.focusMe] = false;
           }, 0);
+        } else {
+          element[0].blur();
         }
       });
     }


### PR DESCRIPTION
This work fixes Bugzilla bug [1085030](https://bugzilla.mozilla.org/show_bug.cgi?id=1085030).

This allows users to reclick the + icon on repeated bug entries and have focus set correctly.

The focusMe directive appeared to be setting `attrs.focusMe=false` all the time, which was why the bug input never got focus again on 2nd or later invocations. So we remove that and also set `.blur()` when toggle, save, enter, closes the input field. This ensures after a close, we don't have a hidden input with focus.

Here's bug entry before and after the fix:

![togglebugnumberuicurrent](https://cloud.githubusercontent.com/assets/3660661/4906806/feb6d6d2-645b-11e4-81ec-1da54720a2e7.jpg)

![togglebugnumberuifixed](https://cloud.githubusercontent.com/assets/3660661/4906811/026e44ea-645c-11e4-89a5-efba52b7c759.jpg)

One minor edge case I found, if you close the job panel with the field open, and then re-open the job panel on another job, that cursor focus isn't preserved. But it's only at that time, re-clicking on the + icon works fine from that point onward as usual. That behavior is the same with master, although the cell didn't have focus to begin with. It seems a minor issue and not core workflow.

I was only able to test on Firefox with the job panel still not working on Chrome due to [1072346](https://bugzilla.mozilla.org/show_bug.cgi?id=1072346).

Tested on Windows:
FF Release **32.0.3**

Adding @wlach for review and @philor for visibility.
