### PR TITLE
Bug 1107940 - Remove unused partials from the repo

### DIFF
--- a/webapp/app/partials/main/revisionListModal.html
+++ b/webapp/app/partials/main/revisionListModal.html
@@ -1,3 +1,0 @@
-<div class="modal-body">
-    <div ng-repeat="revision in revisions">{{::currentRepo.url}}/rev/{{::revision.revision}}</div>
-</div>

--- a/webapp/app/partials/main/thStar.html
+++ b/webapp/app/partials/main/thStar.html
@@ -1,5 +1,0 @@
-<span class="label {{::badgeColorClass}}"
-   title="hoverText"
-   ng-show="note">
-   <i class="glyphicon glyphicon-star-empty"></i>
-</span>


### PR DESCRIPTION
This fixes Bugzilla bug [1107940](https://bugzilla.mozilla.org/show_bug.cgi?id=1107940).

This removes what I believe to be two unused partials from the repo. It would be helpful if in review a double check could be done, just for a second opinion before it's merged.

I've run a local branch and the platform appears to be behaving correctly without them.

We may want also consider removing the unused`thSettingsPanel` partial and its controller. I guess it depends if we still intend to have a Settings panel. I'll mention that in the bug thread in case someone wants that included.

Tested on Windows:
FF Release **33.1.1**
Chrome Latest Release **39.0.2171.71 m**

Adding @camd and/or @maurodoglio for review.

nb. if you are seeing a user.email console error when you get to this review, it's addressed by open PR https://github.com/mozilla/treeherder-ui/pull/292.
