### PR TITLE
No bug - Clean up in-progress shortcut key conditional

### DIFF
--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -52,7 +52,7 @@ treeherder.controller('MainCtrl', [
             // test for key modifiers to allow browser shortcuts eg.
             // console, new/private browsing window, history, print
             if (!ev.metaKey && !ev.shiftKey && !ev.ctrlKey) {
-                if ((ev.keyCode === 73)) {
+                if (ev.keyCode === 73) {
                     // toggle display in-progress jobs(pending/running), key:i
                     $scope.toggleInProgress();
 


### PR DESCRIPTION
Nothing exciting, I just noticed this in passing while doing other shortcut work for bug  [1030686](https://bugzilla.mozilla.org/show_bug.cgi?id=1030686). It wasn't really within the scope of that work, so I thought I'd fix it separately.

nb. Toggle in-progress jobs isn't working currently per [1106646](https://bugzilla.mozilla.org/show_bug.cgi?id=1106646) due to other reasons.

Tested on Windows:
FF Release **33.1.1**
Chrome Latest Release **39.0.2171.71 m**

Adding @wlach for review.
