### PR TITLE
Bug 1104149 - Fix digest cycle error on related bug addition

### DIFF
--- a/webapp/app/js/directives/main.js
+++ b/webapp/app/js/directives/main.js
@@ -33,7 +33,9 @@ treeherder.directive('focusMe', [
             element[0].focus();
           }, 0);
         } else {
-          element[0].blur();
+          $timeout(function() {
+            element[0].blur();
+          }, 0);
         }
       });
     }


### PR DESCRIPTION
This change fixes Bugzilla bug [1104149](https://bugzilla.mozilla.org/show_bug.cgi?id=1104149).

This fixes a regression I introduced in PR https://github.com/mozilla/treeherder-ui/pull/259 in which a new bug addition, triggers a digest cycle error:

`Error: [$rootScope:inprog] $digest already in progress`

Wrapping the `.blur` in a similar timeout that the `.focus` is already wrapped in, seems to address the issue.

With this change, we shouldn't generate that error when adding bugs, and regardless of the sequence or speed of entry. I've tested it pretty extensively on Windows to confirm the fix, but @camd if you can try my branch on OSX locally that would be awesome.

Tested on Windows:
FF Release **33.1.1**
Chrome Latest Release **39.0.2171.65 m**

Adding @camd for review.
