### PR TITLE
Bug 1120133 - Remove ui fragment from logviewer hover link

### DIFF
--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -148,7 +148,7 @@ treeherder.controller('PluginCtrl', [
                         });
                     }
                     $scope.lvUrl = thUrl.getLogViewerUrl($scope.job.id);
-                    $scope.lvFullUrl = location.origin + "/ui/" + $scope.lvUrl;
+                    $scope.lvFullUrl = location.origin + "/" + $scope.lvUrl;
                     $scope.resultStatusShading = "result-status-shading-" + thResultStatus($scope.job);
 
                     updateVisibleFields();


### PR DESCRIPTION
Supplemental fix to Bugzilla bug [1120133](https://bugzilla.mozilla.org/show_bug.cgi?id=1120133).

This removes the `/ui` path fragment from the logviewer icon 'hover' url, as it is not needed on production.

Someone with vagrant will want to sanity-check this change locally before merge. I have checked the existing production environment works without the fragment, so it should work.

Not locally tested, per above.

Adding @camd for review and a local check.