### PR TITLE
bug 1071541 - remove local.conf.js from the grunt build

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -32,6 +32,7 @@
 
         <script src="js/index.min-b6bcd946fa1b14e6db4d70e64581f36d.js"></script>
 
+        <script src="js/config/local.conf.js"></script>
         <script src="https://login.persona.org/include.js"></script>
 
         <!-- Clone targets -->

--- a/dist/logviewer.html
+++ b/dist/logviewer.html
@@ -39,5 +39,8 @@
         </div>
 
         <script src="js/logviewer.min-73e49e674d119ede5e5af8ccb93d9485.js"></script>
+
+        <script src="js/config/local.conf.js"></script>
+
     </body>
 </html>

--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -51,7 +51,6 @@
 
         <script src="js/app.js"></script>
         <script src="js/services/log.js"></script>
-        <script src="js/config/local.conf.js"></script>
         <script src="js/providers.js"></script>
         <script src="js/values.js"></script>
         <!-- Directives -->
@@ -104,6 +103,7 @@
         <script src="js/filters.js"></script>
         <!-- endbuild -->
 
+        <script src="js/config/local.conf.js"></script>
         <script src="https://login.persona.org/include.js"></script>
 
         <!-- Clone targets -->

--- a/webapp/app/logviewer.html
+++ b/webapp/app/logviewer.html
@@ -56,7 +56,6 @@
         <script src="vendor/resizer.js"></script>
 
         <script src="js/app.js"></script>
-        <script src="js/config/local.conf.js"></script>
         <script src="js/providers.js"></script>
 
         <!-- Directives -->
@@ -75,5 +74,8 @@
         <!-- Controllers -->
         <script src="js/controllers/logviewer.js"></script>
         <!-- endbuild -->
+
+        <script src="js/config/local.conf.js"></script>
+
     </body>
 </html>


### PR DESCRIPTION
Now that we default to the same host for the service, we don’t need a
local.conf.js file to work properly.  Removing this prevents the
accident of stage pointing to prod or vice-versa, etc.