### PR TITLE
Bug 1115410 - Remove job controls boundary

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -558,10 +558,6 @@ div#bottom-panel .navbar-nav > li > a.disabled {
     text-decoration: none;
 }
 
-div#bottom-panel ul.bottom-panel-controls{
-    border-right: 1px solid #42484F;
-}
-
 div#bottom-panel .navbar-nav > li.active a,
 div#bottom-panel .navbar-nav > li.active a:hover,
 div#bottom-panel .navbar-nav > li.active a:focus {

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -12,7 +12,7 @@
   <div id="bottom-left-panel">
     <div id="bottom-left-top">
       <nav class="navbar navbar-dark">
-        <ul class="nav navbar-nav bottom-panel-controls">
+        <ul class="nav navbar-nav">
 
           <li ng-repeat="job_log_url in job_log_urls">
             <a ng-if="job_log_url.parse_status == 'parsed'"


### PR DESCRIPTION
This fixes Bugzilla bug [1115410](https://bugzilla.mozilla.org/show_bug.cgi?id=1115410).

A little LHF. Since we already have the implied boundary from the adjacent Failure Summary tab(s), and they will always exist when the job panel is up, we can make the UI a little cleaner here.

Here's the before:

![jobcontrolsboundarycurrent](https://cloud.githubusercontent.com/assets/3660661/5583800/c4c5274a-904c-11e4-9e1f-e4458c813980.jpg)

Here's the after:

![jobcontrolsboundaryproposed](https://cloud.githubusercontent.com/assets/3660661/5583801/cc44a176-904c-11e4-9871-8fbb47376c85.jpg)

Here's the full control block:

![jobcontrolsboundaryall](https://cloud.githubusercontent.com/assets/3660661/5583802/d3f12020-904c-11e4-8716-77fff9f43004.jpg)

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Everything seems fine at varying sizes, job types with different numbers of controls, etc.

Adding @camd for review and @edmorley for visibility.
