### PR TITLE
Bug 1107987 - Correctly show bug suggestions from the all_others bucket

### DIFF
--- a/webapp/app/plugins/failure_summary/controller.js
+++ b/webapp/app/plugins/failure_summary/controller.js
@@ -41,13 +41,6 @@ treeherder.controller('BugsPluginCtrl', [
                     if(artifact_list.length > 0){
                         var artifact = artifact_list[0];
                         angular.forEach(artifact.blob, function (suggestion) {
-
-                            // Workaround logs ingested prior to the fix for
-                            // bug 1059306 landing.
-                            if(!suggestion.bugs){
-                                suggestion.bugs = {"open_recent":[], "all_others":[]};
-                            }
-
                             suggestion.bugs.too_many_open_recent = (
                                 suggestion.bugs.open_recent.length > bug_limit
                             );

--- a/webapp/app/plugins/failure_summary/controller.js
+++ b/webapp/app/plugins/failure_summary/controller.js
@@ -47,16 +47,17 @@ treeherder.controller('BugsPluginCtrl', [
                             suggestion.bugs.too_many_all_others = (
                                 suggestion.bugs.all_others.length > bug_limit
                             );
-                            suggestion.open_recent_hidden = (
-                                suggestion.bugs.too_many_open_recent ||
-                                suggestion.bugs.open_recent.length === 0
+                            suggestion.valid_open_recent = (
+                                suggestion.bugs.open_recent.length > 0 &&
+                                !suggestion.bugs.too_many_open_recent
                             );
-
-                            suggestion.all_others_hidden = (
-                                suggestion.bugs.too_many_all_others ||
-                                suggestion.bugs.all_others.length === 0
+                            suggestion.valid_all_others = (
+                                suggestion.bugs.all_others.length > 0 &&
+                                !suggestion.bugs.too_many_all_others &&
+                                // If we have too many open_recent bugs, we're unlikely to have
+                                // relevant all_others bugs, so don't show them either.
+                                !suggestion.bugs.too_many_open_recent
                             );
-
                             suggestions.push(suggestion);
                         });
                         $scope.suggestions = suggestions;

--- a/webapp/app/plugins/failure_summary/main.html
+++ b/webapp/app/plugins/failure_summary/main.html
@@ -6,7 +6,7 @@
                 <span>{{::suggestion.search}}</span>
             </div>
             <!--Open recent bugs-->
-            <ul ng-if="! suggestion.bugs.open_recent_hidden"
+            <ul ng-if="suggestion.valid_open_recent"
                 class="list-unstyled failure-summary-bugs">
                 <li ng-repeat="bug in suggestion.bugs.open_recent">
                     <a class="btn btn-xs btn-default"
@@ -27,12 +27,12 @@
             </ul>
 
             <!--All other bugs-->
-            <a ng-if="!suggestion.all_others_hidden && !suggestion.open_recent_hidden"
+            <a ng-if="suggestion.valid_all_others && suggestion.valid_open_recent"
                href="" prevent-default-on-left-click
-               ng-click="suggestion.open_others = suggestion.open_others === true ? false : true"
+               ng-click="suggestion.clicked_show_more = (suggestion.clicked_show_more === true ? false : true)"
                class="show-hide-more">Show / Hide more</a>
 
-            <ul ng-if="!suggestion.all_others_hidden && suggestion.open_others"
+            <ul ng-if="suggestion.valid_all_others && (suggestion.clicked_show_more || !suggestion.valid_open_recent)"
                 class="list-unstyled failure-summary-bugs">
                 <li ng-repeat="bug in suggestion.bugs.all_others">
                     <a class="btn btn-xs btn-default"
@@ -52,7 +52,7 @@
                 </li>
             </ul>
 
-            <mark ng-if="suggestion.bugs.too_many_open_recent && suggestion.bugs.too_many_all_others"
+            <mark ng-if="suggestion.bugs.too_many_open_recent || (suggestion.bugs.too_many_all_others && !suggestion.valid_open_recent)"
                     >Exceeded max bug suggestions</mark>
 
         </li>


### PR DESCRIPTION
* Removes the temporary workaround added by https://bugzilla.mozilla.org/show_bug.cgi?id=1059949.
* Renames `{open_recent,all_others}_hidden` to `valid_{open_recent,all_others}` and inverts the conditionals accordingly.
* Adds the missing `(... || !suggestion.valid_open_recent)` to the all_others ng-if, which was the cause of this bug.
* Also adjusts the behaviour when open_recent exceeds the max bug count, such that we now no longer show the bugs from all_others, since they are likely also not relevant. ie we now show the "Exceeded max bug suggestions" error in more cases.
* Renamed `suggestion.open_others` to `suggestion.clicked_show_more` since it was too confusing alongside "all_others" and "open_recent".