### PR TITLE
Bug 1107719 - De-bold purple infra-exception jobs

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1283,7 +1283,6 @@ fieldset[disabled] .btn-green.active {
 .btn-purple {
   background-color: #9a7da6;
   border-color: #6f0296;
-  font-weight: bold;
   color: white;
 }
 .btn-purple:hover,


### PR DESCRIPTION
This fixes Bugzilla bug [1107719](https://bugzilla.mozilla.org/show_bug.cgi?id=1107719).

Not to much to report here, I believe we intend to have a normal font for purple infra jobs, so they are consistent with red/orange failures. Rather than bold as they currently are:

![purpleboldcurrent](https://cloud.githubusercontent.com/assets/3660661/5311281/d6b65348-7c10-11e4-9a0a-e746954c1a18.jpg)

Tested on Windows:
FF Release **33.1.1**
Chrome Latest Release **39.0.2171.71 m**

Adding @edmorley for review.
