### PR TITLE
Bug 1060058 - clipping of logviewer UI in smaller browsers is patched 

### DIFF
--- a/webapp/app/css/logviewer.css
+++ b/webapp/app/css/logviewer.css
@@ -61,7 +61,17 @@ body {
     padding: 20px 5px 4px;
     display: table-row;
 }
+.run-data .break-word{
+    -ms-word-break: break-all;
+    word-break: break-all;
 
+    /* Non standard for webkit */
+    word-break: break-word;
+
+    -webkit-hyphens: auto;
+    -moz-hyphens: auto;
+    hyphens: auto;
+}
 .run-data .steps-data {
     max-height: 210px;
     overflow: auto;
@@ -78,6 +88,7 @@ body {
     -ms-user-select: text;
     -o-user-select: text;
     user-select: text;
+    white-space: normal;
 }
 
 .logviewer-step.selected {
@@ -115,9 +126,7 @@ body {
 }
 
 .lv-log-msg {
-    position: fixed;
-    top: 530px;
-    left: 3%;
+    position: relative;
     font-weight: bold;
 }
 
@@ -138,4 +147,9 @@ body {
 
 .lv-log-error {
     border: 2px solid #ff0000;
+}
+.job-header{
+    max-height:270px;
+    overflow-y:auto;
+    margin-bottom:20px;
 }

--- a/webapp/app/logviewer.html
+++ b/webapp/app/logviewer.html
@@ -12,23 +12,26 @@
     </head>
     <body class="body-logviewer">
         <div class="run-data">
-            <div class="col-md-6">
-                <table class="table table-condensed">
-                    <tr ng-repeat="(label, value) in artifact.header">
-                        <th ng-cloak>{{label}}</th>
-                        <td ng-if="label == 'revision'">
-                            <a href="{{logRevisionFilterUrl}}"
-                               title="open resultset in new tab"
-                               target="_blank"
-                               class="repo-link"
-                               ng-cloak>{{value}}</a>
-                        </td>
-                        <td ng-if="label == 'starttime'"
-                            ng-cloak>{{logDisplayDate}}</td>
-                        <td ng-if="label != 'revision' && label != 'starttime'"
-                            ng-cloak>{{value}}</td>
-                    </tr>
-                </table>
+            <div class="col-md-6" >
+                <div class="job-header">
+                    <table class="table table-condensed" >
+                        <tr ng-repeat="(label, value) in artifact.header">
+                            <th ng-cloak>{{label}}</th>
+                            <td ng-if="label == 'revision'" class="break-word">
+                                {{value}}
+                                <a href="{{logRevisionFilterUrl}}"
+                                   title="open resultset in new tab"
+                                   target="_blank"
+                                   class="repo-link"
+                                   ng-cloak>link</a>
+                            </td>
+                            <td ng-if="label == 'starttime'"
+                                ng-cloak class="break-word">{{logDisplayDate}}</td>
+                            <td ng-if="label != 'revision' && label != 'starttime'"
+                                ng-cloak class="break-word">{{value}}</td>
+                        </tr>
+                    </table>
+                </div>
             </div>
 
             <div class="col-md-6" lv-log-steps></div>

--- a/webapp/app/partials/logviewer/lvLogSteps.html
+++ b/webapp/app/partials/logviewer/lvLogSteps.html
@@ -7,7 +7,7 @@
          ng-if="showSuccessful === true || step.result !== 'success'"
          class="btn btn-block logviewer-step clearfix"
          order="{{step.order}}">
-        <span class="pull-left clearfix">
+        <span class="pull-left clearfix text-left">
             {{::step.order+1}}. {{::step.name}}
         </span>
 
@@ -25,7 +25,7 @@
                  ng-class="{'lv-line-highlight': check}"
                  ng-click="scrollTo($event, step, error.linenumber);"
                  class="text-left pull-left lv-error-line">
-                <span class="label label-default lv-line-no">
+                <span class="label label-default lv-line-no text-left">
                     {{::error.linenumber}}
                 </span>
 


### PR DESCRIPTION
 I) 	In the first table, content is clipped and is patched by breaking words into new line .

II)	Link in the 1st table is removed and is replaced by plain text, with an additional 'link' representing href tag, This is added because, breaking a link won't be a good habit
III)  	In the 2nd table, clipping of content is patched by wrapping whitespace with changing 'whitespace' CSS property from whitespace='no-wrap' to whitespace='normal'


![screenshot from 2014-12-11 16 22 07](https://cloud.githubusercontent.com/assets/5105654/5431944/bd36b1ba-8458-11e4-9f02-57a8fc1e1230.png)
![screenshot from 2014-12-13 15 56 54](https://cloud.githubusercontent.com/assets/5105654/5431947/c2059dbe-8458-11e4-9c14-1ec3454a74c3.png)

