### PR TITLE
Bug 1108871 - handle option_collections in the job_exclusions

### DIFF
--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -83,6 +83,7 @@
         <script src="js/models/job_type.js"></script>
         <script src="js/models/job_log_url.js"></script>
         <script src="js/models/option.js"></script>
+        <script src="js/models/option_collection.js"></script>
         <script src="js/models/user.js"></script>
         <!-- Controllers -->
         <script src="js/controllers/main.js"></script>

--- a/webapp/app/js/models/job_exclusion.js
+++ b/webapp/app/js/models/job_exclusion.js
@@ -80,7 +80,7 @@ treeherder.factory('ThJobExclusionModel', [
             )
             .then(
                 function(response){
-                    angular.extend(job_filter, response.data.id);
+                    angular.extend(job_filter, response.data);
                     thNotify.send("Job filter successfully updated", "success");
                 },
                 function(reason){

--- a/webapp/app/js/models/option_collection.js
+++ b/webapp/app/js/models/option_collection.js
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+treeherder.factory('ThOptionCollectionModel', [
+    '$http', '$log', 'thUrl',
+    function($http, $log, thUrl) {
+    // ThOptionCollectionModel is the js counterpart of option
+
+    var ThOptionCollectionModel = function(data) {
+        // creates a new instance of ThOptionCollectionModel
+        // using the provided properties
+        angular.extend(this, data);
+    };
+
+    ThOptionCollectionModel.get_uri = function(){return thUrl.getRootUrl("/optioncollection/");};
+
+    ThOptionCollectionModel.get_list = function(options) {
+        options = options || {};
+        // a static method to retrieve a list of ThOptionCollectionModel
+        var query_string = $.param(options);
+        return $http.get(ThOptionCollectionModel.get_uri()+"?"+query_string)
+            .then(function(response) {
+                var item_list = [];
+                angular.forEach(response.data, function(elem){
+                    item_list.push(new ThOptionCollectionModel(elem));
+                });
+                return item_list;
+        });
+    };
+
+    ThOptionCollectionModel.get = function(pk) {
+        // a static method to retrieve a single instance of ThOptionCollectionModel
+        return $http.get(ThOptionCollectionModel.get_uri()+pk).then(function(response) {
+            return new ThOptionCollectionModel(response.data);
+        });
+    };
+
+    return ThOptionCollectionModel;
+}]);

--- a/webapp/app/partials/main/thSheriffPanel.html
+++ b/webapp/app/partials/main/thSheriffPanel.html
@@ -92,7 +92,7 @@
                     <th>Description</th>
                     <th>Repositories</th>
                     <th>Platform</th>
-                    <th>Options</th>
+                    <th>Option Collections</th>
                     <th>Job Type</th>
                     <th>Actions</th>
                 </tr>
@@ -101,7 +101,7 @@
                     <td>{{::exclusion.description}}</td>
                     <td><th-truncated-list visible="2" elements="exclusion.info.repos" /></td>
                     <td><th-truncated-list visible="2" elements="exclusion.info.platforms" /></td>
-                    <td><th-truncated-list visible="2" elements="exclusion.info.options" /></td>
+                    <td><th-truncated-list visible="2" elements="exclusion.info.option_collections" /></td>
                     <td><th-truncated-list visible="2" elements="exclusion.info.job_types" /></td>
                     <td>
                         <button ng-click="init_exclusion_update(exclusion)" type="button" class="btn btn-default btn-xs">
@@ -148,8 +148,8 @@
                         <th-multi-select left-list="form_platforms" right-list="form_exclusion.info.platforms"></th-multi-select>
                     </div>
                     <div class="form-group">
-                        <label>Options</label>
-                        <th-multi-select left-list="form_options" right-list="form_exclusion.info.options"></th-multi-select>
+                        <label>Option Collections</label>
+                        <th-multi-select left-list="form_option_collections" right-list="form_exclusion.info.option_collections"></th-multi-select>
                     </div>
                     <div class="form-group">
                         <label>Job Types</label>


### PR DESCRIPTION
This fixes bug 1108871
The UI companion to https://github.com/mozilla/treeherder-service/pull/294

**STATE**
This feels solid to me, but I haven't had too much time to test it.  So if we want to push to production, then merge this to master for more testing on dev/stage, that's fine by me.

**Changes**
This changes the `options` values in the `job_exclusions` to be `option_collections`.  When we save to the service, we add a field called `option_collection_hashes` which is used on the service.  But both the textual and the hashes are saved for convenience.

I had to add temporary handling for JSON field name change from `options` to `option_collections` to aid in migrating from the older versions of the exclusions.

When this is pushed, we need to go to every `job_exclusion` and `exclusion_profile` and re-save them to update the json.  `job_exclusions` first.
