### PR TITLE
Bug 1114665 - Prevent focus on suggested bug buttons for Firefox

### DIFF
--- a/webapp/app/plugins/failure_summary/main.html
+++ b/webapp/app/plugins/failure_summary/main.html
@@ -9,11 +9,12 @@
             <ul ng-if="! suggestion.bugs.open_recent_hidden"
                 class="list-unstyled failure-summary-bugs">
                 <li ng-repeat="bug in suggestion.bugs.open_recent">
-                    <button class="btn btn-xs btn-default"
-                            ng-click="pinboard_service.addBug(bug, selectedJob)"
-                            title="add to list of bugs to associate with all pinned jobs">
-                        <i class="glyphicon glyphicon-pushpin"></i>
-                    </button>
+                    <a class="btn btn-xs btn-default"
+                       prevent-default-on-left-click
+                       ng-click="pinboard_service.addBug(bug, selectedJob)"
+                       title="add to list of bugs to associate with all pinned jobs">
+                      <i class="glyphicon glyphicon-pushpin"></i>
+                    </a>
                     <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.id}}"
                        target="_blank"
                        ng-class="{'deleted': bug.resolution != ''}">{{::bug.id}}
@@ -34,11 +35,12 @@
             <ul ng-if="!suggestion.all_others_hidden && suggestion.open_others"
                 class="list-unstyled failure-summary-bugs">
                 <li ng-repeat="bug in suggestion.bugs.all_others">
-                    <button class="btn btn-xs btn-default"
-                            ng-click="pinboard_service.addBug(bug, selectedJob)"
-                            title="add to list of bugs to associate with all pinned jobs">
-                        <i class="glyphicon glyphicon-pushpin"></i>
-                    </button>
+                    <a class="btn btn-xs btn-default"
+                       prevent-default-on-left-click
+                       ng-click="pinboard_service.addBug(bug, selectedJob)"
+                       title="add to list of bugs to associate with all pinned jobs">
+                      <i class="glyphicon glyphicon-pushpin"></i>
+                    </a>
                     <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.id}}"
                        target="_blank"
                        ng-class="{'deleted': bug.resolution != ''}">{{::bug.id}}


### PR DESCRIPTION
This work fixes Bugzilla bug [1114665](https://bugzilla.mozilla.org/show_bug.cgi?id=1114665).

In it we prevent left click and subsequent focus on the tiny Failure Summary 'pin' icons adjacent to the suggested bugs. This allows the favored sheriff workflow of:

1) clicking on a failed job
2) clicking to pin a suggested bug (and the job)
3) ctrl+enter to save the classification

The latter step was triggering a re-invocation of the 2nd step on Windows with Firefox, re-pinning and re-adding the bug, so the perception was the pinboard never cleared.

Here's the appearance pre-save:

![pinboardpresave](https://cloud.githubusercontent.com/assets/3660661/5544097/c18bb118-8acd-11e4-839f-51c3f10a685b.jpg)

And with the fix, post-save:

![pinboardpostsave](https://cloud.githubusercontent.com/assets/3660661/5544101/c95df036-8acd-11e4-9c10-d07b96244ead.jpg)

Other browsers like Chrome, and platforms (OSX) with Firefox did not display the bug, but I re-tested Chrome on windows to confirm it was still fine.

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Adding @camd for review and @KWierso for visibility.
