### PR TITLE
Bug 1088970 - fix treestatus for comm-central

### DIFF
--- a/webapp/app/js/models/repository.js
+++ b/webapp/app/js/models/repository.js
@@ -221,8 +221,8 @@ treeherder.factory('ThRepositoryModel', [
                 // we've received all the statuses we expect to
                 _.defer(function() {
                     _.each(newStatuses, function(status) {
-                        watchedRepos[status.tree].treeStatus = status;
                         $log.debug("updateTreeStatus", "updateStatusesIfDone", status.tree, status.status);
+                        watchedRepos[treeStatus.getRepoName(status.tree)].treeStatus = status;
                     });
                 });
             }

--- a/webapp/app/js/services/treestatus.js
+++ b/webapp/app/js/services/treestatus.js
@@ -20,6 +20,12 @@ treeherder.factory('treeStatus', [
         return name;
     };
 
+    // the inverse of getTreeStatusName.  Seems like overhead to put this one
+    // line here, but it keeps the logic to do/undo all in one place.
+    var getRepoName = function(name) {
+        return name.replace("-thunderbird", "");
+    };
+
     var get = function(repoName) {
         var url = urlBase + getTreeStatusName(repoName);
 
@@ -29,6 +35,7 @@ treeherder.factory('treeStatus', [
     return {
         get: get,
         getTreeStatusName: getTreeStatusName,
+        getRepoName: getRepoName
     };
 }]);
 


### PR DESCRIPTION
``comm-central`` is for thunderbird and the name doesn't match between us and treestatus, so this is a fix for it.  We already had 1/2 the workaround in there to get the right url for ``treestatus`` based on our repo name for ``comm-central``.  This just goes the other direction in translating back to our repo name of ``comm-central`` from ``comm-central-thunderbird``