### PR TITLE
Bug 1114878 - Correct the size of the Sheriffs menu button

### DIFF
--- a/webapp/app/partials/main/thGlobalTopNavPanel.html
+++ b/webapp/app/partials/main/thGlobalTopNavPanel.html
@@ -6,7 +6,7 @@
         <!-- nav begin -->
         <span class="navbar-right">
             <span ng-show="user.is_staff">
-                <span class="btn btn-view-nav"
+                <span class="btn btn-view-nav btn-right-navbar nav-menu-btn"
                       ng-class="{'active': (isSheriffPanelShowing)}"
                       ng-click="setSheriffPanelShowing(!isSheriffPanelShowing)"
                       tabindex="0"


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1114878](https://bugzilla.mozilla.org/show_bug.cgi?id=1114878).

The Sheriffs menu button had not received the same navbar tweaks as the rest of the menus. It was too large (14px) and not padded correctly for hover.

Here's the before:

![sheriffingmenucurrent](https://cloud.githubusercontent.com/assets/3660661/5534975/2d93fd32-8a3f-11e4-9593-975d28967696.jpg)

Here's the after:

![sheriffingmenuproposed](https://cloud.githubusercontent.com/assets/3660661/5534976/31edbbc0-8a3f-11e4-9ddf-4e8f0880ffec.jpg)

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Adding @camd for review and @edmorley for visibility.
