### PR TITLE
Bug 1119038 -  Update the logviewer icon for pending/failed jobs

### DIFF
--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -26,19 +26,22 @@
             <a ng-if="job_log_url.parse_status == 'failed'"
                title="Log parsing has failed"
                class="disabled" >
-              <span class="glyphicon glyphicon-tasks"></span>
+              <img src="./img/logviewerIcon.svg"
+                   class="logviewer-icon"><img>
             </a>
             <a ng-if="job_log_url.parse_status == 'pending'"
                class="disabled"
                title="Log parsing in progress">
-              <span class="glyphicon glyphicon-tasks"></span>
+              <img src="./img/logviewerIcon.svg"
+                   class="logviewer-icon"><img>
             </a>
           </li>
           <li>
             <a ng-if="!job_log_urls.length"
                class="disabled"
                title="No logs available for this job">
-              <span class="glyphicon glyphicon-tasks"></span>
+              <img src="./img/logviewerIcon.svg"
+                   class="logviewer-icon"><img>
             </a>
           </li>
 


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1119038](https://bugzilla.mozilla.org/show_bug.cgi?id=1119038).

This updates the logviewer icon for jobs whose status is either failed, pending or unavailable. So they also receive the new icon, rather than the old glyph.

For some reason I hadn't hit any jobs in progress during testing of [bug 1057349](https://bugzilla.mozilla.org/show_bug.cgi?id=1057349) until it was pushed to stage.

Here's the fix:

![logunavailablefix](https://cloud.githubusercontent.com/assets/3660661/5655891/b44b3a92-96a2-11e4-9c6f-cbf38a80dd64.jpg)

Tested on Windows:
FF Release **34.0**
Chrome Latest Release **39.0.2171.95 m**

Adding @camd for review.
