### PR TITLE
Bug 1106120 - Align resultset title content for collapse readability

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -359,7 +359,24 @@ th-watched-repo {
     padding-top: 10px;
 }
 
-.result-set-title-left, .result-set-buttons, .result-counts {
+.result-set-title-left {
+    flex: 0 0 23.5em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-right: 10px;
+}
+
+.result-set-buttons {
+    flex: 0 0 13em;
+}
+
+.result-set-fa-icon {
+    float: left;
+    padding-top: 4px;
+    padding-right: 4px;
+}
+
+.result-counts {
     flex: none;
     -webkit-flex: none;
     padding-right: 10px;
@@ -388,7 +405,7 @@ th-watched-repo {
 .revision-text {
     overflow: hidden;
     text-overflow: ellipsis;
-    width: 95px;
+    width: 7.2em;
     display: inline-block;
     vertical-align: middle;
 }
@@ -890,12 +907,6 @@ ul.failure-summary-list li .btn-xs {
     margin-top: 0.3em;
 }
 
-.timestamp-name {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
 .annotations-panel {
     overflow: scroll;
     margin-right: 0;
@@ -909,10 +920,6 @@ ul.failure-summary-list li .btn-xs {
     list-style: none inside none;
     padding-left: 0;
 }
-
-
-
-
 
 /**
  * RESULT STATUS COUNTS

--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -11,13 +11,11 @@
     <div class="result-set-title">
       <span class="result-set-title-left">
         <span class="btn btn-default btn-sm glyphicon glyphicon-download" ng-show="isLoadingJobs"></span>
-        <span class="timestamp-name">
-          <span>
-            <a href="{{::revisionResultsetFilterUrl}}"
-               title="open this resultset in new tab"
-               target="_blank">{{::resultsetDateStr}}</a> - </span>
-          <th-author author="{{::resultset.author}}"></th-author>
-        </span>
+        <span>
+          <a href="{{::revisionResultsetFilterUrl}}"
+             title="open this resultset in new tab"
+             target="_blank">{{::resultsetDateStr}}</a> - </span>
+        <th-author author="{{::resultset.author}}"></th-author>
       </span>
       <span class="result-set-buttons">
         <span class="revision-text">{{::resultset.revision}}</span>
@@ -42,7 +40,10 @@
       <span class="btn btn-default btn-sm btn-resultset revision-button"
             tabindex="0" role="button"
             ng-click="toggleRevisions()"
-            title="show revisions"><i class="fa fa-code-fork fa-lg"></i> {{::resultset.revision_count}}</span>
+            title="show revisions">
+        <i class="fa fa-code-fork fa-lg
+                  result-set-fa-icon"></i> {{::resultset.revision_count}}
+      </span>
       <th-result-counts class="result-counts"/>
     </div>
     <div class="result-set-body" th-clone-jobs ></div>

--- a/webapp/app/partials/main/thResultCounts.html
+++ b/webapp/app/partials/main/thResultCounts.html
@@ -2,7 +2,7 @@
           tabindex="0" role="button"
           ng-click="toggleJobs()"
           title="total job count - toggle jobs">
-            <i class="fa fa-list fa-lg"></i>
+            <i class="fa fa-list fa-lg result-set-fa-icon"></i>
             <span class="result-status-total-value"></span>
     </span>
     <span class="result-status-count-group">


### PR DESCRIPTION
This work fixes Bugzilla bug [1106120](https://bugzilla.mozilla.org/show_bug.cgi?id=1106120).

This aligns the result set title elements, so particularly when collapsed via the Collapse/Expand Result Sets button, they are more readable. In doing so, the authors' name will be clipped and ellipsized if it is exceptionally long. I set the width at `23.5em` to accommodate as many users as possible, particularly the sheriffs, while not making the overall title too much wider.

There were more severe examples, but here is a before and after:

![resultsettitlecurrent](https://cloud.githubusercontent.com/assets/3660661/5231050/aecafdf0-76fe-11e4-8b71-eebfc40c113b.jpg)

![resultsettitleproposed](https://cloud.githubusercontent.com/assets/3660661/5231140/18539efc-7700-11e4-9dbf-7476b15870b9.jpg)

I also took the opportunity to adjust it so that with that em spacing, when the platform is fully 'expanded', the Total Job Count button is aligned flush left with the Platform/Job block. At least at default browser font size, on Windows. Whether that matches on OSX or Linux is perhaps unlikely, but there was intent at least in that em width.

![resultsettitlefullwidth](https://cloud.githubusercontent.com/assets/3660661/5231062/d7850a88-76fe-11e4-8fe1-582eeb41ae66.jpg)

The Show Revisions and Total Job Count icons received a `float left` to align their interior icons, but it seems contained within that element and not subject to a containing flexbox. Also `timestamp-name` didn't appear required any more, so it was removed.

I've tested it on both Firefox and Chrome, and it all seems reasonable.

Tested on Windows:
FF Release **33.1.1**
Chrome Latest Release **39.0.2171.71 m**

Adding @wlach for review and @edmorley for visibility.
