### PR TITLE
Bug 1059284 - Make the retrigger and cancel job buttons more clear

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -405,9 +405,20 @@ th-watched-repo {
     padding-left: 0;
 }
 
-/* Cancel all jobs custom icon size */
-.glyphicon-minus-sign {
-    font-size: 85%;
+.cancel-job-icon {
+    font-size: 13px;
+}
+
+.icon-green:hover {
+    color: #0de00d !important;
+}
+
+.dim-half {
+    opacity: 0.5;
+}
+
+.dim-quarter {
+    opacity: 0.75;
 }
 
 .revision-text {

--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -33,7 +33,7 @@
               title="cancel all jobs in this resultset"
               ng-show="currentRepo.repository_group.name == 'try' || user.is_staff"
               ng-click="cancelAllJobs(resultset.revision)">
-          <span class="glyphicon glyphicon-minus-sign"></span>
+          <span class="fa fa-times-circle cancel-job-icon dim-quarter"></span>
         </span>
       </span>
 

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -57,7 +57,8 @@
             <!--the first 3 items are in the same box-->
             <ul class="nav navbar-nav">
               <li>
-                <a href="" prevent-default-on-left-click  title="Add the selected job to the pinboard via ctrl/cmd+click or spacebar"
+                <a href="" prevent-default-on-left-click
+                   title="Add this job to the pinboard"
                    ng-click="pinboard_service.pinJob(selectedJob)">
                   <span class="glyphicon glyphicon-pushpin"></span>
                   <span class="pinned-job-count"><strong>{{ getCountPinnedJobs() }}</strong></span>
@@ -67,19 +68,20 @@
             </ul>
           </li>
           <li ng-show="canCancel()">
-            <a title="Cancel job"
+            <a title="Cancel this job"
                href="" prevent-default-on-left-click
                target="_blank"
                ng-click="cancelJob()">
-              <span class="fa fa-stop"></span>
+              <span class="fa fa-times-circle cancel-job-icon dim-half"></span>
             </a>
           </li>
           <li ng-show="canRetrigger()">
-            <a title="Retrigger job"
+            <a title="Retrigger this job"
+               class="icon-green"
                href="" prevent-default-on-left-click
                target="_blank"
                ng-click="retriggerJob()">
-              <span class="fa fa-play"></span>
+              <span class="fa fa-repeat"></span>
             </a>
           </li>
           <li ng-show="isReftest()" ng-repeat="job_log_url in job_log_urls">


### PR DESCRIPTION
This work fixes Bugzilla bug [1059284](https://bugzilla.mozilla.org/show_bug.cgi?id=1059284).

This makes the retrigger and cancel job buttons a bit more clear, per the bug request.

In it we:
- replace both icons with the requested font awesomes
- slighly de-emphasize the cancel button since it is mildly 'destructive'
- make the retrigger interaction a bit more polished and communicative

Here's the before:

![cancelretriggercurrent](https://cloud.githubusercontent.com/assets/3660661/5521537/3d7f3b54-8971-11e4-95ee-e8b168518b48.jpg)

Here is the after:

![cancelalljobsproposed](https://cloud.githubusercontent.com/assets/3660661/5521474/4f6befa8-896f-11e4-898d-0de17eeb5f14.jpg)

Here is the interaction on retrigger:

![cancelalljobsproposedhover](https://cloud.githubusercontent.com/assets/3660661/5521475/66b957b8-896f-11e4-8f83-7837a86d7ef0.jpg)

We've also updated the resultset cancel all jobs to be consistent:

![cancelalljobsresultset](https://cloud.githubusercontent.com/assets/3660661/5521477/75ed883a-896f-11e4-99c4-04faf8091c4e.jpg)

We've also updated the job panel cancel tooltips to use a common wording, "Cancel this job", "Add this job to the pinboard", and so forth:

![cancelretriggertooltip](https://cloud.githubusercontent.com/assets/3660661/5521490/b6339984-896f-11e4-8540-bab39938849e.jpg)

Unfortunately I had to use an `!important` on the icon-green class. I'd prefer not to, but to override the inheritance of the fa classes, I didn't seem to have any easy alternative, to paint the icon when the entire element boundary has been crossed.

I created some generic `dim-` classes, in case they need to be leveraged elsewhere. They are used for the cancel button in the job panel and the resultset bar.

We needed to override the default 12px font height, and go 13 because these new icons are simply not as large as their predecessors.

Other than that, everything seems fine. I am planning other improvements to the Logviewer and Raw log icons, just a note they haven't been forgotten about. They are in a separate bug.

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Adding @camd  for review and @edmorley for visibility.
