### PR TITLE
Bug 1118253 - Remove footer spacer for a future clearing method

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -27,10 +27,6 @@ a:visited {
     margin-bottom: 0;
 }
 
-.footer-spacer {
-    height: 300px;
-}
-
 .pagination, .carousel, .panel-title a {
     cursor: pointer;
 }

--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -107,8 +107,3 @@
         </div>
     </div>
 </div>
-
-<!-- Footer spacer -->
-<div class="footer-spacer"
-     ng-click="closeJob()">
-</div>


### PR DESCRIPTION
This is a continuation of work for Bugzilla bug [1118253](https://bugzilla.mozilla.org/show_bug.cgi?id=1118253).

With sheriff feedback, we decided to try for another approach to clearing the selected job in the area below the get-next footer. Preference is for trying to do it without a spacer, and try for my previously investigated approach to see if we can handle all the events correctly in `th-content` and clear it there.

I made sure the removal is working properly and we are back to our old state, and it seems to be fine.

Tested on Windows:
FF Release **35.0.1**
Chrome Latest Release **40.0.2214.93 m**

Adding @wlach for review and @edmorley and @rvandermeulen for visibility.