### PR TITLE
Bug 1080408 - Pad wording for 'Unknown revision ID' page

### DIFF
--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -50,7 +50,7 @@
 
 <div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending &&
               !isLoadingJobs && locationHasSearchParam('revision')"
-              class="result-set">
+              class="result-set-body">
   <span ng-init="revision=getSearchParamValue('revision')">
     <div><b>Unknown revision ID.</b></div>
     <span>Waiting for a result set matching revision</span>
@@ -68,7 +68,7 @@
 <div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending &&
               !isLoadingJobs && !locationHasSearchParam('revision') &&
               !locationHasSearchParam('repo') && currentRepo.url"
-              class="result-set">
+              class="result-set-body">
   <span>
     <div><b>No resultsets found.</b></div>
     <span>No commit information could be loaded for this repository.
@@ -79,7 +79,7 @@
 <div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending &&
               !isLoadingJobs && !locationHasSearchParam('revision') &&
               locationHasSearchParam('repo') && !currentRepo.url"
-              class="result-set">
+              class="result-set-body">
   <span>
     <div><b>Unknown repository.</b></div>
     <span>This repository is either unknown to Treeherder or it doesn't exist.


### PR DESCRIPTION
This is a supplementary fix to Bugzilla bug [1080408](https://bugzilla.mozilla.org/show_bug.cgi?id=1080408).

In the main fix in the bug to handle unknown revisions, the class referenced in treeherder.css changed on master due to other work. It was then merged in that state. This change re-targets it so we get some semblance of a page border.

Here is the before and after:

![unknownmessagecurrent](https://cloud.githubusercontent.com/assets/3660661/4988206/acebcb7e-692d-11e4-941e-905c7ffedd2e.jpg)

![unknownmessageproposed](https://cloud.githubusercontent.com/assets/3660661/4988209/b14a22a6-692d-11e4-87af-78525e01947c.jpg)

Tested on Windows:
FF Release **33.1**
Chrome Latest Release **38.0.2125.111 m**

Adding @wlach for review.
