### PR TITLE
Bug 1124792 - Failure summary: Add bug resolution to closed bug tooltips

### DIFF
--- a/webapp/app/plugins/failure_summary/main.html
+++ b/webapp/app/plugins/failure_summary/main.html
@@ -39,12 +39,20 @@
                        title="add to list of bugs to associate with all pinned jobs">
                       <i class="glyphicon glyphicon-pushpin"></i>
                     </a>
-                    <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.id}}"
-                       target="_blank"
-                       ng-class="{'deleted': bug.resolution != ''}">{{::bug.id}}
+                    <a ng-if="bug.resolution === ''"
+                       href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.id}}"
+                       target="_blank">{{::bug.id}}
                         <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:suggestion.search"
-                              title="{{::bug.summary}}"
-                              ng-class="{'deleted': bug.resolution != ''}">{{::bug.summary}}
+                              title="{{::bug.summary}}">{{::bug.summary}}
+                        </span>
+                    </a>
+                    <a ng-if="bug.resolution !== ''"
+                       href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.id}}"
+                       target="_blank"
+                       class="deleted">{{::bug.id}}
+                        <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:suggestion.search"
+                              title="{{::bug.resolution}} - {{::bug.summary}}"
+                              class="deleted">{{::bug.summary}}
                         </span>
                     </a>
                 </li>

--- a/webapp/app/plugins/failure_summary/main.html
+++ b/webapp/app/plugins/failure_summary/main.html
@@ -16,11 +16,9 @@
                       <i class="glyphicon glyphicon-pushpin"></i>
                     </a>
                     <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{::bug.id}}"
-                       target="_blank"
-                       ng-class="{'deleted': bug.resolution != ''}">{{::bug.id}}
+                       target="_blank">{{::bug.id}}
                         <span ng-bind-html="bug.summary | escapeHTML | highlightCommonTerms:suggestion.search"
-                              title="{{::bug.summary}}"
-                              ng-class="{'deleted': bug.resolution != ''}">{{::bug.summary}}
+                              title="{{::bug.summary}}">{{::bug.summary}}
                         </span>
                     </a>
                 </li>


### PR DESCRIPTION
This:
* Removes unnecessary resolution check for open_recent bugs (since the bugs by definition are always open).
* If a bug is resolved/closed, shows the resolution (eg 'FIXED', 'INVALID') in the tooltip for the bug link. With this change, there would have been three places that were conditional on |bug.resolution != ''| so I've switched to an ng-if and two versions of the link.