### PR TITLE
Bug 1107128 - Improve the failed classification save message

### DIFF
--- a/webapp/app/plugins/pinboard.js
+++ b/webapp/app/plugins/pinboard.js
@@ -62,7 +62,7 @@ treeherder.controller('PinboardCtrl', [
                 thPinboard.save(classification);
                 $scope.classification = thPinboard.createNewClassification();
             } else {
-                thNotify.send("must be logged in to classify jobs", "danger");
+                thNotify.send("must be logged in to save job classifications", "danger");
             }
         };
 
@@ -71,7 +71,7 @@ treeherder.controller('PinboardCtrl', [
                 $scope.classification.who = $scope.user.email;
                 thPinboard.saveClassificationOnly($scope.classification);
             } else {
-                thNotify.send("must be logged in to classify jobs", "danger");
+                thNotify.send("must be logged in to save job classifications", "danger");
             }
         };
 
@@ -79,7 +79,7 @@ treeherder.controller('PinboardCtrl', [
             if ($scope.user.loggedin) {
                 thPinboard.saveBugsOnly();
             } else {
-                thNotify.send("must be logged in to classify jobs", "danger");
+                thNotify.send("must be logged in to save job classifications", "danger");
             }
         };
 


### PR DESCRIPTION
This work fixes Bugzilla bug [1107128](https://bugzilla.mozilla.org/show_bug.cgi?id=1107128).

Pretty straightforward here, I've provided context in the bug for the rationale on the wording change.

![errordialogue](https://cloud.githubusercontent.com/assets/3660661/5286269/c1f6a5c8-7af0-11e4-9fd1-717faed09522.jpg)

Tested on Windows:
FF Release **33.1.1**
Chrome Latest Release **39.0.2171.71 m**

Adding @edmorley for review.
