### PR TITLE
Bug 1116804 - speed up repo switching by fixing error

### DIFF
--- a/webapp/app/js/models/repository.js
+++ b/webapp/app/js/models/repository.js
@@ -100,7 +100,7 @@ treeherder.factory('ThRepositoryModel', [
 
                     _.each(data, addRepoAsUnwatched);
                     var storedWatched = JSON.parse(sessionStorage.getItem("thWatchedRepos"));
-                    if (_.isArray(storedWatched)) {
+                    if (_.isArray(storedWatched) && _.contains(storedWatched, name)) {
                         _.each(storedWatched, function (repo) {
                             watchRepo(repo);
                         });


### PR DESCRIPTION
this check prevents checking the treestatus on the previous repo when switching.