### PR TITLE
Bug 1103425 - Add a bit more polish to the pinboard

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -458,9 +458,9 @@ div#bottom-panel-resizer {
     display: flex;
     flex: none;
     -webkit-flex: none;
-    background-color: #42484F;
+    background-color: #919dad;
     cursor: ns-resize;
-    height: 4px;
+    height: 2px;
 }
 
 
@@ -546,13 +546,6 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:hover,
 div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
     background-color: #1A4666;
     color: #EEF0F2;
-}
-
-div#bottom-panel .navbar-nav.pull-right li a,
-div#bottom-panel .navbar-nav.pull-right li a:hover,
-div#bottom-panel .navbar-nav.pull-right li a:focus {
-    font-size: 12px;
-    line-height: 8px;
 }
 
 #bottom-panel-content {
@@ -738,9 +731,8 @@ ul.failure-summary-list li .btn-xs {
  */
 
 #pinboard-panel {
-    background-color: #252C33;
-    color: #EEF0F2;
-    padding: 0px 5px;
+    background-color: #e6eef5;
+    color: #252c33;
 
     flex: auto;
     -webkit-flex: auto;
@@ -752,7 +744,16 @@ ul.failure-summary-list li .btn-xs {
 }
 
 #pinboard-panel .header{
+    padding-left: 2px;
     height: 18px;
+}
+
+.pinboard-preload-txt {
+    color: #bfbfbf;
+}
+
+.pinboard-related-bug-preload-txt {
+    vertical-align: top;
 }
 
 #pinned-job-list{
@@ -765,7 +766,7 @@ ul.failure-summary-list li .btn-xs {
     padding: 2px;
     margin: 2px;
     background-color: #FFFFFF;
-    min-height: 60px;
+    min-height: 80px;
     max-height: 120px;
     overflow: auto;
 }
@@ -782,10 +783,40 @@ ul.failure-summary-list li .btn-xs {
     padding: 2px;
     margin: 2px;
     background-color: #FFFFFF;
-    min-height: 60px;
+    min-height: 80px;
     max-height: 120px;
-    overflow: auto;
+    overflow-x: hidden;
     color: black;
+}
+
+#pinboard-related-bugs a {
+    text-decoration: none;
+}
+
+.add-related-bugs-icon {
+    margin-right: 2px;
+    font-size: 17px;
+    color: #98c3da;
+}
+
+.add-related-bugs-form {
+    position: relative;
+    top: -18px;
+    left: 20px;
+}
+
+.add-related-bugs-input {
+    width: 12em;
+}
+
+.pinboard-open-btn {
+    margin-top: -1px;
+    background-color: #e6eef5 !important;
+    color: #252c33 !important;
+}
+
+.pinboard-related-bugs-btn {
+    margin-bottom: -1px;
 }
 
 /* Spin button suppression on chrome */
@@ -817,14 +848,7 @@ ul.failure-summary-list li .btn-xs {
 #pinboard-classification textarea {
     width: 177px;
     margin-top: 5px;
-    height: 37px;
-}
-
-#pinboard-controls-close-button-container {
-    padding-left: 5px;
-    flex: none;
-    -webkit-flex: none;
-    color: #9fa3a5;
+    height: 40px;
 }
 
 #pinboard-controls {

--- a/webapp/app/js/services/pinboard.js
+++ b/webapp/app/js/services/pinboard.js
@@ -142,6 +142,10 @@ treeherder.factory('thPinboard', [
             return !_.isEmpty(pinnedJobs);
         },
 
+        hasRelatedBugs: function() {
+            return !_.isEmpty(relatedBugs);
+        },
+
         spaceRemaining: function() {
             return api.maxNumPinned - api.count.numPinnedJobs;
         },

--- a/webapp/app/partials/main/thPinboardPanel.html
+++ b/webapp/app/partials/main/thPinboardPanel.html
@@ -1,8 +1,8 @@
 <div id="pinned-job-list">
-  <div class="header">
-    <i class="glyphicon glyphicon-pushpin"></i> pinboard
-  </div>
   <div class="content">
+    <span class="pinboard-preload-txt"
+          ng-hide="hasPinnedJobs()">
+          press spacebar to pin a selected job</span>
     <span ng-repeat="job in pinnedJobs">
       <th-pinned-job></th-pinned-job>
     </span>
@@ -10,17 +10,20 @@
 </div>
 
 <div id="pinboard-related-bugs">
-  <div class="header">
-    <i class="fa fa-bug"></i> related bugs
-    <a ng-click="toggleEnterBugNumber()"
-       class="click-able-icon lightgray"
-       title="type in a bug number"><i class="fa fa-plus"></i>
-    </a>
-  </div>
   <div class="content">
-    <form ng-submit="saveEnteredBugNumber()">
+    <a ng-click="toggleEnterBugNumber()"
+       class="click-able-icon"
+       title="Add a related bug">
+       <i class="fa fa-plus-square add-related-bugs-icon"></i>
+    </a>
+    <span class="pinboard-preload-txt pinboard-related-bug-preload-txt"
+          ng-if="!hasRelatedBugs()">
+          click to add a related bug</span>
+    <form ng-submit="saveEnteredBugNumber()"
+          ng-show="enteringBugNumber"
+          class="add-related-bugs-form">
       <input type="number"
-             ng-show="enteringBugNumber"
+             class="add-related-bugs-input"
              ng-model="$parent.newEnteredBugNumber"
              placeholder="enter bug number"
              focus-me="focusInput">
@@ -30,8 +33,9 @@
     </span>
   </div>
 </div>
+
 <div id="pinboard-classification">
-  <div class="header"><i class="fa fa-star"></i> classification</div>
+  <div class="header">classification</div>
   <div id="pinboard-classification-content" class="content">
     <form ng-submit="saveNewClassification()" class="form">
       <select ng-model="classification.failure_classification_id"
@@ -66,14 +70,4 @@
       <li><a ng-click="saveBugsOnly()"><i class="fa fa-bug"></i> bugs only</a></li>
     </ul>
   </div>
-</div>
-
-<div id="pinboard-controls-close-button-container">
-  <a class="click-able-icon lightgray"
-     ng-click="togglePinboardVisibility()"
-     prevent-default-on-left-click>
-    <span title="Close the pinboard"
-          class="glyphicon glyphicon-remove">
-    </span>
-  </a>
 </div>

--- a/webapp/app/partials/main/thRelatedBugQueued.html
+++ b/webapp/app/partials/main/thRelatedBugQueued.html
@@ -1,5 +1,5 @@
-<span class="btn-group">
-    <a class="btn btn-default btn-xs pinboard-related-bug-button"
+<span class="btn-group pinboard-related-bugs-btn">
+    <a class="btn btn-default btn-xs"
        title="{{::bug.summary}}"
        href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.id}}"
        target="_blank"

--- a/webapp/app/partials/main/thRelatedBugSaved.html
+++ b/webapp/app/partials/main/thRelatedBugSaved.html
@@ -1,5 +1,5 @@
-<span class="btn-group">
-    <a class="btn btn-default btn-xs pinboard-related-bug-button"
+<span class="btn-group pinboard-related-bugs-btn">
+    <a class="btn btn-default btn-xs"
        href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.bug_id}}"
        target="_blank"
        >{{::bug.bug_id}}</a>

--- a/webapp/app/plugins/pinboard.js
+++ b/webapp/app/plugins/pinboard.js
@@ -82,6 +82,10 @@ treeherder.controller('PinboardCtrl', [
             return thPinboard.hasPinnedJobs();
         };
 
+        $scope.hasRelatedBugs = function() {
+            return thPinboard.hasRelatedBugs();
+        };
+
         $scope.toggleEnterBugNumber = function() {
             $scope.enteringBugNumber = !$scope.enteringBugNumber;
             $scope.focusInput = $scope.enteringBugNumber;

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -229,18 +229,21 @@
 
         <ul class="nav navbar-nav pull-right">
           <li>
-            <a href="#" prevent-default-on-left-click ng-click="togglePinboardVisibility()">
+            <a href="#" prevent-default-on-left-click ng-click="togglePinboardVisibility()"
+               ng-class="{'pinboard-open-btn': isPinboardVisible}">
               <span ng-hide="isPinboardVisible"
-                    title="Show the pinboard"
-                    class="glyphicon glyphicon-chevron-down"></span>
+                    title="Open the pinboard">Open pinboard&nbsp
+                    <span class="fa fa-angle-up"></span>
+              </span>
               <span ng-show="isPinboardVisible"
-                    title="Hide the pinboard"
-                    class="glyphicon glyphicon-chevron-up"></span>
+                    title="Close the pinboard">Close pinboard&nbsp
+                    <span class="fa fa-angle-down"></span>
+              </span>
             </a>
           </li>
           <li>
-            <a prevent-default-on-left-click title="close panel" href="#" ng-click="closeJob()">
-              <span class="glyphicon glyphicon-remove"></span>
+            <a prevent-default-on-left-click title="Close the job panel" href="#" ng-click="closeJob()">
+              <span class="fa fa-times"></span>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
This work fixes Bugzilla bug [1103425](https://bugzilla.mozilla.org/show_bug.cgi?id=1103425).

This adds some more layout improvements to the pinboard, specifically to:
- address past concerns the job panel/pinboard was too heavy/dark/high-contrast
- 'tie' the pinboard to the job panel, but present it as separate functionality
- maximize available space for pinned jobs, bugs
- retire icons which don't do anything
- eliminate unnecessary labels, headers where possible
- imply functionality and context

In the code, among the changes we:
- add a new `hasRelatedBugs()` function to support suppression of the related bugs message
- remove some now-unnecessary hover styling for the pinboard button
- remove the extra close icon in the pinboard (top right corner)
- shrink the resizer as much as we can get away with
- continue with the min/max-height containers but make them 80/120 instead of 60/120
- tweak wording of the pinboard message per KWierso's request

Here is a before and after:

![pinboardcurrent](https://cloud.githubusercontent.com/assets/3660661/5204333/89d069ac-755c-11e4-8a3e-93e1174fb3ba.jpg)

![pinboardproposed](https://cloud.githubusercontent.com/assets/3660661/5204334/8cde22a6-755c-11e4-84e5-77cd4ab0655a.jpg)

The actual screen space consumed by the pinboard is identical, and all optimizations happen within that space.

I've tested it pretty extensively on Windows and @camd had a go yesterday on OSX with an earlier wip branch. We'd probably want to let everyone try it out on dev for awhile. A note, for clean related bug additions in the console, this PR requires PR https://github.com/mozilla/treeherder-ui/pull/278 to be merged first.

Tested on Windows:
FF Release **33.1.1**
Chrome Latest Release **39.0.2171.65 m**

Adding @camd for review and @wlach for an extra set of eyes on the change.
