### PR TITLE
Bug 1080408 - Update wording for 'Unknown revision ID' page

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -327,6 +327,11 @@ th-watched-repo {
     padding-right: 25px;
 }
 
+/* Encompasses unknown push,resultset,repo */
+.unknown-message-body {
+    padding-top: 10px;
+}
+
 .result-set-title-left, .result-set-buttons, .result-counts {
     flex: none;
     -webkit-flex: none;

--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -50,17 +50,14 @@
 
 <div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending &&
               !isLoadingJobs && locationHasSearchParam('revision')"
-              class="result-set">
+              class="result-set-body unknown-message-body">
   <span ng-init="revision=getSearchParamValue('revision')">
-    <div><b>Unknown revision ID.</b></div>
-    <span>Waiting for a result set matching revision</span>
+      <span>Waiting for a push with revision <strong>{{revision}}</strong></span>
       <a href="{{currentRepo.url}}/pushloghtml?changeset={{revision}}"
          target="_blank"
-         title="open revision {{revision}} on {{currentRepo.url}}">{{revision}}</a>
+         title="open revision {{revision}} on {{currentRepo.url}}">(view pushlog)</a>
     <span class="fa fa-refresh fa-spin"></span>
-    <div>Your push has either not been processed yet or the revision is invalid.
-      This page will refresh automatically, and your jobs will show up within
-      a few minutes of the push if it exists.
+    <div>If the push exists, it will appear in a few minutes once it has been processed.
     </div>
   </span>
 </div>
@@ -68,7 +65,7 @@
 <div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending &&
               !isLoadingJobs && !locationHasSearchParam('revision') &&
               !locationHasSearchParam('repo') && currentRepo.url"
-              class="result-set">
+              class="result-set-body unknown-message-body">
   <span>
     <div><b>No resultsets found.</b></div>
     <span>No commit information could be loaded for this repository.
@@ -79,7 +76,7 @@
 <div ng-show="result_sets.length == 0 && !isLoadingRsBatch.appending &&
               !isLoadingJobs && !locationHasSearchParam('revision') &&
               locationHasSearchParam('repo') && !currentRepo.url"
-              class="result-set">
+              class="result-set-body unknown-message-body">
   <span>
     <div><b>Unknown repository.</b></div>
     <span>This repository is either unknown to Treeherder or it doesn't exist.


### PR DESCRIPTION
This is a supplementary fix to Bugzilla bug [1080408](https://bugzilla.mozilla.org/show_bug.cgi?id=1080408).

In the main fix in the bug to handle unknown revisions, the class referenced in treeherder.css changed on master due to other work. It was then merged in that state. This change re-targets it so we get some semblance of a page border. In addition:
- we tweaked the message further iterating with Ed in channel
- I added a new class to provide a vertical page boundary at the top, as it's marginal without a resultset

Here is the before and after:

![unknown_rev_current](https://cloud.githubusercontent.com/assets/3660661/5014034/8aa49bac-6a60-11e4-8d39-5627171d32ef.jpg)

![unknown_rev_proposed](https://cloud.githubusercontent.com/assets/3660661/5014036/8c341dda-6a60-11e4-8363-e6f1e111e731.jpg)

Tested on Windows:
FF Release **33.1**
Chrome Latest Release **38.0.2125.111 m**

Adding @wlach for review and @edmorley for visibility.
