### PR TITLE
Bug 1114839 - Prevent pinboard shortcut overflows during focus

### DIFF
--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -87,6 +87,9 @@ treeherder.controller('MainCtrl', [
                     if ($scope.selectedJob) {
                         $rootScope.$emit(thEvents.addRelatedBug,
                                          $rootScope.selectedJob);
+
+                        // Prevent shortcut key overflow during focus
+                        ev.preventDefault();
                         $rootScope.$broadcast('focus-this', "related-bug-input");
                     }
 
@@ -95,6 +98,9 @@ treeherder.controller('MainCtrl', [
                     // key:c
                     if ($scope.selectedJob) {
                         $rootScope.$emit(thEvents.jobPin, $rootScope.selectedJob);
+
+                        // Prevent shortcut key overflow during focus
+                        ev.preventDefault();
                         $rootScope.$broadcast('focus-this', "classification-comment");
                     }
 


### PR DESCRIPTION
This fixes Bugzilla bug [1114839](https://bugzilla.mozilla.org/show_bug.cgi?id=1114839).

This prevents overflow events from the 'r' and 'c' keyboard shortcuts for add-related-bug and add-comment. Occasionally an extra 'r' or 'c' was ending up in those fields.

I've tested with rapid inputs, paused (elongated) key presses, additions and removals, pinning, saving, and main panel navigation, and far as I can tell everything is behaving correctly on both Firefox and Chrome.

Screen grab post-fix:

![cleaninput](https://cloud.githubusercontent.com/assets/3660661/5555916/97b8dc5c-8c95-11e4-9ab7-3a9c632ca30c.jpg)

It would be helpful if someone could check it out on Linux or OSX to be sure we are fine there.

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Adding @camd for review and @KWierso for visibility.
