### PR TITLE
Bug 1118253 - Clear job selection in page bottom and get-next-footer

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -23,6 +23,14 @@ a:visited {
     height: 100%;
 }
 
+.getnext-footer {
+    margin-bottom: 0;
+}
+
+.footer-spacer {
+    height: 300px;
+}
+
 .pagination, .carousel, .panel-title a {
     cursor: pointer;
 }

--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -96,7 +96,9 @@
     <div class="progress-bar"  role="progressbar" style="width: 100%"></div>
 </div>
 
-<div class="well" ng-if="result_sets.length > 1">
+<!-- Get next resultsets footer -->
+<div class="well getnext-footer" ng-if="result_sets.length > 1"
+     ng-click="closeJob()">
      get next:
     <div class="btn-group">
         <div class="btn btn-default btn-sm"
@@ -104,4 +106,9 @@
              ng-repeat="count in [10, 20, 50]">{{::count}}</div>
         </div>
     </div>
+</div>
+
+<!-- Footer spacer -->
+<div class="footer-spacer"
+     ng-click="closeJob()">
 </div>


### PR DESCRIPTION
This work fixes Bugzilla bug [1118253](https://bugzilla.mozilla.org/show_bug.cgi?id=1118253).

In it, we close the selected job when clicking in the get-next footer, and also provide a reasonably sized click region below it for the same functionality for short result sets.

Here's the get-next behavior pre-click and post-click (clicking in the grey region):

![getnextpreclick](https://cloud.githubusercontent.com/assets/3660661/5942013/cf8e3b06-a6e2-11e4-9223-6e735dbd56ba.jpg)

![getnextpostclick](https://cloud.githubusercontent.com/assets/3660661/5942021/d82c5f0e-a6e2-11e4-9f17-46f74c28b9f3.jpg)

And the behavior in the region below the job rows, pre-click and post-click:

![shortpushpreclick](https://cloud.githubusercontent.com/assets/3660661/5942041/f4695abe-a6e2-11e4-81f8-54d4d5f5ec05.jpg)

![shortpushpostclick](https://cloud.githubusercontent.com/assets/3660661/5942042/f9e0a466-a6e2-11e4-958b-b06edcaaa257.jpg)

For now we just use a 300px static spacer, and don't attempt to calculate a dynamic one, given the vagaries of the movable job panel, pinboard, and pin-board job panel combo (open or closed), all of which affect a potential dimension calculation. We could revisit that later if needed.

Tested on Windows:
FF Release **35.0.1**
Chrome Latest Release **40.0.2214.93 m**

Adding @camd for review and @edmorley for visibility.