### PR TITLE
Bug 1112238 - Create a UI help link to better access the build version

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1617,6 +1617,10 @@ fieldset[disabled] .btn-repo.active {
     color: lightgray;
 }
 
+.midgray, .midgray a {
+    color: gray;
+}
+
 #help {
     padding: 10px 10px 0px;
     overflow: auto;
@@ -1628,6 +1632,10 @@ fieldset[disabled] .btn-repo.active {
 
 #help.panel {
     padding: 5px;
+}
+
+.help-footer {
+    overflow: auto;
 }
 
 .panel-spacing table {

--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -365,6 +365,10 @@
     </div>
 </div>
 </div>
+<div class="panel-footer help-footer">
+  <a class="midgray pull-right"
+     href="../media/revision" target="_blank">Build</a>
+</div>
 </div>
 
 </body>


### PR DESCRIPTION
This fixes Bugzilla bug [1112238](https://bugzilla.mozilla.org/show_bug.cgi?id=1112238).

Nothing exciting, but it seems it would be helpful to access the build revision via the UI.

I had to ask in channel where the file was and I am pretty sure I might not be the only one, or I might later forget the location and have to ask again :)

This puts a nice subtle Build link in a new footer at the bottom right of the help page. It points to where I understand the `media/revision` file to be.

![helpbuildlinkproposed](https://cloud.githubusercontent.com/assets/3660661/5466882/c7c057b4-8582-11e4-95fa-60ec844fe763.jpg)

I've simulated that location locally and assuming I have the correct path, it seems to be working fine.

I added a generic `midgrey` class and used the same targets as `lightgrey`, in case we want to leverage it elsewhere for other elements. The help markup is a bit inconsistent but I tried to match its indentation logic.

I assume we may also want to turn off caching for the revision file, so when the user loads the file it will always be current.

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Adding @maurodoglio  for review, and @edmorley for visibility.
