### PR TITLE
Bug 1118929 - Remove job tab outline decoration

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -566,9 +566,7 @@ div#bottom-panel .navbar-nav > li > a.disabled {
 div#bottom-panel .navbar-nav > li.active a,
 div#bottom-panel .navbar-nav > li.active a:hover,
 div#bottom-panel .navbar-nav > li.active a:focus {
-    box-shadow: inset 0px 2px 0px;
     outline: 0;
-
 }
 
 div#bottom-panel .navbar > ul.tab-headers > li{


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1118929](https://bugzilla.mozilla.org/show_bug.cgi?id=1118929).

Nothing exciting, but this removes the extra tab decoration in the active job panel tab. We already differentiate by color and luminance, and the perception of the active tab seems fine without it. 

There is some other bootstrap or treeherder active dotted border triggered on Firefox (for all the UI), but I haven't yet gotten to looking at that yet. So I've preserved the `outline: 0` override so we don't get that dotted outline on the tabs. Otherwise I would have removed the entire block of css.

Adding @maurodoglio for visibility in case I've missed some other reason why this white decoration was present. I've checked also and it doesn't appear used anywhere else.

Here's the before:

![jobtabcurrrent](https://cloud.githubusercontent.com/assets/3660661/5653648/2b14bfea-968a-11e4-9dd2-75a0c3a4f2bf.jpg)

Here's the after:

![jobtabproposed](https://cloud.githubusercontent.com/assets/3660661/5653650/303163d4-968a-11e4-854e-7448fa107b8e.jpg)

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Adding @wlach for review.