### PR TITLE
Bug 1110892 - fixed array handling issues on query params

### DIFF
--- a/webapp/app/js/services/jobfilters.js
+++ b/webapp/app/js/services/jobfilters.js
@@ -492,8 +492,8 @@ treeherder.factory('thJobFilters', [
      * check if we're in the state of showing only unclassified failures
      */
     var _isUnclassifiedFailures = function() {
-        return (_.isEqual($location.search()[QS_RESULT_STATUS], thFailureResults) &&
-                _.isEqual($location.search()[QS_CLASSIFIED_STATE], ['unclassified']));
+        return (_.isEqual(_toArray($location.search()[QS_RESULT_STATUS]), thFailureResults) &&
+                _.isEqual(_toArray($location.search()[QS_CLASSIFIED_STATE]), ['unclassified']));
     };
 
     var _matchesDefaults = function(field, values) {

--- a/webapp/app/vendor/jquery.deparam.js
+++ b/webapp/app/vendor/jquery.deparam.js
@@ -1,8 +1,10 @@
 /**
  * jQuery.deparam - The oposite of jQuery param. Creates an object of query string parameters.
- * 
+ *
  * Credits for the idea and Regex:
  * http://stevenbenner.com/2010/03/javascript-regex-trick-parse-a-query-string-into-an-object/
+ *
+ * :camd - added support for multiple values of the same param
 */
 (function($){
   $.deparam = $.deparam || function(uri){
@@ -13,7 +15,16 @@
     uri.replace(
       new RegExp(
         "([^?=&]+)(=([^&#]*))?", "g"),
-        function($0, $1, $2, $3) { queryString[$1] = $3; }
+        function($0, $1, $2, $3) {
+            if (queryString.hasOwnProperty($1)) {
+                if (!$.isArray(queryString[$1])) {
+                    queryString[$1] = [queryString[$1]]
+                }
+                queryString[$1].push($3);
+            } else {
+                queryString[$1] = $3;
+            }
+        }
       );
       return queryString;
     };


### PR DESCRIPTION
When we have multiple values for the same query param,
not all the code was creating an array for the values.  The deparam was
just giving you the last one in the list.  this caused the check for changes to in most cases (unless the last in the list happened to be changed).

The check for whether we were in unclassified failure only state was also broken on initial page load.  By assuring the values we check are arrays, it fixes it.  Otherwise, you had to click the button twice to get back to default view state.
