### PR TITLE
Bug 1030686 - Add keyboard shortcut for classification entry

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -838,6 +838,25 @@ ul.failure-summary-list li .btn-xs {
     width: 12em;
 }
 
+.classification-comment-container {
+    margin-top: 5px;
+}
+
+.classification-comment-preload-txt {
+    position: relative;
+    top: -17px;
+    left: 5px;
+    pointer-events: none;
+}
+
+.add-classification-input {
+    width: 177px;
+    height: 20px;
+    padding: 0 0 0 3px;
+    border-radius: 0;
+    font-size: 12px;
+}
+
 .pinboard-open-btn {
     margin-top: -1px;
     background-color: #e6eef5 !important;
@@ -859,6 +878,10 @@ ul.failure-summary-list li .btn-xs {
     -moz-appearance: textfield;
 }
 
+.pinboard-label {
+    color: #777;
+}
+
 #pinboard-classification{
     flex: none;
     -webkit-flex: none;
@@ -874,17 +897,11 @@ ul.failure-summary-list li .btn-xs {
     width: 177px;
 }
 
-#pinboard-classification textarea {
-    width: 177px;
-    margin-top: 5px;
-    height: 40px;
-}
-
 #pinboard-controls {
     flex: none;
     -webkit-flex: none;
     padding: 10px;
-    margin: 13px;
+    margin: 10px;
 }
 
 #pinboard-controls .dropdown-menu {

--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -126,7 +126,9 @@
                     <td>Add a selected job to the pinboard</td></tr>
                     <tr><th>r</th>
                     <td>Add a selected job to the pinboard + enter related bug</td></tr>
-                    <tr><th>ctrl<span> + </span>enter</th>
+                    <tr><th>c</th>
+                    <td>Add a selected job to the pinboard + enter classification</td></tr>
+                    <tr><th>ctrl<span>+</span>enter</th>
                     <td>Save pinboard classification and related bugs</td></tr>
                     <tr><th>i</th>
                     <td>Toggle in-progress (running/pending) jobs</td></tr>

--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -85,7 +85,17 @@ treeherder.controller('MainCtrl', [
                 } else if (ev.keyCode === 82) {
                     // Pin selected job to pinboard and add a related bug, key:r
                     if ($scope.selectedJob) {
-                        $rootScope.$emit(thEvents.addRelatedBug, $rootScope.selectedJob);
+                        $rootScope.$emit(thEvents.addRelatedBug,
+                                         $rootScope.selectedJob);
+                        $rootScope.$broadcast('focus-this', "related-bug-input");
+                    }
+
+                } else if (ev.keyCode === 67) {
+                    // Pin selected job to pinboard and enter classification
+                    // key:c
+                    if ($scope.selectedJob) {
+                        $rootScope.$emit(thEvents.jobPin, $rootScope.selectedJob);
+                        $rootScope.$broadcast('focus-this', "classification-comment");
                     }
 
                 } else if (ev.keyCode === 27) {

--- a/webapp/app/js/directives/main.js
+++ b/webapp/app/js/directives/main.js
@@ -18,10 +18,34 @@ treeherder.directive('ngRightClick', [
     };
 }]);
 
-// allow an input on a form to request focus when the value it sets in its
-// ``focus-me`` directive is true.  You can set ``focus-me="focusInput"`` and
-// when ``$scope.focusInput`` changes to true, it will request focus on
-// the element with this directive.
+//Directive focusThis which applies focus to a specific element
+treeherder.directive('focusThis', ['$timeout', function($timeout) {
+  return function(scope, elem, attr) {
+      scope.$on('focus-this', function(event, id) {
+        if (attr.id == id) {
+          $timeout(function() {
+            elem[0].focus();
+          }, 0);
+        }
+      });
+  };
+}]);
+
+//Directive blurThis which removes focus from a specific element
+treeherder.directive('blurThis', ['$timeout', function($timeout) {
+  return function(scope, elem, attr) {
+      scope.$on('blur-this', function(event, id) {
+        if (attr.id == id) {
+          $timeout(function() {
+            elem[0].blur();
+          }, 0);
+        }
+      });
+  };
+}]);
+
+// Directive focusMe which sets a global focus state for elements
+// which listen to it via ''focus-me="focusInput'' in angular markup
 treeherder.directive('focusMe', [
   '$timeout',
   function($timeout) {
@@ -41,6 +65,7 @@ treeherder.directive('focusMe', [
     }
   };
 }]);
+
 // Select all text input in an html element on click.
 treeherder.directive('selectOnClick', [
     function () {

--- a/webapp/app/partials/main/thPinboardPanel.html
+++ b/webapp/app/partials/main/thPinboardPanel.html
@@ -22,7 +22,8 @@
     <form ng-submit="saveEnteredBugNumber()"
           ng-show="enteringBugNumber"
           class="add-related-bugs-form">
-      <input type="number"
+      <input id="related-bug-input"
+             type="number"
              class="add-related-bugs-input"
              ng-model="$parent.newEnteredBugNumber"
              placeholder="enter bug number"
@@ -35,13 +36,22 @@
 </div>
 
 <div id="pinboard-classification">
-  <div class="header">classification</div>
+  <div class="pinboard-label">classification</div>
   <div id="pinboard-classification-content" class="content">
-    <form ng-submit="saveNewClassification()" class="form">
+    <form ng-submit="completeClassification()" class="form">
       <select ng-model="classification.failure_classification_id"
               ng-options="item.id as item.name for item in classificationTypes.classificationOptions">
       </select>
-      <textarea class="comment" ng-model="classification.note"></textarea>
+      <div class="classification-comment-container">
+        <input id="classification-comment"
+               type="text"
+               class="form-control add-classification-input"
+               ng-model="classification.note"
+               focus-this blur-this></input>
+        <span class="pinboard-preload-txt classification-comment-preload-txt"
+              ng-if="!classification.note">
+              click to add comment</span>
+      </div>
     </form>
   </div>
 </div>

--- a/webapp/app/plugins/pinboard.js
+++ b/webapp/app/plugins/pinboard.js
@@ -102,6 +102,10 @@ treeherder.controller('PinboardCtrl', [
             $scope.focusInput = $scope.enteringBugNumber;
         };
 
+        $scope.completeClassification = function() {
+            $rootScope.$broadcast('blur-this', "classification-comment");
+        };
+
         $scope.saveEnteredBugNumber = function() {
             $log.debug("new bug number to be saved: ", $scope.newEnteredBugNumber);
             thPinboard.addBug({id:$scope.newEnteredBugNumber});


### PR DESCRIPTION
This work fixes 'part 1' of Bugzilla bug [1030686](https://bugzilla.mozilla.org/show_bug.cgi?id=1030686) requested by philor in [comment 11](https://bugzilla.mozilla.org/show_bug.cgi?id=1030686#c11).

This feature adds the selected job to the pinboard, and focuses the optional comment field when depressing the letter 'c'. On enter, it de-focuses that comment field. On re-invocation it refocuses, and also acts as a focus toggle, when the shortcut is depressed each time.

It can also be used in conjunction with the new 'r' shortcut, allowing users to add a related bug, then switch and depress 'c' and add a comment. Similarly it also be used in conjunction with save via 'ctrl/cmd+enter', to save the entire classification.

Basically you can do the entire process up to this point, without taking your hands off the keyboard.

Here's a screen grab of the UI before and after the focus:

![addcommentproposed_stp1](https://cloud.githubusercontent.com/assets/3660661/5458653/15900f22-8522-11e4-8804-702110462eea.jpg)

![addcommentproposed_stp2](https://cloud.githubusercontent.com/assets/3660661/5458654/1a74c55a-8522-11e4-9e54-6dfff7fdec50.jpg)

![addcommentproposed_stp3](https://cloud.githubusercontent.com/assets/3660661/5458656/1e9b949c-8522-11e4-8942-82c424b92fa1.jpg)

As you can see above, I'm also pre-populating the field with a discoverable overlay, like the other fields. I also adjusted the position of the Unpin/Save buttons slightly, so everything is aligned for now.

I've tested the feature on Windows in Firefox and Chrome and all related functionality seems to be fine. Esc to close the job panel, n,p,j,k for next and previous unclassified failure navigation, classification save, manual focus and manual defocus, and other workflows. @wlach tested the basic workflow on Linux also yesterday. Occasionally I do notice a shortcut key "overflow" into the cell, and the cell gets populated with a letter "c". I have noticed this also though with the related bugs shortcut we already landed.

I've also added the related Help item for it, and tweaked Save slightly while I was there to be more clear.

![addcommentproposedhelp](https://cloud.githubusercontent.com/assets/3660661/5458738/c03e5a82-8522-11e4-96c4-fe35b3827ad0.jpg)

As mentioned in the bug, to accommodate more than one element in a partial which can potentially receive focus, we needed a new focus and blur directive. This is because the state was ambiguous when two elements in the same partial wanted focus via the existing focusMe directive.

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Adding @camd for review, and @edmorley for visibility.
