### PR TITLE
Bug 1074905 - Adjust result set datetime format displayed in UI

### DIFF
--- a/webapp/app/js/controllers/jobs.js
+++ b/webapp/app/js/controllers/jobs.js
@@ -239,9 +239,16 @@ treeherder.controller('ResultSetCtrl', [
             });
         };
 
-        $scope.revisionResultsetFilterUrl = $scope.urlBasePath + "?repo=" + $scope.repoName + "&revision=" + $scope.resultset.revision;
-        $scope.resultsetDateStr = dateFilter($scope.resultset.push_timestamp*1000, 'medium');
-        $scope.authorResultsetFilterUrl = $scope.urlBasePath + "?repo=" + $scope.repoName + "&author=" + encodeURIComponent($scope.resultset.author);
+        $scope.revisionResultsetFilterUrl = $scope.urlBasePath + "?repo=" +
+                                            $scope.repoName + "&revision=" +
+                                            $scope.resultset.revision;
+
+        $scope.resultsetDateStr = dateFilter($scope.resultset.push_timestamp*1000,
+                                             'EEE MMM d, H:mm:ss');
+
+        $scope.authorResultsetFilterUrl = $scope.urlBasePath + "?repo=" +
+                                          $scope.repoName + "&author=" +
+                                          encodeURIComponent($scope.resultset.author);
 
         $scope.resultStatusFilters = thJobFilters.copyResultStatusFilters();
 


### PR DESCRIPTION
This work fixes Bugzilla bug [1074905](https://bugzilla.mozilla.org/show_bug.cgi?id=1074905).

This adjusts the date format in the resultset per Sheriff's request, and makes it roughly consistent with the new Logviewer format. Specifically we add the day, switch to the 24 hour clock format, and remove the year.

Here's the before and after:

![resultsetdatecurrent](https://cloud.githubusercontent.com/assets/3660661/4948571/c5105ac8-6638-11e4-943e-93f82f0e1340.jpg)

![resultsetdateproposed](https://cloud.githubusercontent.com/assets/3660661/4948573/e5461500-660e-11e4-8b62-0bb0144b5a8a.jpg)

In one of those scenarios we discussed today at the work week meeting, I ended up tidying up a couple of unrelated adjacent long lines.

I was only able to test on Firefox with the job panel still not working on Chrome due to [1072346](https://bugzilla.mozilla.org/show_bug.cgi?id=1072346).

Tested on Windows:
FF Release **33.0.2**

Adding @wlach for review and adding @edmorley for visibility.

A note - in the event we ever wanted to utilize relative time, I had a working version in a wip branch, and using [moment.min.js](http://momentjs.com/), the incantation for a "10 minutes ago", "4 days ago" sort of thing, would have instead been:

```
$scope.resultsetDateStrNow = moment(dateFilter($scope.resultset.push_timestamp*1000, 'yyyy MM dd'),
                                               "YYYY MM DD").fromNow();
```
