### PR TITLE
Bug 1095211 -  Add a bit more polish and tooltips to the navbar

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -68,11 +68,42 @@ th-watched-repo {
     float: left;
 }
 
+.repo-menu {
+    margin-right: -4px;
+}
+
+.repo-dropdown-menu {
+    margin-right: 4px;
+}
+
 .navbar .repo-menu-form {
     padding: 5px 10px 0;
     overflow-y: scroll;
     top: inherit;
     right: auto;
+}
+
+.nav-repo-btn {
+    padding-left: 14px;
+    padding-right: 14px;
+}
+
+.nav-filter-btn {
+    margin-right: -4px;
+    padding-left: 14px;
+    padding-right: 14px;
+}
+
+.nav-help-btn {
+    margin-right: -9px;
+}
+
+.nav-help-icon {
+    font-size: 18px;
+}
+
+.nav-login-btn {
+    padding-left: 22px;
 }
 
 .watched-repo-main-btn {
@@ -104,10 +135,6 @@ th-watched-repo {
 
 .th-username {
     margin-right: 5px;
-}
-
-.th-help-link {
-    padding-top: 8px;
 }
 
 .th-context-navbar {
@@ -517,7 +544,7 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
 
 div#bottom-panel .navbar-nav.pull-right li a,
 div#bottom-panel .navbar-nav.pull-right li a:hover,
-div#bottom-panel .navbar-nav.pull-right li a:focus{
+div#bottom-panel .navbar-nav.pull-right li a:focus {
     font-size: 12px;
     line-height: 8px;
 }
@@ -699,6 +726,7 @@ ul.failure-summary-list li .btn-xs {
 .btn-group + .btn + .save-btn-dropdown {
     margin-left: -5px;
 }
+
 /*
  * pinboard
  */
@@ -932,6 +960,21 @@ ul.failure-summary-list li .btn-xs {
  * CUSTOM BUTTONS
  */
 
+.btn-right-navbar {
+   font-size: 13px;
+}
+
+.btn-collapse-resultsets {
+   margin-top: -1px;
+   margin-bottom: -1px;
+   font-size: 14px;
+}
+
+.btn-jobs-revisions {
+   padding-left: 14px !important;
+   padding-right: 18px !important;
+}
+
  .job-btn.btn-dkgray,
  .job-btn.btn-ltgray,
  .job-btn.btn-green,
@@ -947,20 +990,20 @@ ul.failure-summary-list li .btn-xs {
  }
 
 .btn-view-nav {
-  background-color: rgba(75, 86, 93, 0.56);
-  border-color: #22282d;
+  background-color: transparent;
+  border-color: #373d40;
   color: lightgray;
   border-radius: 0;
   border-bottom: 0;
   border-top: 0;
-  border-left: 0;
+  border-right: 0;
 }
 
 .btn-view-nav:hover,
 .btn-view-nav:focus,
 .btn-view-nav:active,
 .btn-view-nav.active {
-  background-color: #25292b;
+  background-color: #2c3133;
   border-color: #1a1d20;
   color: white;
 }
@@ -1014,6 +1057,8 @@ fieldset[disabled] .btn-view-nav-closed.active {
 }
 
 .btn-unclassified-failures {
+  margin-top: 1px;
+  padding: 3px 10px;
   background-color: rgba(78, 93, 21, 0.56);
   border-color: #9fa01d;
   color: lightgray;

--- a/webapp/app/partials/main/persona_buttons.html
+++ b/webapp/app/partials/main/persona_buttons.html
@@ -1,2 +1,9 @@
-<a class="btn btn-view-nav" ng-if="user.loggedin" ng-click="logout()"><span>Logout</span></a>
-<a class="btn btn-view-nav" ng-if="!user.loggedin" ng-click="login()"><span>Login / Register</span></a>
+<a class="btn btn-view-nav btn-right-navbar nav-login-btn"
+   ng-if="user.loggedin"
+   ng-click="logout()">
+   <span>Logout</span></a>
+
+<a class="btn btn-view-nav btn-right-navbar nav-login-btn"
+   title="Log in for additional functionality"
+   ng-if="!user.loggedin" ng-click="login()">
+   <span>Login / Register</span></a>

--- a/webapp/app/partials/main/thGlobalTopNavPanel.html
+++ b/webapp/app/partials/main/thGlobalTopNavPanel.html
@@ -11,9 +11,9 @@
                       ng-click="setSheriffPanelShowing(!isSheriffPanelShowing)"
                       tabindex="0"
                       role="button"><span>Sheriffing</span>
-                    <i class="fa fa-caret-down lightgray"
+                    <i class="fa fa-angle-down lightgray"
                        ng-hide="isSheriffPanelShowing"></i>
-                    <i class="fa fa-caret-up lightgray"
+                    <i class="fa fa-angle-up lightgray"
                        ng-show="isSheriffPanelShowing"></i>
                 </span>
             </span>
@@ -22,8 +22,10 @@
                 <!--<span class="repo-menu dropdown keep-open">-->
                 <span th-repo-dropdown-container class="repo-menu dropdown">
                     <!-- Repo Button -->
-                    <button id="repoLabel" role="button" href="#" data-toggle="dropdown" data-target="#" class="btn btn-view-nav">
-                        Repos <b class="fa fa-caret-down lightgray"></b>
+                    <button id="repoLabel" title="Watch a repo" role="button"
+                            href="#" data-toggle="dropdown" data-target="#"
+                            class="btn btn-view-nav btn-right-navbar nav-repo-btn">Repos
+                        <span class="fa fa-angle-down lightgray"></span>
                     </button>
 
                     <!-- Repo Menu -->
@@ -36,27 +38,35 @@
 
                     </ul>
                 </span>
-                <span class="btn btn-view-nav"
+
+                <!-- Global Filter Button -->
+                <span class="btn btn-view-nav btn-right-navbar nav-filter-btn"
+                      title="Global job filters"
                       ng-class="{'active': (isFilterPanelShowing)}"
                       ng-click="setFilterPanelShowing(!isFilterPanelShowing)"
                       tabindex="0"
                       role="button"><span>Filters</span>
-                    <i class="fa fa-caret-down lightgray"
+                    <i class="fa fa-angle-down lightgray"
                        ng-hide="isFilterPanelShowing"></i>
-                    <i class="fa fa-caret-up lightgray"
+                    <i class="fa fa-angle-up lightgray"
                        ng-show="isFilterPanelShowing"></i>
                 </span>
-                <a class="btn btn-view-nav" href="help.html" target="_blank">Help</a>
+
+                <!-- Help Button -->
+                <a class="btn btn-view-nav nav-help-btn"
+                   title="Treeherder help" href="help.html" target="_blank">
+                    <span class="fa fa-question-circle lightgray nav-help-icon"></span></a>
+
                 <span class="nav-text white th-username">{{user.email}}</span>
                 <!--TODO: change this condition to enable the settings panel-->
-                <span ng-show="false" class="btn btn-view-nav"
+                <span ng-show="false" class="btn btn-view-nav btn-right-navbar"
                       ng-class="{'active': (isSettingsPanelShowing)}"
                       ng-click="setSettingsPanelShowing(!isSettingsPanelShowing)"
                       tabindex="0"
                       role="button"><span>Settings</span>
-                    <i class="fa fa-caret-down lightgray"
+                    <i class="fa fa-angle-down lightgray"
                        ng-hide="isSettingsPanelShowing"></i>
-                    <i class="fa fa-caret-up lightgray"
+                    <i class="fa fa-angle-up lightgray"
                        ng-show="isSettingsPanelShowing"></i>
                 </span>
                 <persona-buttons></persona-buttons>

--- a/webapp/app/partials/main/thWatchedRepoNavPanel.html
+++ b/webapp/app/partials/main/thWatchedRepoNavPanel.html
@@ -3,52 +3,60 @@
     <div class="navbar-right">
         <span>
             <form role="search" class="form-inline">
+
+                <!--Unclassified Failures Button-->
                 <span class="btn btn-sm"
                       ng-click="toggleUnclassifiedFailures()"
-                      title="toggle filtering for unclassified failures - count of loaded failures"
+                      title="Loaded failures / Toggle filtering for unclassified failures"
                       tabindex="0" role="button"
                       ng-class="{'btn-unclassified-failures': getUnclassifiedFailureCount(repoName), 'btn-view-nav': getUnclassifiedFailureCount(repoName)===0}">
                     <span>{{ getUnclassifiedFailureCount(repoName) }}</span> unclassified
                 </span>
-                <span class="btn btn-view-nav btn-sm"
-                      title="toggle showing hidden jobs"
+
+                <!--Hidden Jobs Button-->
+                <span class="btn btn-view-nav btn-sm btn-right-navbar"
+                      title="Show/hide hidden jobs"
                       tabindex="0" role="button"
                       ng-click="toggleExcludedJobs()">
-                    <i class="fa fa=lg"
-                       ng-class="{'fa-eye': isSkippingExclusionProfiles(), 'fa-eye-slash': !isSkippingExclusionProfiles()}"></i>
+                    <i class="fa"
+                       ng-class="{'fa-square': isSkippingExclusionProfiles(), 'fa-square-o': !isSkippingExclusionProfiles()}"></i>
                 </span>
+
+                <!--Collapse Resultsets Button-->
                 <span class="btn-group">
-                    <span class="btn btn-view-nav btn-sm"
-                          title="collapse/expand all result sets"
+                    <span class="btn btn-view-nav btn-sm btn-collapse-resultsets"
+                          title="Collapse/expand all result sets"
                           tabindex="0" role="button"
-                          ng-click="toggleAllJobsAndRevisions()"><i class="fa fa-list fa-lg"></i>
+                          ng-click="toggleAllJobsAndRevisions()"><i class="fa fa-list"></i>
                     </span>
-                    <span class="btn btn-view-nav btn-sm dropdown-toggle save-btn-dropdown"
-                            data-toggle="dropdown"><i class="fa fa-caret-down"></i>
+
+                    <!--Jobs and Revisions Menu Button-->
+                    <span class="btn btn-view-nav btn-sm dropdown-toggle
+                                 save-btn-dropdown btn-jobs-revisions"
+                          title="Jobs and revisions"
+                          data-toggle="dropdown"><i class="fa fa-angle-down"></i>
                     </span>
                     <ul class="dropdown-menu pull-right" role="menu">
                         <li>
                             <a href="" prevent-default-on-left-click  ng-click="toggleAllRevisions(false)">
-                                <span class="fa fa-minus-square"></span>
                                 <span class="fa fa-code-fork"></span> Collapse all revisions</a>
                         </li>
                         <li>
                             <a href="" prevent-default-on-left-click  ng-click="toggleAllRevisions(true)">
-                            <span class="fa fa-plus-square"></span>
                             <span class="fa fa-code-fork"></span> Expand all revisions</a>
                         </li>
                         <li>
                             <a href="" prevent-default-on-left-click  ng-click="toggleAllJobs(false)">
-                                <span class="fa fa-minus-square"></span>
-                                <span class="fa fa-list"></span> Collapse all jobs</a>
+                                <span class="fa fa-ellipsis-v"></span> Collapse all jobs</a>
                         </li>
                         <li>
                             <a href="" prevent-default-on-left-click  ng-click="toggleAllJobs(true)">
-                            <span class="fa fa-plus-square"></span>
-                            <span class="fa fa-list"></span> Expand all jobs</a>
+                            <span class="fa fa-th"></span> Expand all jobs</a>
                         </li>
                     </ul>
                 </span>
+
+                <!--Search Field-->
                 <span ng-controller="SearchCtrl" class="form-group form-inline">
                     <input id="platform-job-text-search-field"
                            ng-model="searchQueryStr" ng-keyup="search($event)" type="text"


### PR DESCRIPTION
This work fixes Bugzilla bug [1095211](https://bugzilla.mozilla.org/show_bug.cgi?id=1095211).

I'm pretty pleased with the results of this work. This adds a bunch of graphic design, UI polish, and consistency to the right hand navbar. Specifically:
- arbitrary Repo, Filter, Help, Collapse, etc, button spacing has been eliminated
- Repo, Filter, Login button font size has been reduced 1px so they aren't so overwhelming
- a clean help icon has been used instead of "Help"
- we get rid of the grey buttons in the dark navbar for a peaceful appearance
- we use 1 pixel button borders to delineate the dark bar button boundaries
- we reduce the height of the unclassified failures button 1 pixel so it floats - evocative of a job button
- we add tooltips for all menus and buttons, instead of only some having them
- we remove the double icons in the Collapse jobs/revisions menu
- we use `fa-bar` for the concept of collapse, since it is a lot cleaner visually than `fa-list`
- we use the much cleaner `fa-angle` for drop down menus
- we do some -ve margins and one `!important` to override some crazy `.btn` class inheritance

What we _aren't_ doing in this change, and intend to do later:
- a new icon for the problematic Show/hide hidden jobs
- possible color change to a sympathetic orange hue for the Unclassified failures button

Here is the before and after:

![navbarrightcurrent](https://cloud.githubusercontent.com/assets/3660661/4971203/63ecd17e-6893-11e4-9ee0-df7d874016e5.jpg)

![navbarrightproposed](https://cloud.githubusercontent.com/assets/3660661/4971204/68c72550-6893-11e4-81ae-bb0ed052f283.jpg)

Here is the more subtle highlight color and an example of a new tooltip for the Filters button. I am consciously only highlighting the text:

![navbarrighthighlighttooltip](https://cloud.githubusercontent.com/assets/3660661/4971211/9304a8bc-6869-11e4-8f41-52d7f945886b.jpg)

Here are the new tooltips for the lower navbar. Button widths have also been equalized.

![navbarrightshowhidden](https://cloud.githubusercontent.com/assets/3660661/4971219/b9b5bb4a-6869-11e4-9a7a-8ebe7ba58ab8.jpg)

![navbarrightcollapseexpand](https://cloud.githubusercontent.com/assets/3660661/4971222/c001e37a-6869-11e4-92e6-54989c8efce5.jpg)

![navbarrightjobrevisionmenu](https://cloud.githubusercontent.com/assets/3660661/4971223/c2259a48-6869-11e4-982c-0eb25c093c58.jpg)

I've done a bunch of testing on Firefox and Chrome, and am very happy with the results. If we could try this on dev, or if someone could try the branch locally with a vagrant backend underneath so they can log in and ensure the "Login" field is sufficient for the user email, that would be great. I put in a significant left-hand padding to be sure we are ok there.

Tested on Windows:
FF Release **33.0.2**
Chrome Latest Release **38.0.2125.111 m**

Adding @wlach for review, and @edmorley and @rvandermeulen for visibility.
