### PR TITLE
Bug 1107136 -  Add a keyboard shortcut for clear-all in pinboard

### DIFF
--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -118,8 +118,6 @@
                     <td>Highlight next unclassified failure</td></tr>
                     <tr><th>k<span> or </span>p</th>
                     <td>Highlight previous unclassified failure</td></tr>
-                    <tr><th>u</th>
-                    <td>Show only unclassified failures</td></tr>
                     <tr><th>ctrl<span> or </span>cmd</span></th>
                     <td>Add job to the pinboard during selection</td></tr>
                     <tr><th>spacebar</th>
@@ -130,8 +128,12 @@
                     <td>Add a selected job to the pinboard + enter classification</td></tr>
                     <tr><th>ctrl<span>+</span>enter</th>
                     <td>Save pinboard classification and related bugs</td></tr>
+                    <tr><th>ctrl<span>+</span>shift<span>+</span>u</th>
+                    <td>Clear the pinboard</td></tr>
                     <tr><th>i</th>
                     <td>Toggle in-progress (running/pending) jobs</td></tr>
+                    <tr><th>u</th>
+                    <td>Show only unclassified failures</td></tr>
                 </table>
             </div>
         </div>

--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -106,10 +106,16 @@ treeherder.controller('MainCtrl', [
                     $scope.closeJob();
                 }
 
-            // Ctrl+Enter saves pinboard classification and related bugs
+            // Clear the pinboard: Ctrl+Shift+u
+            } else if (!ev.metaKey && !ev.altKey && ev.shiftKey && ev.ctrlKey) {
+                if ((ev.keyCode === 85) && $scope.selectedJob) {
+                    $rootScope.$emit(thEvents.clearPinboard);
+                }
+
+            // Save pinboard classification and related bugs: Ctrl+Enter
             } else if (!ev.metaKey && !ev.altKey && !ev.shiftKey && ev.ctrlKey) {
                 if ((ev.keyCode === 13) && $scope.selectedJob) {
-                  $rootScope.$emit(thEvents.saveClassification);
+                    $rootScope.$emit(thEvents.saveClassification);
                 }
             }
         };

--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -233,6 +233,8 @@ treeherder.provider('thEvents', function() {
 
             saveClassification: "save-classification-EVT",
 
+            clearPinboard: "clear-pinboard-EVT",
+
             searchPage: "search-page-EVT",
 
             selectJob: "select-job-EVT",

--- a/webapp/app/plugins/pinboard.js
+++ b/webapp/app/plugins/pinboard.js
@@ -29,6 +29,12 @@ treeherder.controller('PinboardCtrl', [
             }
         });
 
+        $rootScope.$on(thEvents.clearPinboard, function(event) {
+            if ($scope.isPinboardVisible) {
+                $scope.unPinAll();
+            }
+        });
+
         $scope.pinJob = function(job) {
             thPinboard.pinJob(job);
             if (!$scope.selectedJob) {


### PR DESCRIPTION
This work fixes Bugzilla bug [1107136](https://bugzilla.mozilla.org/show_bug.cgi?id=1107136).

In it we invoke the same clear as if the user had clicked on the 'clear all' button in the pinboard, if:
- the job panel is open
- the pinboard is open
- both modifiers and the shortcut are depressed

If the pinboard is closed, we will not clear, since the user can't see what they are about to remove.

As discussed in the bug I used '**ctrl+shift+u**' akin to the unix and vi functionality 'ctrl+u' which clears a line of input. A double modifier combination requires a bit more conscious choice so it won't be accidentally invoked. It also keeps us clear of existing modifiers in Treeherder (u: toggle unclassified) and in the browser (ctrl+u: view source).

Here's an example pre-clear state:

![preclearstate](https://cloud.githubusercontent.com/assets/3660661/5570945/84e866e6-8f57-11e4-8c36-d4d1c2a1129a.jpg)

And post-clear state:

![postclearstate](https://cloud.githubusercontent.com/assets/3660661/5570948/8c236d84-8f57-11e4-974e-5d4825245fdc.jpg)

I also added it to Help, and did a bit of re-arranging while I was there, so all the pin functionality shortcuts are grouped together.

![helpupdate](https://cloud.githubusercontent.com/assets/3660661/5570963/d0dafb5e-8f57-11e4-8032-5b25fded4bfd.jpg)

All my local testing seems fine. Pinning, related bugs, comments, classification states, all cleared correctly. Similarly preserving and _not_ pinning when the pinboard is closed, or the job panel is closed. And the other u shortcuts mentioned (treeherder, native browser) are still working properly on both browsers.

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Adding @camd for review and @edmorley for visibility.
