### PR TITLE
Bug 1030686 - Add keyboard shortcut for save job classification

### DIFF
--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -120,12 +120,14 @@
                     <td>Highlight previous unstarred failure</td></tr>
                     <tr><th>u</th>
                     <td>Show only unstarred failures</td></tr>
-                    <tr><th>ctrl/cmd<span> click</span></th>
-                    <td>Add job to the pinboard</td></tr>
+                    <tr><th>ctrl<span> or </span>cmd</span></th>
+                    <td>Add job to the pinboard during selection</td></tr>
                     <tr><th>spacebar</th>
                     <td>Add a selected job to the pinboard</td></tr>
                     <tr><th>r</th>
                     <td>Add a selected job to the pinboard + enter related bug</td></tr>
+                    <tr><th>ctrl<span> + </span>enter</th>
+                    <td>Save pinboard classification and related bugs</td></tr>
                     <tr><th>i</th>
                     <td>Toggle in-progress (running/pending) jobs</td></tr>
                 </table>

--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -95,6 +95,12 @@ treeherder.controller('MainCtrl', [
                     $scope.setSheriffPanelShowing(false);
                     $scope.closeJob();
                 }
+
+            // Ctrl+Enter saves pinboard classification and related bugs
+            } else if (!ev.metaKey && !ev.altKey && !ev.shiftKey && ev.ctrlKey) {
+                if ((ev.keyCode == 13) && $scope.selectedJob) {
+                  $rootScope.$emit(thEvents.saveClassification);
+                }
             }
         };
 

--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -231,6 +231,8 @@ treeherder.provider('thEvents', function() {
 
             addRelatedBug: "add-related-bug-EVT",
 
+            saveClassification: "save-classification-EVT",
+
             searchPage: "search-page-EVT",
 
             selectJob: "select-job-EVT",

--- a/webapp/app/partials/main/thPinboardPanel.html
+++ b/webapp/app/partials/main/thPinboardPanel.html
@@ -57,7 +57,7 @@
   <div class="btn-group"
        ng-show="hasPinnedJobs()">
     <span class="btn btn-default btn-xs save-btn"
-          title="save classification and bug associations"
+          title="Save classification and related bugs"
           ng-click="save()">
       <span class="fa fa-floppy-o pull-left btn-icon-top-margin"></span> save
     </span>

--- a/webapp/app/plugins/pinboard.js
+++ b/webapp/app/plugins/pinboard.js
@@ -23,6 +23,12 @@ treeherder.controller('PinboardCtrl', [
             $scope.toggleEnterBugNumber();
         });
 
+        $rootScope.$on(thEvents.saveClassification, function(event) {
+            if ($scope.isPinboardVisible) {
+                $scope.save();
+            }
+        });
+
         $scope.pinJob = function(job) {
             thPinboard.pinJob(job);
             if (!$scope.selectedJob) {


### PR DESCRIPTION
This work fixes 'part 3' of Bugzilla bug [1030686](https://bugzilla.mozilla.org/show_bug.cgi?id=1030686) requested by philor in [comments 8 and 11](https://bugzilla.mozilla.org/show_bug.cgi?id=1030686#c11).

This feature saves a job classification in its entirety, on a ctrl + enter.

I've only run it locally without a vagrant, so I can't confirm the actual save is occurring, but it is functionally doing the same as the save() when pressing the equivalent menu entry. I've tried it in workflows using the new 'r' for pin plus enter a related bug, regular pinning, and you can do everything including save without taking your hands off the keyboard.

Here's a screen grab of an attempted save (not logged in). An expected save() and result:

![saveclassificationshortcut](https://cloud.githubusercontent.com/assets/3660661/5284747/7e66c0a6-7ae4-11e4-8adc-ed5bf88ac573.jpg)

I updated the help as usual with the new entry 2nd from the bottom. I tweaked the wording of select to pin also while I was there, for more clarity.

![saveclassificationshortcuth](https://cloud.githubusercontent.com/assets/3660661/5284777/a8e52ba6-7ae4-11e4-9c26-7dff8cecb747.jpg)

This all very much mimics the previous work in PR https://github.com/mozilla/treeherder-ui/pull/281, and will be similar to the shortcut to enter a classification, still tbd.

I am also testing against the Alt modifier to ensure it is not also depressed at the same time. Otherwise I could depress Alt+Ctrl+Enter and issue the save(). I am not sure why the bulk of the other shortcuts don't test for Alt but it seems reasonable in this case. Let me know if I should exclude it.

We also test to make sure the pinboard is visible, per the thread with philor in [comment 18](https://bugzilla.mozilla.org/show_bug.cgi?id=1030686#c18).

Tested on Windows:
FF Release **33.1.1**
Chrome Latest Release **39.0.2171.71 m**

Adding @camd and/or @maurodoglio for review, and @edmorley for visibility.
