### PR TITLE
Bug 1120133 - Enhance copy of logviewer/raw log icon links

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -28,6 +28,23 @@ body {
     visibility: hidden;
 }
 
+#clipboard-container {
+    position: fixed;
+    top: 0px;
+    left: 0px;
+    width: 0px;
+    height: 0px;
+    z-index: 100;
+    display: none;
+    opacity: 0;
+}
+
+#clipboard {
+    width: 1px;
+    height: 1px;
+    padding: 0px;
+}
+
 .th-navbar {
     background-color: #273038;
     margin-bottom: 0px;

--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -134,6 +134,8 @@
                     <td>Toggle in-progress (running/pending) jobs</td></tr>
                     <tr><th>u</th>
                     <td>Show only unclassified failures</td></tr>
+                    <tr><th><span>(hover) + </span>ctrl/cmd<span>+</span>c</th>
+                    <td>Copy logviewer or raw log icon links to clipboard</td></tr>
                 </table>
             </div>
         </div>

--- a/webapp/app/js/directives/main.js
+++ b/webapp/app/js/directives/main.js
@@ -78,6 +78,30 @@ treeherder.directive('selectOnClick', [
         }
     };
 }]);
+
+// Allow copy to system clipboard during hover
+treeherder.directive('copyValue', [
+    function() {
+        return {
+            restrict: 'A',
+            link: function(scope, element, attrs) {
+                var cont = document.getElementById('clipboard-container'),
+                    clip = document.getElementById('clipboard');
+                element.on('mouseenter', function() {
+                    cont.style.display = 'block';
+                    clip.value = attrs.copyValue;
+                    clip.focus();
+                    clip.select();
+                });
+                element.on('mouseleave', function() {
+                    cont.style.display = 'none';
+                    clip.value = '';
+                });
+            }
+        }
+    }
+]);
+
 // Prevent default behavior on left mouse click. Useful
 // for html anchor's that need to do in application actions
 // on left click but default href type functionality on

--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -148,6 +148,7 @@ treeherder.controller('PluginCtrl', [
                         });
                     }
                     $scope.lvUrl = thUrl.getLogViewerUrl($scope.job.id);
+                    $scope.lvFullUrl = location.origin + "/ui/" + $scope.lvUrl;
                     $scope.resultStatusShading = "result-status-shading-" + thResultStatus($scope.job);
 
                     updateVisibleFields();

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -19,6 +19,7 @@
                title="Open the log viewer in a new window"
                target="_blank"
                href="{{::lvUrl}}"
+               copy-value="{{::lvFullUrl}}"
                class="">
               <img src="./img/logviewerIcon.svg"
                    class="logviewer-icon"><img>
@@ -46,7 +47,10 @@
           </li>
 
           <li ng-repeat="job_log_url in job_log_urls">
-            <a title="Open the raw log in a new window" target="_blank" href="{{::job_log_url.url}}">
+            <a title="Open the raw log in a new window"
+               target="_blank"
+               href="{{::job_log_url.url}}"
+               copy-value="{{::job_log_url.url}}">
               <span class="glyphicon glyphicon-align-left"></span>
             </a>
           </li>
@@ -274,3 +278,4 @@
     </div>
   </div>
 </div>
+<div id="clipboard-container"><textarea id="clipboard"></textarea></div>


### PR DESCRIPTION
This work fixes Bugzilla bug [1120133](https://bugzilla.mozilla.org/show_bug.cgi?id=1120133).

This allows the user to hover over the logviewer or raw log icon, which injects into a placeholder clipboard div a specified value. This can then be directly copied to the users' system clipboard.

In the change below, we mimic the Trello solution in angular. Here's the general workflow scenario:

* User hovers over a log icon

...![mouseenterhover2](https://cloud.githubusercontent.com/assets/3660661/5824347/066a5394-a0b2-11e4-880d-638da21d840d.jpg)

* User simply issues a copy to their clipboard via **ctrl+c** or **cmd+c**

* User pastes it somewhere, for example in channel

...![linkpaste](https://cloud.githubusercontent.com/assets/3660661/5824215/0311b9cc-a0b1-11e4-84ff-892ecba930f5.jpg)

So the previous workflows, are no longer required.

Everything seems to be working generally fine, at least on windows. If someone can try it with vagrant which uses the intended $scope.lvFullUrl link fragment value of `/ui/` that would be great. I was using a local value of `/app/` during local development.

If someone feels strongly we should include this in Help or expand the tooltip title for logviewer/raw log we can, but it seemed a bit excessive, since this is quite a power user type of feature and clutters the tooltip.

Tested on Windows:
FF Release **35.0**
Chrome Latest Release **39.0.2171.99 m**

Adding @camd for review and @edmorley and @rvandermeulen for visibility.