### PR TITLE
Bug 1101760 - Clear classification fully on an unpin all

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -905,6 +905,10 @@ ul.failure-summary-list li .btn-xs {
     width: 70px;
 }
 
+#pinboard-controls .clear-all-spacer {
+    width: 3px;
+}
+
 .pinned-job {
     margin-bottom: 2px;
     padding: 1px 2px;

--- a/webapp/app/partials/main/thPinboardPanel.html
+++ b/webapp/app/partials/main/thPinboardPanel.html
@@ -51,7 +51,8 @@
   <span class="btn btn-xs btn-default close-btn"
           ng-show="hasPinnedJobs()"
           ng-click="unPinAll()">
-    <span class="fa fa-minus pull-left btn-icon-top-margin"></span> un-pin all
+    <span class="fa fa-minus pull-left btn-icon-top-margin
+                 clear-all-spacer"></span> clear all
   </span>
 
   <div class="btn-group"

--- a/webapp/app/plugins/pinboard.js
+++ b/webapp/app/plugins/pinboard.js
@@ -54,6 +54,7 @@ treeherder.controller('PinboardCtrl', [
 
         $scope.unPinAll = function() {
             thPinboard.unPinAll();
+            $scope.classification = thPinboard.createNewClassification();
         };
 
         $scope.save = function() {


### PR DESCRIPTION
This work fixes Bugzilla bug [1101760](https://bugzilla.mozilla.org/show_bug.cgi?id=1101760).

Not a huge bug fix here, but this clears both the classification comments field, and resets the value for the classification drop down menu, when the user Clears the pinboard (formerly 'Un-pin all').

I've renamed the button in the menu cluster, so that it matches. I needed to add a 3px compensation unfortunately, so it looks sort-of justified with the save button text below it. Here's the label change:

![clearallpinboardcurrent](https://cloud.githubusercontent.com/assets/3660661/5483704/88497818-8645-11e4-84ff-7f8f1ef95ef5.jpg)

![clearallpinboardproposed](https://cloud.githubusercontent.com/assets/3660661/5483705/8b686e82-8645-11e4-8cbd-9f1477095539.jpg)

Unless someone feels strongly about it, I don't think it's worth changing all the method names from `.unPinAll` to `.clearAll` etc, since the UI still may be a bit of a moving target, and could change again.

I imagine I'll be able to remove that css tweak later when hopefullly we migrate these buttons underneath the upcoming one-line classification comment field, still to be landed.

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Adding @camd  for review, and @edmorley for visibility.
