### PR TITLE
Bug 1030686 - Add keyboard shortcut for related bug addition

### DIFF
--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -114,18 +114,20 @@
                 <table id="shortcuts">
                     <tr><th>esc</th>
                     <td>Close all open job or filter panels</td></tr>
-                    <tr><th>spacebar</th>
-                    <td>Add selected job to the pin board</td></tr>
                     <tr><th>j<span> or </span>n</th>
                     <td>Highlight next unstarred failure</td></tr>
                     <tr><th>k<span> or </span>p</th>
                     <td>Highlight previous unstarred failure</td></tr>
                     <tr><th>u</th>
                     <td>Show only unstarred failures</td></tr>
+                    <tr><th>ctrl/cmd<span> click</span></th>
+                    <td>Add job to the pinboard</td></tr>
+                    <tr><th>spacebar</th>
+                    <td>Add a selected job to the pinboard</td></tr>
+                    <tr><th>r</th>
+                    <td>Add a selected job to the pinboard + enter related bug</td></tr>
                     <tr><th>i</th>
                     <td>Toggle in-progress (running/pending) jobs</td></tr>
-                    <tr><th>ctrl/cmd click</th>
-                    <td>Add job to the pinboard</td></tr>
                 </table>
             </div>
         </div>

--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -81,6 +81,13 @@ treeherder.controller('MainCtrl', [
                 } else if (ev.keyCode === 85) {
                     // Display only unclassified failures, keys:u
                     $scope.toggleUnclassifiedFailures();
+
+                } else if (ev.keyCode === 82) {
+                    // Pin selected job to pinboard and add a related bug, key:r
+                    if ($scope.selectedJob) {
+                        $rootScope.$emit(thEvents.addRelatedBug, $rootScope.selectedJob);
+                    }
+
                 } else if (ev.keyCode === 27) {
                     // Escape closes any open panels and clears the selected job
                     $scope.setFilterPanelShowing(false);

--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -229,6 +229,8 @@ treeherder.provider('thEvents', function() {
 
             selectPreviousUnclassifiedFailure: "previous-unclassified-failure-EVT",
 
+            addRelatedBug: "add-related-bug-EVT",
+
             searchPage: "search-page-EVT",
 
             selectJob: "select-job-EVT",

--- a/webapp/app/plugins/pinboard.js
+++ b/webapp/app/plugins/pinboard.js
@@ -18,6 +18,11 @@ treeherder.controller('PinboardCtrl', [
             }
         });
 
+        $rootScope.$on(thEvents.addRelatedBug, function(event, job) {
+            $scope.pinJob(job);
+            $scope.toggleEnterBugNumber();
+        });
+
         $scope.pinJob = function(job) {
             thPinboard.pinJob(job);
             if (!$scope.selectedJob) {


### PR DESCRIPTION
This work fixes 'part2' of Bugzilla bug [1030686](https://bugzilla.mozilla.org/show_bug.cgi?id=1030686) requested by philor in [comment 8](https://bugzilla.mozilla.org/show_bug.cgi?id=1030686#c8).

This feature adds the selected job to the pinboard, and simultaneously opens the input field for adding a related bug.

After the event, you can issue additional 'r's and continue adding related bugs. Similarly you can 'n' or 'p' and navigate to the next unclassified failure and issue the 'r' again to add another if you wish. Esc to close the panel works also as expected.

Basically you can do the entire process up to this point, without taking your hands off the keyboard.

With this feature, here is the UI appearance on the keyboard event:

![addrelatedbugshortcutproposed](https://cloud.githubusercontent.com/assets/3660661/5219716/07e07388-7629-11e4-8c38-6bb5da18dddb.jpg)

I've tested fairly extensively on Firefox and Chrome on windows, and it appears to be working correctly. I've also updated the Help and re-ordered the content slightly to group all the pinboard related shortcuts together.

Tested on Windows:
FF Release **33.1.1**
Chrome Latest Release **39.0.2171.71 m**

Adding @camd for review and @philor and @edmorley for visibility.
