### PR TITLE
When selecting a Talos run, for each uploaded profile zip, show a link for opening it directly in Cleopatra.

### DIFF
--- a/webapp/app/plugins/talos/main.html
+++ b/webapp/app/plugins/talos/main.html
@@ -16,3 +16,10 @@
     </li>
   </ul>
 </span>
+
+<ul>
+  <li ng-repeat="line in job_details"
+      ng-if="line.content_type == 'link' && line.value.substr(-8) == '.sps.zip'">
+    <a href="http://people.mozilla.com/~bgirard/cleopatra/?zippedProfile={{line.url}}">Open {{line.value}} in Cleopatra</a>
+  </li>
+</ul>


### PR DESCRIPTION
This will work once these are fixed: https://github.com/bgirard/cleopatra/pull/54 , https://bugzilla.mozilla.org/show_bug.cgi?id=1121571 , https://bugzilla.mozilla.org/show_bug.cgi?id=1122848

Here's the motivation, copied from https://bugzilla.mozilla.org/show_bug.cgi?id=1122848#c0 :

I'd like to make Talos profiles accessible in cleopatra (our profile visualization / consumption tool) through a simple link on treeherder.

When you push to try with "mozharness: --spsProfile" at the end of the try chooser commit message, Talos will run its performance tests under a profiler, create zip files that contain the collected profiles, and put them in the MOZ_UPLOAD_DIR. These files can then be downloaded using the "artifact uploaded" links on treeherder. At the moment, the user then has to unzip those files, load http://people.mozilla.com/~bgirard/cleopatra/ in a browser, and drag one of the unzipped profiles into the file chooser on cleopatra.

I'd like to simplify this process by having treeherder insert a link to 
http://people.mozilla.com/~bgirard/cleopatra/?zippedProfile=[url to the zip].
Then cleopatra would grab the zip, extract it right in the browser, ask the user to select one of the contained profiles, and then display that profile.