### PR TITLE
Bug 1118345 - Ignore empty related bug input fields on entry

### DIFF
--- a/webapp/app/plugins/pinboard.js
+++ b/webapp/app/plugins/pinboard.js
@@ -114,10 +114,15 @@ treeherder.controller('PinboardCtrl', [
         };
 
         $scope.saveEnteredBugNumber = function() {
-            $log.debug("new bug number to be saved: ", $scope.newEnteredBugNumber);
-            thPinboard.addBug({id:$scope.newEnteredBugNumber});
-            $scope.toggleEnterBugNumber();
-            $scope.newEnteredBugNumber = "";
+            if (!$scope.newEnteredBugNumber) {
+                $scope.toggleEnterBugNumber();
+            } else {
+                $log.debug("new bug number to be saved: ",
+                           $scope.newEnteredBugNumber);
+                thPinboard.addBug({id:$scope.newEnteredBugNumber});
+                $scope.toggleEnterBugNumber();
+                $scope.newEnteredBugNumber = "";
+            }
         };
 
         $scope.viewJob = function(job) {


### PR DESCRIPTION
This work fixes Bugzilla bug [1118345](https://bugzilla.mozilla.org/show_bug.cgi?id=1118345).

If the user hasn't entered any bug number in the add related bug field, we now ignore it instead of creating an empty bug association on *enter*.

So the scenario in question we'd have:

![ignoreenterpre](https://cloud.githubusercontent.com/assets/3660661/5651539/514556ca-9676-11e4-8a8f-53ffa92f1f7f.jpg)

Pre fix we'd have:

![ignoreentercurrent](https://cloud.githubusercontent.com/assets/3660661/5651545/57e9fe86-9676-11e4-875a-19481e5b236e.jpg)

Post-fix we now have:

![ignoreenterproposed](https://cloud.githubusercontent.com/assets/3660661/5651553/5f1cd0fc-9676-11e4-89ac-6b57839a8f70.jpg)

I've tested on both Firefox and Chrome, single and multiple resultsets, both using the 'r' key shortcut with rapid input, and the manual [+] icon, and in conjunction with the other pinboard shortcuts (pin, save, clear, comment). Everything seems to be working fine.

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Adding @camd for review and @rvandermeulen for visibility.