### PR TITLE
bug 1072346 - make detail panel visible in chrome

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -445,6 +445,7 @@ div#bottom-panel {
     background-color: #AAAAAA;
     font-size: 12px;
 
+    height: 35%;
     max-height: 35%;
     flex: none;
     -webkit-flex: none;


### PR DESCRIPTION
This just fixes the bottom detail panel for chrome.  Without setting a `height` value, it didn't take the max-height as default.  Firefox took the max-height as default, so it worked there.
