### PR TITLE
Bug 1096349 - Remove unused labels in clonejobs directive

### DIFF
--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -775,7 +775,7 @@ treeherder.directive('thCloneJobs', [
         }
 
         var platforms, groups, jobs, r;
-        superloop:
+
         for(r = 0; r < resultsets.length; r++){
 
             platforms = resultsets[r].platforms;
@@ -839,7 +839,6 @@ treeherder.directive('thCloneJobs', [
 
         var platforms, groups, jobs, r;
 
-        superloop:
         for(r = resultsets.length - 1; r >= 0; r--){
 
             platforms = resultsets[r].platforms;


### PR DESCRIPTION
This fixes Bugzilla bug [1096349](https://bugzilla.mozilla.org/show_bug.cgi?id=1096349).

Not much to add, except there were a couple of labels to remove.

Tested on Windows:
FF Release **33.1**
Chrome Latest Release **38.0.2125.111 m**

Adding @maurodoglio and @edmorley for merge/review whoever gets to it first.
