### PR TITLE
Bug 1045606 - Make global filters discoverable/prominant

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1178,6 +1178,71 @@ fieldset[disabled] .btn-unclassified-failures.active {
   border-color: #e0e0e0;
 }
 
+.btn-filter-chicklets {
+  background-color: white;
+  border-color: #a9a9a9;
+  color: white;
+}
+
+.btn-nav-filter {
+  padding: 7px 2px;
+}
+
+.chicklet-off {
+  text-decoration: line-through;
+  opacity: 0.5;
+}
+
+.btn-filter-chicklet-orange,
+.btn-filter-chicklet-orange:hover {
+  color: #dd6602;
+}
+
+.btn-filter-chicklet-red,
+.btn-filter-chicklet-red:hover {
+  color: #C03A44;
+}
+
+.btn-filter-chicklet-purple,
+.btn-filter-chicklet-purple:hover {
+  color: #77438D;
+}
+
+.btn-filter-chicklet-green,
+.btn-filter-chicklet-green:hover {
+  color: rgba(2, 130, 51, 0.75);
+}
+
+.btn-filter-chicklet-dkblue,
+.btn-filter-chicklet-dkblue:hover {
+  color: #3656FF;
+}
+
+.btn-filter-chicklet-pink,
+.btn-filter-chicklet-pink:hover {
+  color: rgba(250, 115, 172, 0.82);
+}
+
+.btn-filter-chicklet-yellow,
+.btn-filter-chicklet-yellow:hover {
+  color: #cdce1d;
+}
+
+.btn-filter-chicklet-ltgray,
+.btn-filter-chicklet-ltgray:hover {
+  color: #e0e0e0;
+}
+
+.btn-filter-chicklet-dkgray,
+.btn-filter-chicklet-dkgray:hover {
+  color: #7c7a7d;
+}
+
+.btn-filter-chicklet-black,
+.btn-filter-chicklet-black:hover {
+  color: black;
+}
+
 /* Transformed job buttons for main job block */
 .btn-lg-xform {
     margin: -2px !important;

--- a/webapp/app/js/controllers/filters.js
+++ b/webapp/app/js/controllers/filters.js
@@ -36,6 +36,7 @@ treeherder.controller('FilterPanelCtrl', [
         };
 
         $scope.resultStatusFilters = {};
+        $scope.orderedFilters = _.flatten(_.pluck($scope.filterGroups, "resultStatuses"));
 
         // field filters
         $scope.newFieldFilter = null;
@@ -68,6 +69,21 @@ treeherder.controller('FilterPanelCtrl', [
             if (!$scope.resultStatusFilters[filter]) {
                 thJobFilters.removeFilter(thJobFilters.resultStatus, filter);
             } else {
+                thJobFilters.addFilter(thJobFilters.resultStatus, filter);
+            }
+        };
+
+        /**
+         * Handle toggling one of the individual result status filter chicklets
+         * on the nav bar
+         */
+        $scope.toggleResultStatusFilterChicklet = function(filter) {
+            console.log("$scope.resultStatusFilters", $scope.resultStatusFilters);
+            if ($scope.resultStatusFilters[filter]) {
+                $scope.resultStatusFilters[filter] = false;
+                thJobFilters.removeFilter(thJobFilters.resultStatus, filter);
+            } else {
+                $scope.resultStatusFilters[filter] = true;
                 thJobFilters.addFilter(thJobFilters.resultStatus, filter);
             }
         };

--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -226,6 +226,10 @@ treeherder.controller('MainCtrl', [
 
         };
 
+        $scope.toggleCompactMode = function() {
+            $rootScope.isCompactMode = !$rootScope.isCompactMode;
+        };
+
         var getNewReloadTriggerParams = function() {
             return _.pick(
                 $location.search(),
@@ -265,6 +269,9 @@ treeherder.controller('MainCtrl', [
             $location.search({"repo": repo_name});
         };
 
+        $scope.isFilterDefaults = function() {
+            thJobFilters.isDefaults();
+        };
 
         $scope.isFilterPanelShowing = false;
         $scope.setFilterPanelShowing = function(tf) {

--- a/webapp/app/js/directives/top_nav_bar.js
+++ b/webapp/app/js/directives/top_nav_bar.js
@@ -17,6 +17,19 @@ treeherder.directive('thFilterCheckbox', [
     };
 }]);
 
+treeherder.directive('thResultStatusChicklet', [
+    'thResultStatusInfo',
+    function (thResultStatusInfo) {
+
+    return {
+        restrict: "E",
+        link: function(scope, element, attrs) {
+            scope.chickletClass = thResultStatusInfo(scope.filterName).chickletClass;
+        },
+        templateUrl: 'partials/main/thResultStatusChicklet.html'
+    };
+}]);
+
 treeherder.directive('thWatchedRepo', [
     'ThLog',
     function (ThLog) {

--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -76,6 +76,7 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 1,
                         btnClass: "btn-red",
+                        chickletClass: "btn-filter-chicklet-red",
                         btnClassClassified: "btn-red-classified",
                         jobButtonIcon: "glyphicon glyphicon-fire",
                         countText: "busted"
@@ -85,6 +86,7 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 2,
                         btnClass: "btn-purple",
+                        chickletClass: "btn-filter-chicklet-purple",
                         btnClassClassified: "btn-purple-classified",
                         jobButtonIcon: "glyphicon glyphicon-fire",
                         countText: "exception"
@@ -94,6 +96,7 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 3,
                         btnClass: "btn-orange",
+                        chickletClass: "btn-filter-chicklet-orange",
                         btnClassClassified: "btn-orange-classified",
                         jobButtonIcon: "glyphicon glyphicon-warning-sign",
                         countText: "failed"
@@ -103,6 +106,7 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 4,
                         btnClass: "btn-black",
+                        chickletClass: "btn-filter-chicklet-black",
                         btnClassClassified: "btn-black-classified",
                         jobButtonIcon: "",
                         countText: "unknown"
@@ -112,6 +116,7 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 5,
                         btnClass: "btn-pink",
+                        chickletClass: "btn-filter-chicklet-pink",
                         jobButtonIcon: "",
                         countText: "cancel"
                     };
@@ -120,6 +125,7 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 6,
                         btnClass: "btn-dkblue",
+                        chickletClass: "btn-filter-chicklet-dkblue",
                         jobButtonIcon: "",
                         countText: "retry"
                     };
@@ -128,6 +134,7 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 7,
                         btnClass: "btn-green",
+                        chickletClass: "btn-filter-chicklet-green",
                         jobButtonIcon: "",
                         countText: "success"
                     };
@@ -136,6 +143,7 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 8,
                         btnClass: "btn-dkgray",
+                        chickletClass: "btn-filter-chicklet-dkgray",
                         jobButtonIcon: "",
                         countText: "running"
                     };
@@ -144,6 +152,7 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 100,
                         btnClass: "btn-ltgray",
+                        chickletClass: "btn-filter-chicklet-ltgray",
                         jobButtonIcon: "",
                         countText: "pending"
                     };
@@ -152,6 +161,7 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 101,
                         btnClass: "btn-yellow",
+                        chickletClass: "btn-filter-chicklet-yellow",
                         jobButtonIcon: "",
                         countText: "coalesced"
                     };

--- a/webapp/app/partials/main/thFilterChicklets.html
+++ b/webapp/app/partials/main/thFilterChicklets.html
@@ -1,0 +1,8 @@
+<span id="filterChicklets"
+     ng-controller="FilterPanelCtrl">
+
+    <!-- result status filters -->
+    <span ng-repeat="filterName in orderedFilters">
+        <th-result-status-chicklet></th-result-status-chicklet>
+    </span>
+</span>

--- a/webapp/app/partials/main/thGlobalTopNavPanel.html
+++ b/webapp/app/partials/main/thGlobalTopNavPanel.html
@@ -52,6 +52,17 @@
                        ng-show="isFilterPanelShowing"></i>
                 </span>
 
+                <!-- Compactness Button -->
+                <span class="btn btn-view-nav btn-right-navbar nav-menu-btn"
+                      title="Toggle terse mode"
+                      ng-click="toggleCompactMode()"
+                      tabindex="0"><span>Compact</span>
+                    <span class="label label-default"
+                       ng-if="isCompactMode">On</span>
+                    <span class="label label-default"
+                       ng-if="!isCompactMode">Off</span>
+                </span>
+
                 <!-- Help Button -->
                 <a class="btn btn-view-nav nav-help-btn"
                    title="Treeherder help" href="help.html" target="_blank">

--- a/webapp/app/partials/main/thResultStatusChicklet.html
+++ b/webapp/app/partials/main/thResultStatusChicklet.html
@@ -1,0 +1,11 @@
+<span ng-if="!isCompactMode"
+      class="btn btn-view-nav btn-sm btn-nav-filter {{chickletClass}}"
+      ng-class="{'chicklet-off': (!resultStatusFilters[filterName])}"
+      ng-click="toggleResultStatusFilterChicklet(filterName)">{{filterName}}
+</span>
+<span ng-if="isCompactMode"
+      class="btn btn-view-nav btn-sm btn-nav-filter {{chickletClass}} fa"
+      ng-class="{'fa-dot-circle-o': (resultStatusFilters[filterName]), 'fa-circle-thin': (!resultStatusFilters[filterName])}"
+      ng-click="toggleResultStatusFilterChicklet(filterName)"
+      title="{{filterName}}">
+</span>

--- a/webapp/app/partials/main/thWatchedRepoNavPanel.html
+++ b/webapp/app/partials/main/thWatchedRepoNavPanel.html
@@ -32,6 +32,11 @@
                     </span>
                 </span>
 
+                <!--Result Status Filter Chicklets-->
+                <span class="resultStatusChicklets">
+                    <ng-include src="'partials/main/thFilterChicklets.html'"></ng-include>
+                </span>
+
                 <!--Search Field-->
                 <span ng-controller="SearchCtrl" class="form-group form-inline">
                     <input id="platform-job-text-search-field"


### PR DESCRIPTION
This work fixes [Bug 1045606](https://bugzilla.mozilla.org/show_bug.cgi?id=1045606)
- Expose Result State filters on the top nav bar to make them more discoverable and more easily actionable.  It might be better to have these just plain text/not colored.  Not sure.
  ![screenshot 2015-02-02 19 13 18](https://cloud.githubusercontent.com/assets/419924/6013871/943f01b2-ab0f-11e4-8e92-692053aad8ba.png)
- Created a "Compact" mode switch.  Only the state filters honor it, at this time.  But this can be used to set things to have only icons (terse on) or text (terse off).  It's not persisted yet, but easily could be in localStorage.
  ![screenshot 2015-02-13 11 41 51](https://cloud.githubusercontent.com/assets/419924/6194040/5cf6e710-b375-11e4-8edf-420649ca5a24.png)

Here's the filters in compact mode:
![screenshot 2015-02-02 19 10 54](https://cloud.githubusercontent.com/assets/419924/6013847/3c9f98e0-ab0f-11e4-9bd0-8cae72829c7a.png)
![screenshot 2015-02-02 19 12 29](https://cloud.githubusercontent.com/assets/419924/6013859/77ad720e-ab0f-11e4-9ada-08bd7f23cf89.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/353)

<!-- Reviewable:end -->
