### PR TITLE
Bug 1097485 - Switch logviewer raw log tooltip to a text label

### DIFF
--- a/webapp/app/css/logviewer.css
+++ b/webapp/app/css/logviewer.css
@@ -104,6 +104,16 @@ body {
     color: #9fa3a5;
 }
 
+.logviewer-stepbar a:hover,
+.logviewer-stepbar a:focus {
+    text-decoration: none;
+}
+
+.logviewer-stepbar .raw-log {
+    padding-right: 5px;
+    font-size: 12px;
+}
+
 .logviewer-stepbar input[type="checkbox"] {
     margin: 0;
     vertical-align: middle;

--- a/webapp/app/partials/logviewer/lvLogSteps.html
+++ b/webapp/app/partials/logviewer/lvLogSteps.html
@@ -38,8 +38,9 @@
 </div>
 
 <div class="logviewer-stepbar">
-    <a title="Open the raw log in a new window" target="_blank" href="{{::artifact.logurl}}">
-        <span class="glyphicon glyphicon-align-left"></span>
+    <a target="_blank" href="{{::artifact.logurl}}">
+        <span class="glyphicon glyphicon-align-left raw-log"></span>
+        <span>open raw log</span>
     </a>
 </div>
 


### PR DESCRIPTION
This work fixes Bugzilla bug [1097485](https://bugzilla.mozilla.org/show_bug.cgi?id=1097485).

Per the bug request, this switches the logviewer tool tip, into a text label adjacent to the icon.

Here's the before:

![logviewerrawiconcurrent](https://cloud.githubusercontent.com/assets/3660661/5562315/b21f1ede-8de0-11e4-8530-10f56846cfc8.jpg)

Here's the after:

![logviewerrawiconrequested](https://cloud.githubusercontent.com/assets/3660661/5562310/43635dca-8de0-11e4-99cc-7f8bee220883.jpg)

The entire region including the text functions as a target area for the click.

There's a peculiar width increase for jobs which have short run data headers (per above). Just adding the span seems to also increase width of the resultset run data (not pictured), and the failed steps container above. A bit of a mystery but the containers still flow correctly and work with small browser sizes, and with typical run data.

I also tweaked the size of the icon down to 12px, as it seems to render more clearly.

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Adding @camd for review and @edmorley and @dbaron for visibility.
