### PR TITLE
Bug 1119412 - treeherder should display results for 10.10 test jobs

### DIFF
--- a/webapp/app/js/values.js
+++ b/webapp/app/js/values.js
@@ -9,7 +9,7 @@ treeherder.value("thPlatformNameMap", {
     "linux64": "Linux x64",
     "osx-10-6": "OS X 10.6",
     "osx-10-8": "OS X 10.8",
-    "osx-10-9": "OS X 10.9",
+    "osx-10-10": "OS X 10.10",
     "windowsxp": "Windows XP",
     "windows7-32": "Windows 7",
     "windows8-32": "Windows 8",


### PR DESCRIPTION
We haven't run jobs on 10.9 for over a month since we decided to leapfrog that platform and move directly to 10.10. The 10.9 jobs when they were running were only on cedar.