### PR TITLE
Bug 1042646 - Deselect job when closing job panel

### DIFF
--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -27,8 +27,14 @@ treeherder.controller('MainCtrl', [
         };
 
         $scope.closeJob = function() {
-            // setting the selectedJob to null closes the bottom panel
+            // Setting the selectedJob to null closes the bottom panel
             $rootScope.selectedJob = null;
+
+            // Clear the selected job display style
+            $rootScope.$broadcast(thEvents.clearJobStyles, $rootScope.selectedJob);
+
+            // Reset selected job to null to initialize nav position
+            ThResultSetModel.setSelectedJob($rootScope.repoName);
         };
 
         $scope.processKeyboardInput = function(ev){
@@ -81,10 +87,6 @@ treeherder.controller('MainCtrl', [
                     $scope.setSettingsPanelShowing(false);
                     $scope.setSheriffPanelShowing(false);
                     $scope.closeJob();
-                    $rootScope.$broadcast(thEvents.clearJobStyles, $rootScope.selectedJob);
-
-                    // Reset selected job to null to initialize nav position
-                    ThResultSetModel.setSelectedJob($rootScope.repoName);
                 }
             }
         };


### PR DESCRIPTION
This work fixes Bugzilla bug [1042646](https://bugzilla.mozilla.org/show_bug.cgi?id=1042646).

This change clears the job selection styles, and re-initializes the internal job "position" for future keyboard job failure navigation, upon a _manual close_ of the job panel via the 'x' close icon. Basically it was a case of re-locating those events into the main closeJob function.

So the above behavior is now consistent with all close workflows:
- manual close via the icon
- esc (keyboard) event to close the panel
- clicking "away" from the job on the main page

Here's the appearance pre-close:

![closejobpanelfix_panelopen](https://cloud.githubusercontent.com/assets/3660661/4920561/37dca8b8-6503-11e4-9fbc-40b9b125954b.jpg)

And after close:

![closejobpanelfix_closepanel](https://cloud.githubusercontent.com/assets/3660661/4920565/3d05b910-6503-11e4-88d1-a98b3dc082e8.jpg)

I was only able to test on Firefox with the job panel still not working on Chrome due to [1072346](https://bugzilla.mozilla.org/show_bug.cgi?id=1072346), but everything appears to be working correctly in my testing.

Tested on Windows:
FF Release **33.0.2**

Adding @camd for review and @edmorley for visibility.
