### PR TITLE
Bug 1074939 - Switch to a persistent pinboard Save UI

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -919,8 +919,8 @@ ul.failure-summary-list li .btn-xs {
 #pinboard-controls {
     flex: none;
     -webkit-flex: none;
-    padding: 10px;
-    margin: 10px;
+    height: 43px;
+    margin: 20px;
 }
 
 #pinboard-controls .dropdown-menu {

--- a/webapp/app/partials/main/thPinboardPanel.html
+++ b/webapp/app/partials/main/thPinboardPanel.html
@@ -1,3 +1,4 @@
+<!-- Pinboard -->
 <div id="pinned-job-list">
   <div class="content">
     <span class="pinboard-preload-txt"
@@ -9,6 +10,7 @@
   </div>
 </div>
 
+<!-- Related bugs -->
 <div id="pinboard-related-bugs">
   <div class="content">
     <a ng-click="toggleEnterBugNumber()"
@@ -35,6 +37,7 @@
   </div>
 </div>
 
+<!-- Classification dropdown -->
 <div id="pinboard-classification">
   <div class="pinboard-label">classification</div>
   <div id="pinboard-classification-content" class="content">
@@ -42,6 +45,7 @@
       <select ng-model="classification.failure_classification_id"
               ng-options="item.id as item.name for item in classificationTypes.classificationOptions">
       </select>
+      <!-- Classification comment -->
       <div class="classification-comment-container">
         <input id="classification-comment"
                type="text"
@@ -56,24 +60,28 @@
   </div>
 </div>
 
-
-<div id="pinboard-controls" class="btn-group-vertical">
+<!-- Save UI -->
+<div id="pinboard-controls" class="btn-group-vertical"
+     title="{{!hasPinnedJobs() ? 'No jobs pinned' : ''}}">
   <span class="btn btn-xs btn-default close-btn"
-          ng-show="hasPinnedJobs()"
-          ng-click="unPinAll()">
+        title="Clear the entire pinboard"
+        ng-disabled="!hasPinnedJobs()"
+        ng-click="unPinAll()">
     <span class="fa fa-minus pull-left btn-icon-top-margin
                  clear-all-spacer"></span> clear all
   </span>
 
-  <div class="btn-group"
-       ng-show="hasPinnedJobs()">
+  <div class="btn-group">
     <span class="btn btn-default btn-xs save-btn"
-          title="Save classification and related bugs"
-          ng-click="save()">
+          title="Save all classification data"
+          ng-click="save()"
+          ng-disabled="!hasPinnedJobs()">
       <span class="fa fa-floppy-o pull-left btn-icon-top-margin"></span> save
     </span>
     <span class="btn btn-default btn-xs dropdown-toggle save-btn-dropdown"
-          data-toggle="dropdown">
+          title="Save sub classifications"
+          data-toggle="dropdown"
+          ng-disabled="!hasPinnedJobs">
       <span class="caret"></span>
     </span>
     <ul class="dropdown-menu pull-right" role="menu">


### PR DESCRIPTION
This work fixes Bugzilla bug [1074939](https://bugzilla.mozilla.org/show_bug.cgi?id=1074939).

This switches the conditional Save UI in the pinboard to be persistent. We enable the buttons when either:

* a job is pinned
* a classification comment is added (and therefore a job is pinned)
* a related bug is added (and therefore a job is pinned)

The Save UI cluster is unchanged in dimensions and location.

I removed the border from the parent div. There is now only margin. That div carries the title tooltip if the pinboard is empty, because in that scenario, the spans below it are disabled and so are incapable of displaying an alternate title.

The removal of that border also ensures 'No pinned jobs' only appears when the mouse actuallly enters the Save UI, rather than just near it.

Here's the appearance with no jobs (disabled):

![pinboardnojobs](https://cloud.githubusercontent.com/assets/3660661/5607718/3d191d88-9434-11e4-91bf-64f143314692.jpg)

No jobs on hover:

![pinboardnojobssavehover](https://cloud.githubusercontent.com/assets/3660661/5607720/4ef489c0-9434-11e4-8c8f-212f9537c082.jpg)

With pinned jobs (enabled):

![pinboardjobssaveenabled](https://cloud.githubusercontent.com/assets/3660661/5607721/56e1c1a2-9434-11e4-9fda-666b88b58cf2.jpg)

The tooltip for Clear All:

![clearalltooltip](https://cloud.githubusercontent.com/assets/3660661/5607722/605d40b2-9434-11e4-82a2-0fdb1df62e85.jpg)

And for Save:

![savetooltip](https://cloud.githubusercontent.com/assets/3660661/5607724/682949ee-9434-11e4-9c38-32a72e6fd531.jpg)

And for the Save sub-menu:

![savemenu](https://cloud.githubusercontent.com/assets/3660661/5607725/71308516-9434-11e4-9bb9-67285741c767.jpg)

Maybe it's overkill to have a title for Clear All, but I put one in. Everything appears to be behaving correctly on both Firefox and Chrome. I also added some comments to the markup while I was there.

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Adding @camd for review and @edmorley for visibility.


