### PR TITLE
Bug 1113843 - Draw conditional resultset btns correctly on all browsers

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -374,10 +374,6 @@ th-watched-repo {
     padding-right: 10px;
 }
 
-.result-set-buttons {
-    flex: 0 0 13em;
-}
-
 .result-set-fa-icon {
     float: left;
     padding-top: 4px;
@@ -431,7 +427,8 @@ th-watched-repo {
 
 .revision-button {
     flex: 0 0 60px;
-    margin-right: 2px;
+    margin-right: 4px;
+    margin-left: 4px;
 }
 
 .revision-list {

--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -17,7 +17,7 @@
              target="_blank">{{::resultsetDateStr}}</a> - </span>
         <th-author author="{{::resultset.author}}"></th-author>
       </span>
-      <span class="result-set-buttons">
+      <span>
         <span class="revision-text">{{::resultset.revision}}</span>
         <span class="btn btn-default btn-sm btn-resultset"
               tabindex="0" role="button"


### PR DESCRIPTION
This fixes Bugzilla bug [1113843](https://bugzilla.mozilla.org/show_bug.cgi?id=1113843).

For sheriffs or users in the Try repo where the Cancel All Jobs button is displayed, we weren't displaying properly on Chrome.

This change fixes that, and provides a consistent spacing between all the buttons, for all browsers. @wlach's earlier flexbox effects are still present and ensure these buttons flow at small browser widths.

Here's the before:

![conditionalresultsetbtnscurrent](https://cloud.githubusercontent.com/assets/3660661/5540833/464bfd52-8a9e-11e4-92d7-95753fed17fa.jpg)

Here's the after:

![conditionalresultsetbtnsproposed](https://cloud.githubusercontent.com/assets/3660661/5540835/509fe570-8a9e-11e4-9c01-c8a5e01b1066.jpg)

We also now collapse nicely when the Cancel button is suppressed (eg. mozilla-central, regular user):

![conditionalresultsetbtnscenral](https://cloud.githubusercontent.com/assets/3660661/5540838/6ababa02-8a9e-11e4-848e-038b6144d441.jpg)

It appeared we need to leave that orphan `span` in place on line 20, so the child elements receive their correct flex spacing. Without it the flex webkit margins are lost on the first buttons.

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Adding @camd for review and @edmorley for visibility.
