### PR TITLE
Bug 1106303 - Add missing divider between Help and User buttons

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -88,14 +88,14 @@ th-watched-repo {
     padding-right: 14px;
 }
 
-.nav-filter-btn {
+.nav-menu-btn {
     margin-right: -4px;
     padding-left: 14px;
     padding-right: 14px;
 }
 
 .nav-help-btn {
-    margin-right: -9px;
+    margin-right: -4px;
 }
 
 .nav-help-icon {
@@ -133,8 +133,16 @@ th-watched-repo {
     overflow: visible;
 }
 
-.th-username {
-    margin-right: 5px;
+/* Unique navbar username styles */
+.th-username, th-username:hover {
+    padding-left: 18px;
+    cursor: default;
+    color: #777 !important;
+    border-color: #373d40;
+    border-radius: 0;
+    border-top: 0;
+    border-bottom: 0;
+    border-right: 0;
 }
 
 .th-context-navbar {

--- a/webapp/app/partials/main/thGlobalTopNavPanel.html
+++ b/webapp/app/partials/main/thGlobalTopNavPanel.html
@@ -40,7 +40,7 @@
                 </span>
 
                 <!-- Global Filter Button -->
-                <span class="btn btn-view-nav btn-right-navbar nav-filter-btn"
+                <span class="btn btn-view-nav btn-right-navbar nav-menu-btn"
                       title="Global job filters"
                       ng-class="{'active': (isFilterPanelShowing)}"
                       ng-click="setFilterPanelShowing(!isFilterPanelShowing)"
@@ -57,9 +57,9 @@
                    title="Treeherder help" href="help.html" target="_blank">
                     <span class="fa fa-question-circle lightgray nav-help-icon"></span></a>
 
-                <span class="nav-text white th-username">{{user.email}}</span>
-                <!--TODO: change this condition to enable the settings panel-->
-                <span ng-show="false" class="btn btn-view-nav btn-right-navbar"
+                <!-- Settings Button - currently suppressed -->
+                <span ng-show="false"
+                      class="btn btn-view-nav btn-right-navbar nav-menu-btn"
                       ng-class="{'active': (isSettingsPanelShowing)}"
                       ng-click="setSettingsPanelShowing(!isSettingsPanelShowing)"
                       tabindex="0"
@@ -69,6 +69,13 @@
                     <i class="fa fa-angle-up lightgray"
                        ng-show="isSettingsPanelShowing"></i>
                 </span>
+
+                <!-- User Field if logged in -->
+                <span class="btn btn-right-navbar th-username"
+                      ng-if="{{user.email}}">
+                    {{user.email}}</span>
+
+                <!-- Login/Register Button -->
                 <persona-buttons></persona-buttons>
             </span>
         </span>


### PR DESCRIPTION
This work fixes Bugzilla bug [1106303](https://bugzilla.mozilla.org/show_bug.cgi?id=1106303).

This addresses the missing menu divider I noticed in philor's unrelated bug [1106145](https://bugzilla.mozilla.org/show_bug.cgi?id=1106145) between the Help button and the user id, when a user is logged in.

Since the user id is not a menu or button, I didn't want any hover behaviors inherited from the existing navbar classes. So, `th-username` gets a mix of its own properties, a overriding hover, but inherits other common properties where possible.

There is a minor tweak I could have done, adding `margin-right: -4px; padding-right: 16px` to which would make the container "perfect" - but since it has no hover or selection, it seems fine to omit that. It leaves an invisible 4px space at the right  if you inspect the element, but the button UI width presented to the user, is correct.

IIRC, this negative margin compensation stuff is all a by product of a Repo menu offset which we want to keep. Perhaps we can improve all this inheritance later.

Here's philor's appearance from his bug on OSX:

![missingdividernavbar](https://cloud.githubusercontent.com/assets/3660661/5252072/8fb6c69e-7968-11e4-821c-53a1ca271d45.jpg)

Here's my local before, on Windows looking similar (Settings button exposed):

![missingdividernavbarcurrent](https://cloud.githubusercontent.com/assets/3660661/5252077/9b0c9276-7968-11e4-83fe-9233b3fd3e51.jpg)

And after the fix:

![missingdividernavbarpropose](https://cloud.githubusercontent.com/assets/3660661/5252080/9efe6580-7968-11e4-92ca-d7f7c9c89401.jpg)

Note I turned the ng directives on during the work and to generate the screen grabs above, which is why the Login state doesn't match. I created a consolidated `nav-menu-btn` class which is now shared with the Settings and Filter button, so Settings will also look correct, should we ever turn it back on.

I switched the order so the user id is adjacent the Login/Logout persona button, if that makes sense. The user id field uses the same `#777` as the main Treeherder logo, to imply they share the same inert behavior.

Tested on Windows:
FF Release **33.1.1**
Chrome Latest Release **39.0.2171.71 m**

Adding @wlach and/or @camd for review and @edmorley for visibility.
