### PR TITLE
Bug 1109351 - fix searchStr handling wrt buildername

### DIFF
--- a/webapp/app/js/controllers/filters.js
+++ b/webapp/app/js/controllers/filters.js
@@ -209,7 +209,19 @@ treeherder.controller('SearchCtrl', [
     function SearchCtrl(
         $scope, $rootScope, thEvents, thJobFilters, $location){
 
-        $scope.searchQueryStr = thJobFilters.getFieldFiltersObj().searchStr;
+        var getSearchStr = function() {
+            var ss = thJobFilters.getFieldFiltersObj().searchStr;
+            if (ss) {
+                return ss.join(" ");
+            } else {
+                return "";
+            }
+        };
+
+        $scope.searchQueryStr = getSearchStr();
+        $rootScope.$on(thEvents.globalFilterChanged, function() {
+            $scope.searchQueryStr = getSearchStr();
+        });
 
         $scope.search = function(ev){
             //User hit enter

--- a/webapp/app/js/directives/main.js
+++ b/webapp/app/js/directives/main.js
@@ -82,14 +82,7 @@ treeherder.directive('thFilterByBuildername', [
                     // Only execute the in page search if the
                     // user does a left click
                     if(event.which === 1){
-
-                        thJobFilters.setSearchQuery(scope.buildbotJobname || "");
-
-                        // Need to tell angular to run the digest cycle to
-                        // process the new values in thJobFilters.searchStr
-                        if(!scope.$$phase){
-                            scope.$apply();
-                        }
+                        thJobFilters.replaceFilter('searchStr', scope.buildbotJobname || null);
                     }
                 });
             }

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -129,9 +129,9 @@
         <li class="small">
           <label>Job:</label>
           <a title="Filter jobs like these in a new tab"
-             href="{{::buildbotJobnameHref}}" target="_blank"
+             href="{{buildbotJobnameHref}}"
              prevent-default-on-left-click th-filter-by-buildername>
-            {{::buildbotJobname}}</a>
+            {{buildbotJobname}}</a>
         </li>
         <li class="small">
           <label>Machine name:</label>
@@ -223,7 +223,7 @@
               Similar jobs
             </a>
           </li>
-          <li ng-if="tabService.tabs.talos.enabled" 
+          <li ng-if="tabService.tabs.talos.enabled"
               ng-class="{'active': tabService.selectedTab == 'talos'}">
             <a title="show talos job details"
                href="" prevent-default-on-left-click


### PR DESCRIPTION
This PR fixes clicking the buildername.  
**left-click**  - filters in current window - no reload 
**right-click** - allows opening in a new tab, filtered to that buildername
