### PR TITLE
Bug 1059317 - Move talos stats to a separate panel

### DIFF
--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -86,6 +86,14 @@ treeherder.controller('PluginCtrl', [
                     $scope.eta = $scope.job.get_current_eta();
                     $scope.eta_abs = Math.abs($scope.job.get_current_eta());
                     $scope.typical_eta = $scope.job.get_typical_eta()
+                    // this is a bit hacky but for now talos is the only exception we have
+                    if($scope.job.job_group_name == 'Talos Performance'){
+                        $scope.tabService.tabs.talos.enabled = true;
+                        $scope.tabService.selectedTab = 'talos';
+                    }else{
+                        $scope.tabService.tabs.talos.enabled = false;
+                    }
+
                     // the second result come from the buildapi artifact promise
                     var buildapi_artifact = results[1];
                     if (buildapi_artifact.length > 0 &&

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -171,22 +171,7 @@
             <span ng-switch on="line.content_type">
               <a ng-switch-when="link" title="{{::line.value}}" href="{{::line.url}}" target="_blank">{{::line.value}}</a>
               <span ng-switch-when="raw_html" ng-bind-html="line.value"></span>
-              <ul ng-switch-when="TalosResult">
-                <li>Datazilla:
-                  <ul>
-                    <li ng-repeat="(k,v) in line.value.datazilla"><a href="{{::v.url}}" target="_blank">{{::k}}</a>
-                    </li>
-                  </ul>
-                </li>
-
-                <li>Graphserver:
-                  <ul>
-                    <li ng-repeat="(k,v) in line.value.graphserver">{{::k}}:<a href="{{::v.url}}"
-                                                                             target="_blank">{{::v.result}}</a>
-                    </li>
-                  </ul>
-                </li>
-              </ul>
+              <span ng-switch-when="TalosResult">See talos panel</span>
               <span title="{{::line.value}}" ng-switch-when="object">{{::line.value}}</span>
               <span title="{{::line.value}}" ng-switch-default>{{::line.value}}</span>
             </span>
@@ -223,6 +208,14 @@
                href="" prevent-default-on-left-click
                ng-click="tabService.showTab('similarJobs', job.id)">
               Similar jobs
+            </a>
+          </li>
+          <li ng-if="tabService.tabs.talos.enabled" 
+              ng-class="{'active': tabService.selectedTab == 'talos'}">
+            <a title="show talos job details"
+               href="" prevent-default-on-left-click
+               ng-click="tabService.showTab('talos', job.id)">
+              Talos
             </a>
           </li>
         </ul>

--- a/webapp/app/plugins/tabs.js
+++ b/webapp/app/plugins/tabs.js
@@ -10,28 +10,39 @@ treeherder.factory('thTabs', [
             "tabs": {
                 "failureSummary": {
                     title: "Failure summary",
-                    content: "plugins/failure_summary/main.html"
+                    content: "plugins/failure_summary/main.html",
+                    enabled: true
                 },
                 "annotations": {
                     title: "Annotations",
-                    content: "plugins/annotations/main.html"
+                    content: "plugins/annotations/main.html",
+                    enabled: true
                 },
                 "similarJobs": {
                     title: "Similar jobs",
-                    content: "plugins/similar_jobs/main.html"
+                    content: "plugins/similar_jobs/main.html",
+                    enabled: true
+                },
+                "talos": {
+                    title: "Job Info",
+                    content: "plugins/talos/main.html",
+                    enabled: false
                 }
             },
             "selectedTab": "failureSummary",
             "showTab" : function(tab, contentId){
                 thTabs.selectedTab = tab;
+                if(!thTabs.tabs[thTabs.selectedTab].enabled){
+                    thTabs.selectedTab = 'failureSummary';
+                }
                 // if the tab exposes an update function, call it
                 // only refresh the tab if the content hasn't been loaded yet
                 // or we don't have an identifier for the content loaded
-                if(angular.isUndefined(thTabs.tabs[tab].contentId)
-                    || thTabs.tabs[tab].contentId != contentId){
-                    if(angular.isFunction(thTabs.tabs[tab].update)){
-                        thTabs.tabs[tab].contentId = contentId;
-                        thTabs.tabs[tab].update();
+                if(angular.isUndefined(thTabs.tabs[thTabs.selectedTab].contentId)
+                    || thTabs.tabs[thTabs.selectedTab].contentId != contentId){
+                    if(angular.isFunction(thTabs.tabs[thTabs.selectedTab].update)){
+                        thTabs.tabs[thTabs.selectedTab].contentId = contentId;
+                        thTabs.tabs[thTabs.selectedTab].update();
                     }
                 }
             }

--- a/webapp/app/plugins/talos/main.html
+++ b/webapp/app/plugins/talos/main.html
@@ -1,0 +1,18 @@
+<span ng-repeat="line in job_details">
+  <ul ng-if="line.content_type == 'TalosResult'">
+    <li>Datazilla:
+      <ul>
+        <li ng-repeat="(k,v) in line.value.datazilla"><a href="{{::v.url}}" target="_blank">{{::k}}</a>
+        </li>
+      </ul>
+    </li>
+
+    <li>Graphserver:
+      <ul>
+        <li ng-repeat="(k,v) in line.value.graphserver">{{::k}}:<a href="{{::v.url}}"
+                                                                 target="_blank">{{::v.result}}</a>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</span>


### PR DESCRIPTION
This patch creates a new panel dedicated to the talos results.
The way the talos panel is enabled and disabled is a bit hacky, but for now we don't have any other exception like this. We may want to think about a more elegant solution if we face another case like this in the future
