### PR TITLE
Bug 1106842 - Fix filtering by job name from the job details pane

### DIFF
--- a/webapp/app/js/directives/main.js
+++ b/webapp/app/js/directives/main.js
@@ -85,9 +85,8 @@ treeherder.directive('thFilterByBuildername', [
 
                         thJobFilters.setSearchQuery(scope.buildbotJobname || "");
 
-                        // Need to tell angular to run the digest cycle
-                        // to process the new values in
-                        // thJobFilters.searchQuery
+                        // Need to tell angular to run the digest cycle to
+                        // process the new values in thJobFilters.searchStr
                         if(!scope.$$phase){
                             scope.$apply();
                         }

--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -33,7 +33,8 @@ treeherder.controller('PluginCtrl', [
                 delimiter = '&';
             }
 
-            $scope.buildbotJobnameHref = absUrl + delimiter + 'searchQuery=' + buildername;
+            $scope.buildbotJobnameHref = absUrl + delimiter +
+                                         'filter-searchStr=' + buildername;
 
         };
 


### PR DESCRIPTION
This work fixes Bugzilla bug [1106842](https://bugzilla.mozilla.org/show_bug.cgi?id=1106842).

With the recent changes to filtering, the job details filter link in shown in blue below, needed to reflect the new filter parameter.

![jobdetailfilter](https://cloud.githubusercontent.com/assets/3660661/5271083/29044ebc-7a3f-11e4-8fb6-7544b0b3a72a.jpg)

Here is the above link result, before the fix:

![jobdetailfiltercurrent](https://cloud.githubusercontent.com/assets/3660661/5271092/42b22d66-7a3f-11e4-8f33-478554a170ee.jpg)

And after the fix:

![jobdetailfilterfixed](https://cloud.githubusercontent.com/assets/3660661/5271094/461b6148-7a3f-11e4-9673-bea2f0af013b.jpg)

Everything seems to be working correctly on both Firefox and Chrome, in basic testing.

Tested on Windows:
FF Release **33.1.1**
Chrome Latest Release **39.0.2171.71 m**

Adding @wlach and/or @camd for review and @KWierso for visibility.
