### PR TITLE
Bug 1119028 - remove exact count of revisions

### DIFF
--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -130,7 +130,7 @@
         <!-- Clone target for "more" link for large revision sets -->
         <script type="'text/ng-template'" id="pushlogRevisionsClone.html">
             <li>
-                <a href="{{currentRepo.url}}/pushloghtml?changeset={{revision}}" target="_blank"> ...and {{diff}} more
+                <a href="{{currentRepo.url}}/pushloghtml?changeset={{revision}}" target="_blank"> ...and more
                     <i class="fa fa-external-link-square"></i>
                 </a>
             </li>

--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -354,7 +354,6 @@ treeherder.directive('thCloneJobs', [
                 ulEl.append(pushlogInterpolator({
                     currentRepo: $rootScope.currentRepo,
                     revision: resultset.revision,
-                    diff: resultset.revision_count - resultset.revisions.length
                 }));
             }
         }

--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -42,7 +42,9 @@
             ng-click="toggleRevisions()"
             title="show revisions">
         <i class="fa fa-code-fork fa-lg
-                  result-set-fa-icon"></i> {{::resultset.revision_count}}
+                  result-set-fa-icon"></i>
+        <span ng-if="resultset.revision_count <= 20">{{::resultset.revision_count}}</span>
+        <span ng-if="resultset.revision_count > 20">&gt20</span>
       </span>
       <th-result-counts class="result-counts"/>
     </div>


### PR DESCRIPTION
say “>20” on the revision button
say “… and more” in the revision list instead of “… and X more”

This is the companion to https://github.com/mozilla/treeherder-service/pull/318.  Best to merge them both prior to pushing.