### PR TITLE
Bug 1115194 - Update un-starred term to unclassified in the Help

### DIFF
--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -42,10 +42,10 @@
                     <td>Wrapped job group</td>
                   </tr>
                   <tr>
-                    <th class="annotation">
+                    <th class="classified">
                       <button class="btn btn-dkgray help-btn help-btn-comment">Th*</button>
                     </th>
-                    <td>Asterisk, annotation</td>
+                    <td>Asterisk, classified</td>
                   </tr>
                   <tr>
                     <th class="pending">
@@ -115,11 +115,11 @@
                     <tr><th>esc</th>
                     <td>Close all open job or filter panels</td></tr>
                     <tr><th>j<span> or </span>n</th>
-                    <td>Highlight next unstarred failure</td></tr>
+                    <td>Highlight next unclassified failure</td></tr>
                     <tr><th>k<span> or </span>p</th>
-                    <td>Highlight previous unstarred failure</td></tr>
+                    <td>Highlight previous unclassified failure</td></tr>
                     <tr><th>u</th>
-                    <td>Show only unstarred failures</td></tr>
+                    <td>Show only unclassified failures</td></tr>
                     <tr><th>ctrl<span> or </span>cmd</span></th>
                     <td>Add job to the pinboard during selection</td></tr>
                     <tr><th>spacebar</th>


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1115194](https://bugzilla.mozilla.org/show_bug.cgi?id=1115194).

Per the bug, this change makes the terminology across all the Help shortcut keys consistent regarding classification, and retiring the term 'unstarred'.

Here's the change:

![unstarredtounclassified](https://cloud.githubusercontent.com/assets/3660661/5545872/2af6a9f6-8aff-11e4-93bf-75cb2cf7433b.jpg)

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Adding @camd for review.
