### PR TITLE
Bug 1062825 - Include job details in Log viewer page title

### DIFF
--- a/webapp/app/js/controllers/logviewer.js
+++ b/webapp/app/js/controllers/logviewer.js
@@ -175,6 +175,12 @@ logViewer.controller('LogviewerCtrl', [
                     .then(function(buildapiData){
                         if(buildapiData.length > 0){
                             $scope.artifact.header.builder = buildapiData[0].blob.buildername;
+
+                            // Used with ng-bind to avoid template flicker
+                            $scope.getLogviewerTitle = function() {
+                                var ahb = $scope.artifact.header.builder
+                                return "Log viewer - " + ahb;
+                            };
                         }
                     });
                 }

--- a/webapp/app/logviewer.html
+++ b/webapp/app/logviewer.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html ng-app="logViewer">
+<html ng-controller="LogviewerCtrl" ng-init="init()" ng-app="logViewer">
     <head>
         <meta charset="utf-8">
-        <title>Treeherder Log Viewer </title>
+        <title ng-bind="getLogviewerTitle()">Log viewer</title>
         <!-- build:css css/logviewer.min.css -->
         <link href="css/bootstrap.css" rel="stylesheet" media="screen">
         <link href="css/treeherder.css" rel="stylesheet" type="text/css">
@@ -10,7 +10,7 @@
         <!-- endbuild -->
         <link id="favicon" type="image/png" rel="shortcut icon" href="img/tree_open.png">
     </head>
-    <body ng-controller="LogviewerCtrl" ng-init="init()" class="body-logviewer">
+    <body class="body-logviewer">
         <div class="run-data">
             <div class="col-md-6">
                 <table class="table table-condensed">


### PR DESCRIPTION
This work fixes Bugzilla bug [1062825](https://bugzilla.mozilla.org/show_bug.cgi?id=1062825).

In it, we add a descriptive page title for Log viewer, so primarily on hover, they can be differentiated.

Because angular template flicker in `<head>` cannot be presently suppressed by `ng-cloak` we instead add a static title and then switch it on page load to the buildApi data value. It's not a perfect transition, but it does result in a readable title on initial page rendering. Just like the main Treeherder index.html, it undergoes a brief flicker (on my local server to its http:// value), then to the final desired value.

Here is before and after the fix:

![logviewertitlecurrent](https://cloud.githubusercontent.com/assets/3660661/5020265/721eb722-6a95-11e4-9de0-d5b2c4aebc26.jpg)

![logviewertitleproposed](https://cloud.githubusercontent.com/assets/3660661/5020268/74aa924a-6a95-11e4-8382-5f52305e70cd.jpg)

I've tested it in a Chrome browser also, and the behavior seems to be generally similar, and fine. I ended up moving the entire html under the logviewer controller, as the new function lies within in the init(). I am not sure if this has an appreciable performance differences, but I couldn't see any.

When it did not exist inside that init() the new getter wasn't callable, as far as I could tell.

Tested on Windows:
FF Release **33.1**
Chrome Latest Release **38.0.2125.111 m**

Adding @camd  for review and @edmorley for visibility.
