### PR TITLE
Bug 1077554 - Use target="_blank" in fewer places

### DIFF
--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -16,13 +16,13 @@
 
     <h5>
       Want to contribute?
-      <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree+Management&amp;component=Treeherder" target="_blank">File a bug</a> /
-      <a href="https://github.com/mozilla/treeherder-ui" target="_blank">UI source</a> /
-      <a href="https://github.com/mozilla/treeherder-service" target="_blank">Backend source</a> /
-      <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder#Contributing" target="_blank">Contributing</a>
+      <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Tree+Management&amp;component=Treeherder">File a bug</a> /
+      <a href="https://github.com/mozilla/treeherder-ui">UI source</a> /
+      <a href="https://github.com/mozilla/treeherder-service">Backend source</a> /
+      <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder#Contributing">Contributing</a>
     </h5>
     For anything else visit our
-    <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder" target="_blank">Project Wiki</a>
+    <a href="https://wiki.mozilla.org/Auto-tools/Projects/Treeherder">Project Wiki</a>
     or ask us on IRC in
     <a href="irc://irc.mozilla.org/treeherder">#treeherder</a>
 </div>
@@ -479,7 +479,7 @@
   </div>
   <div class="col-xs-6">
     <a class="midgray pull-right"
-       href="../media/revision" target="_blank">Build</a>
+       href="../media/revision">Build</a>
   </div>
 </div>
 

--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -114,7 +114,6 @@
             <li>
                 <span class="revision">
                     <a href="{{currentRepo.url}}/rev/{{revision}}"
-                       target="_blank"
                        title="open revision {{revision}} on {{currentRepo.url}}"
                        >{{revision}}</a>
                     <span title="{{name}}: {{email}}">{{name|initials}}</span>

--- a/webapp/app/js/directives/resultsets.js
+++ b/webapp/app/js/directives/resultsets.js
@@ -132,8 +132,7 @@ treeherder.directive('thAuthor', function () {
             scope.authorEmail = email;
         },
         template: '<span title="open resultsets for {{authorName}}: {{authorEmail}}">' +
-                      '<a href="{{authorResultsetFilterUrl}}" ' +
-                         'target="_blank">{{authorName}}</a></span>'
+                      '<a href="{{authorResultsetFilterUrl}}">{{authorName}}</a></span>'
     };
 });
 

--- a/webapp/app/logviewer.html
+++ b/webapp/app/logviewer.html
@@ -20,8 +20,7 @@
                             <td ng-if="label == 'revision'" class="break-word">
                                 {{value}}
                                 <a href="{{logRevisionFilterUrl}}"
-                                   title="open resultset in new tab"
-                                   target="_blank"
+                                   title="open resultset"
                                    class="repo-link"
                                    ng-cloak>link</a>
                             </td>

--- a/webapp/app/partials/logviewer/lvLogSteps.html
+++ b/webapp/app/partials/logviewer/lvLogSteps.html
@@ -38,7 +38,7 @@
 </div>
 
 <div class="logviewer-stepbar">
-    <a target="_blank" href="{{::artifact.logurl}}">
+    <a href="{{::artifact.logurl}}">
         <span class="glyphicon glyphicon-align-left raw-log"></span>
         <span>open raw log</span>
     </a>

--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -13,8 +13,7 @@
         <span class="btn btn-default btn-sm glyphicon glyphicon-download" ng-show="isLoadingJobs"></span>
         <span>
           <a href="{{::revisionResultsetFilterUrl}}"
-             title="open this resultset in new tab"
-             target="_blank">{{::resultsetDateStr}}</a> - </span>
+             title="open this resultset">{{::resultsetDateStr}}</a> - </span>
         <th-author author="{{::resultset.author}}"></th-author>
       </span>
       <span>


### PR DESCRIPTION
It's currently (a) incorrectly being used for internal navigation links,
and (b) being used in cases where the user would likely not expect it.
eg: the standalone help page, where having to use the back button would
not lose any state (unlike the main Treeherder UI).