### PR TITLE
Bug 1127454 - Remove status counts

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1242,6 +1242,33 @@ fieldset[disabled] .btn-orange.active {
   border-color: #dd6602;
 }
 
+.btn-orange-classified {
+  color: #dd6602;
+}
+.btn-orange-classified:hover,
+.btn-orange-classified:focus,
+.btn-orange-classified:active,
+.btn-orange-classified.active {
+  background-color: #c45a02;
+  border-color: #aa4f02;
+  color: white;
+}
+.btn-orange-classified.disabled:hover,
+.btn-orange-classified.disabled:focus,
+.btn-orange-classified.disabled:active,
+.btn-orange-classified.disabled.active,
+.btn-orange-classified[disabled]:hover,
+.btn-orange-classified[disabled]:focus,
+.btn-orange-classified[disabled]:active,
+.btn-orange-classified[disabled].active,
+fieldset[disabled] .btn-orange-classified:hover,
+fieldset[disabled] .btn-orange-classified:focus,
+fieldset[disabled] .btn-orange-classified:active,
+fieldset[disabled] .btn-orange-classified.active {
+  background-color: #dd6602;
+  border-color: #dd6602;
+}
+
 .btn-orange-count-classified {
   background-color: white;
   border-color: #bfbfbf;
@@ -1281,6 +1308,34 @@ fieldset[disabled] .btn-red:active,
 fieldset[disabled] .btn-red.active {
   background-color: #c2020e;
   border-color: #c2020e;
+}
+
+.btn-red-classified {
+  color: #90010a;
+}
+.btn-red-classified:hover,
+.btn-red-classified:focus,
+.btn-red-classified:active,
+.btn-red-classified.active {
+  background-color: #a9020c;
+  border-color: #90010a;
+  color: white;
+}
+.btn-red-classified.disabled:hover,
+.btn-red-classified.disabled:focus,
+.btn-red-classified.disabled:active,
+.btn-red-classified.disabled.active,
+.btn-red-classified[disabled]:hover,
+.btn-red-classified[disabled]:focus,
+.btn-red-classified[disabled]:active,
+.btn-red-classified[disabled].active,
+fieldset[disabled] .btn-red-classified:hover,
+fieldset[disabled] .btn-red-classified:focus,
+fieldset[disabled] .btn-red-classified:active,
+fieldset[disabled] .btn-red-classified.active {
+  background-color: #c2020e;
+  border-color: #c2020e;
+  color: white;
 }
 
 .btn-red-count-classified {
@@ -1385,6 +1440,34 @@ fieldset[disabled] .btn-purple:hover,
 fieldset[disabled] .btn-purple:focus,
 fieldset[disabled] .btn-purple:active,
 fieldset[disabled] .btn-purple.active {
+  background-color: #9002c2;
+  border-color: #9002c2;
+  color: white;
+}
+
+.btn-purple-classified {
+  color: #6f0296;
+}
+.btn-purple-classified:hover,
+.btn-purple-classified:focus,
+.btn-purple-classified:active,
+.btn-purple-classified.active {
+  background-color: #7d02a9;
+  border-color: #6b0190;
+  color: white;
+}
+.btn-purple-classified.disabled:hover,
+.btn-purple-classified.disabled:focus,
+.btn-purple-classified.disabled:active,
+.btn-purple-classified.disabled.active,
+.btn-purple-classified[disabled]:hover,
+.btn-purple-classified[disabled]:focus,
+.btn-purple-classified[disabled]:active,
+.btn-purple-classified[disabled].active,
+fieldset[disabled] .btn-purple-classified:hover,
+fieldset[disabled] .btn-purple-classified:focus,
+fieldset[disabled] .btn-purple-classified:active,
+fieldset[disabled] .btn-purple-classified.active {
   background-color: #9002c2;
   border-color: #9002c2;
   color: white;

--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -414,8 +414,28 @@ th-watched-repo {
     display: flex;
     display: -webkit-flex;
     -webkit-flex-flow: row wrap;
-    flex-flow: row wrap;
+    flex-flow: row nowrap;
     align-items: center;
+    justify-content: space-between;
+}
+
+.result-set-left {
+    display: flex;
+    display: -webkit-flex;
+    -webkit-flex-flow: row wrap;
+    flex-flow: row wrap;
+    flex: auto;
+    align-items: center;
+}
+
+.result-set-progress {
+    color: #6f6d70;
+    font-style: italic;
+    margin-left: 10px;
+}
+
+.result-set-buttons {
+    margin-right: 25px;
 }
 
 .result-set .revision-list {
@@ -1024,6 +1044,12 @@ ul.failure-summary-list li .btn-xs {
 .result-status-shading-coalesced {background-color: white;}
 
 .result-status-count-group {
+    opacity: 0;
+    font-size: 12px;
+    white-space: nowrap;
+}
+.result-status-count-group:hover {
+    opacity: 1;
     font-size: 12px;
     white-space: nowrap;
 }
@@ -1583,7 +1609,22 @@ fieldset[disabled] .btn-mdgray.active {
 }
 
 .btn-resultset {
-    color: #666;
+  color: #666;
+}
+.btn-resultset:hover{
+  background-color: #6f6d70;
+  color: white;
+}
+.btn-resultset.disabled:hover,
+.btn-resultset.disabled:active,
+.btn-resultset.disabled.active,
+.btn-resultset[disabled]:hover,
+.btn-resultset[disabled]:active,
+.btn-resultset[disabled].active,
+fieldset[disabled] .btn-resultset:hover {
+  background-color: #7c7a7d;
+  border-color: #7c7a7d;
+  color: white;
 }
 
 .btn-dkgray {

--- a/webapp/app/js/controllers/jobs.js
+++ b/webapp/app/js/controllers/jobs.js
@@ -36,7 +36,6 @@ treeherder.controller('JobsCtrl', [
         $scope.isLoadingRsBatch = ThResultSetStore.getLoadingStatus($scope.repoName);
         $scope.result_sets = ThResultSetStore.getResultSetsArray($scope.repoName);
         $scope.job_map = ThResultSetStore.getJobMap($scope.repoName);
-        $scope.statusList = thResultStatusList.counts();
 
         $scope.searchParams = $location.search();
         $scope.locationHasSearchParam = function(prop) {

--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -180,7 +180,7 @@ treeherder.controller('MainCtrl', [
             }else{
                 $location.search('exclusion_profile', 'false');
             }
-        }
+        };
 
         $scope.toggleUnclassifiedFailures = thJobFilters.toggleUnclassifiedFailures;
 

--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -304,7 +304,6 @@ treeherder.directive('thCloneJobs', [
     };
 
     var addRevisions = function(resultset, element){
-//        $log.debug("addRevisions", resultset, element);
 
         if(resultset.revisions.length > 0){
 
@@ -339,7 +338,7 @@ treeherder.directive('thCloneJobs', [
                 var pushlogInterpolator = thCloneHtml.get('pushlogRevisionsClone').interpolator;
                 ulEl.append(pushlogInterpolator({
                     currentRepo: $rootScope.currentRepo,
-                    revision: resultset.revision,
+                    revision: resultset.revision
                 }));
             }
         }
@@ -361,7 +360,7 @@ treeherder.directive('thCloneJobs', [
         var rowEl = revisionsEl.parent();
         rowEl.css('display', 'block');
 
-        if(on){
+        if(on) {
 
             ThResultSetStore.loadRevisions(
                 $rootScope.repoName, this.resultset.id
@@ -376,7 +375,7 @@ treeherder.directive('thCloneJobs', [
                 toggleRevisionsSpanOnWithoutJobs(revisionsEl);
             }
 
-        }else{
+        } else {
             toggleRevisionsSpanOff(revisionsEl);
 
             if(jobsElDisplayState === 'block'){

--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -227,7 +227,13 @@ treeherder.directive('thCloneJobs', [
             jobStatus.key = key;
             if(parseInt(job.failure_classification_id, 10) > 1){
                 jobStatus.value = job.job_type_symbol + '*';
-            }else{
+                if (jobStatus.btnClassClassified) {
+                    // For result types that are displayed more prominently
+                    // when unclassified, switch to the more subtle classified
+                    // style.
+                    jobStatus.btnClass = jobStatus.btnClassClassified;
+                }
+            } else {
                 jobStatus.value = job.job_type_symbol;
             }
 

--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -376,68 +376,11 @@ treeherder.directive('thCloneJobs', [
                 toggleRevisionsSpanOnWithJobs(revisionsEl);
                 //Make sure the jobs span has correct styles
                 toggleJobsSpanOnWithRevisions(jobsEl);
-
-            }else{
-                toggleRevisionsSpanOnWithoutJobs(revisionsEl);
             }
 
         } else {
             toggleRevisionsSpanOff(revisionsEl);
-
-            if(jobsElDisplayState === 'block'){
-                toggleJobsSpanOnWithoutRevisions(jobsEl);
-            }else{
-                //Nothing is displayed, hide the row to
-                //prevent a double border from displaying
-                rowEl.css('display', 'none');
-            }
-        }
-
-    };
-    /**
-     * Toggle the jobs of a resultset expanded or collapsed
-     * @param element - The element to expand/collapse
-     * @param expand - whether to force either expanding or collapsing.  If 'undefined' then
-     *                 just toggle.  If set to true, the expand if it isn't already.  Supports
-     *                 an expand/collapse all button.
-     */
-    var toggleJobs = function(element, expand){
-
-
-        var revisionsEl = element.find('ul').parent();
-        var jobsEl = element.find('table').parent();
-
-        var revElDisplayState = revisionsEl.css('display') || 'block';
-        var jobsElDisplayState = jobsEl.css('display') || 'block';
-
-        var on = jobsElDisplayState !== 'block';
-        if (!_.isUndefined(expand)) {
-            on = expand;
-        }
-
-        var rowEl = revisionsEl.parent();
-        rowEl.css('display', 'block');
-
-        if(on){
-
-            if(revElDisplayState === 'block'){
-                toggleJobsSpanOnWithRevisions(jobsEl);
-                //Make sure the revisions span has correct styles
-                toggleRevisionsSpanOnWithJobs(revisionsEl);
-            }else{
-                toggleJobsSpanOnWithoutRevisions(jobsEl);
-            }
-
-        }else{
-            toggleJobsSpanOff(jobsEl);
-
-            if(revElDisplayState === 'block'){
-                toggleRevisionsSpanOnWithoutJobs(revisionsEl);
-            }else{
-                //Nothing is displayed, hide the row to
-                //prevent a double border from displaying
-                rowEl.css('display', 'none');
-            }
+            toggleJobsSpanOnWithoutRevisions(jobsEl);
         }
 
     };
@@ -445,10 +388,6 @@ treeherder.directive('thCloneJobs', [
     var toggleRevisionsSpanOnWithJobs = function(el){
         el.css('display', 'block');
         el.addClass(col5Cls);
-    };
-    var toggleRevisionsSpanOnWithoutJobs = function(el){
-        el.css('display', 'block');
-        el.removeClass(col5Cls);
     };
     var toggleRevisionsSpanOff = function(el){
         el.css('display', 'none');
@@ -467,9 +406,6 @@ treeherder.directive('thCloneJobs', [
         el.removeClass(jobListPadLeftCls);
         el.addClass(jobListNoPadCls);
         el.addClass(col12Cls);
-    };
-    var toggleJobsSpanOff = function(el){
-        el.css('display', 'none');
     };
 
     var renderJobTableRow = function(

--- a/webapp/app/js/directives/persona.js
+++ b/webapp/app/js/directives/persona.js
@@ -19,6 +19,7 @@ treeherder.directive('personaButtons', [
                 // if the user.email value is null, it means that he's not logged in
                 $rootScope.user.email = response.data.userEmail || null;
                 $rootScope.user.loggedin = $rootScope.user.email !== null;
+
                 if ($rootScope.user.loggedin) {
                     ThUserModel.get().then(function(user){
                         angular.extend($rootScope.user, user);

--- a/webapp/app/js/directives/resultsets.js
+++ b/webapp/app/js/directives/resultsets.js
@@ -51,70 +51,24 @@ treeherder.directive('thResultCounts', [
     return {
         restrict: "E",
         link: function(scope, element, attrs) {
-
             var setTotalCount = function() {
                 if (scope.resultset.job_counts) {
-                    $(element).find('.result-status-total-value').html(
-                        scope.resultset.job_counts.total
-                    );
+
+                    scope.inProgress = scope.resultset.job_counts.pending +
+                                       scope.resultset.job_counts.running;
+                    var total = scope.resultset.job_counts.completed + scope.inProgress;
+                    scope.percentComplete = ((scope.resultset.job_counts.completed / total) * 100).toFixed(0);
                 }
             };
 
-            $rootScope.$on(thEvents.globalFilterChanged, function(evt) {
-                setTotalCount();
-            });
-            $rootScope.$on(thEvents.applyNewJobs, function(evt) {
-                setTotalCount();
+            $rootScope.$on(thEvents.applyNewJobs, function(evt, resultSetId) {
+                if (resultSetId === scope.resultset.id) {
+                    setTotalCount();
+                }
             });
 
         },
         templateUrl: 'partials/main/thResultCounts.html'
-    };
-}]);
-
-treeherder.directive('thResultStatusCount', [
-    'thJobFilters', '$rootScope', 'thEvents',
-    function (thJobFilters, $rootScope, thEvents) {
-
-    var resultCount = 0;
-
-    var updateResultCount = function(scope, rsCountEl) {
-        if(scope.resultset.job_counts) {
-
-            scope.resultCount = (scope.resultset.job_counts[scope.resultStatus] || 0);
-            rsCountEl.find(".rs-count-number").html(scope.resultCount);
-
-            if (scope.resultCount) {
-                rsCountEl.removeClass(scope.classifiedClass);
-                rsCountEl.addClass(scope.unclassifiedClass);
-            } else {
-                rsCountEl.addClass(scope.classifiedClass);
-                rsCountEl.removeClass(scope.unclassifiedClass);
-            }
-        }
-    };
-
-    return {
-        restrict: "E",
-        link: function(scope, element, attrs) {
-            scope.resultStatusCountClassPrefix = scope.getCountClass(scope.resultStatus);
-            scope.unclassifiedClass = scope.resultStatusCountClassPrefix + "-count-unclassified";
-            scope.classifiedClass = scope.resultStatusCountClassPrefix + "-count-classified";
-
-            var resultCountText = scope.getCountText(scope.resultStatus);
-            var resultCountTitleText = "toggle " + scope.resultStatus;
-
-            var rsCountEl = $(element).find(".result-status-count");
-            updateResultCount(scope, element);
-
-            rsCountEl.prop('title', resultCountTitleText);
-            rsCountEl.find('.rs-count-text').html(resultCountText);
-
-            $rootScope.$on(thEvents.applyNewJobs, function(evt) {
-                updateResultCount(scope, rsCountEl);
-            });
-        },
-        templateUrl: 'partials/main/thResultStatusCount.html'
     };
 }]);
 

--- a/webapp/app/js/models/resultsets_store.js
+++ b/webapp/app/js/models/resultsets_store.js
@@ -861,7 +861,7 @@ treeherder.factory('ThResultSetStore', [
             },
             thResultStatusObject.getResultStatusObject()
         );
-    }
+    };
     /*
     * Convert a flat list of jobs into a structure grouped by
     * platform and job_group. this is mainly to keep compatibility
@@ -873,16 +873,16 @@ treeherder.factory('ThResultSetStore', [
             job_counts: getJobCount(jobList)
         };
 
-        if(jobList.length == 0){return groupedJobs;}
+        if(jobList.length === 0){return groupedJobs;}
         groupedJobs.id = jobList[0].result_set_id;
         var lastModified = "";
         for(var i=0; i<jobList.length; i++){
             // search for the right platform
             var job = jobList[i];
             var platform = _.find(groupedJobs.platforms, function(platform){
-                return job.build_platform == platform.name &&
-                 job.platform_option == platform.option;
-            })
+                return job.build_platform === platform.name &&
+                 job.platform_option === platform.option;
+            });
             if(_.isUndefined(platform)){
                 platform = {
                     name: job.build_platform,
@@ -893,9 +893,9 @@ treeherder.factory('ThResultSetStore', [
             }
             // search for the right group
             var group = _.find(platform.groups, function(group){
-                return job.job_group_name == group.name &&
-                job.job_group_symbol == group.symbol;
-            })
+                return job.job_group_name === group.name &&
+                job.job_group_symbol === group.symbol;
+            });
             if(_.isUndefined(group)){
                 group = {
                     name: job.job_group_name,
@@ -937,7 +937,7 @@ treeherder.factory('ThResultSetStore', [
             var outputOrderMap = {};
             _.each(paddedJobSymbolList, function(paddedJob, index){
                 outputOrderMap[symbolMap[paddedJob]] = index;
-            })
+            });
             return outputOrderMap;
         });
     var jobGroupOrderPromise = ThJobGroupModel.get_list().
@@ -964,7 +964,7 @@ treeherder.factory('ThResultSetStore', [
                     group.jobs = _.sortBy(group.jobs, function(job){
                         return jobTypeOrder[job.job_type_symbol];
                     });
-                })
+                });
                 platform.groups = _.sortBy(platform.groups, function(group){
                     return jobGroupOrder[group.symbol];
                 });
@@ -974,8 +974,8 @@ treeherder.factory('ThResultSetStore', [
                 thOptionOrder[platform.option];
             });
             return groupedJobs;
-        })
-    }
+        });
+    };
 
     //Public interface
     var api = {

--- a/webapp/app/js/models/resultsets_store.js
+++ b/webapp/app/js/models/resultsets_store.js
@@ -852,10 +852,10 @@ treeherder.factory('ThResultSetStore', [
         return _.reduce(
             jobList,
             function(memo, job){
-                if(job.state == "pending" || job.state == "running"){
+
+                // don't count coalesced
+                if (!job.job_coalesced_to_guid) {
                     memo[job.state]++;
-                }else{
-                    memo[job.result]++;
                 }
                 return memo;
             },

--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -86,6 +86,7 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 1,
                         btnClass: "btn-red",
+                        btnClassClassified: "btn-red-classified",
                         jobButtonIcon: "glyphicon glyphicon-fire",
                         countText: "busted"
                     };
@@ -94,6 +95,7 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 2,
                         btnClass: "btn-purple",
+                        btnClassClassified: "btn-purple-classified",
                         jobButtonIcon: "glyphicon glyphicon-fire",
                         countText: "exception"
                     };
@@ -102,6 +104,7 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 3,
                         btnClass: "btn-orange",
+                        btnClassClassified: "btn-orange-classified",
                         jobButtonIcon: "glyphicon glyphicon-warning-sign",
                         countText: "failed"
                     };
@@ -110,6 +113,7 @@ treeherder.provider('thResultStatusInfo', function() {
                     resultStatusInfo = {
                         severity: 4,
                         btnClass: "btn-black",
+                        btnClassClassified: "btn-black-classified",
                         jobButtonIcon: "",
                         countText: "unknown"
                     };

--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -19,10 +19,6 @@ treeherder.provider('thResultStatusList', function() {
         return ['success', 'testfailed', 'busted', 'exception', 'retry', 'usercancel', 'running', 'pending', 'coalesced'];
     };
 
-    var counts = function() {
-        return ['success', 'testfailed', 'busted', 'exception', 'retry', 'running', 'pending', 'coalesced'];
-    };
-
     var defaultFilters = function() {
         return ['success', 'testfailed', 'busted', 'exception', 'retry', 'usercancel', 'running', 'pending'];
     };
@@ -30,7 +26,6 @@ treeherder.provider('thResultStatusList', function() {
     this.$get = function() {
         return {
             all: all,
-            counts: counts,
             defaultFilters: defaultFilters
         };
     };
@@ -53,14 +48,9 @@ treeherder.provider('thResultStatus', function() {
 treeherder.provider('thResultStatusObject', function() {
     var getResultStatusObject = function(){
         return {
-            'success':0,
-            'testfailed':0,
-            'busted':0,
-            'exception':0,
-            'retry':0,
             'running':0,
             'pending':0,
-            'coalesced': 0
+            'completed':0
             };
     };
 

--- a/webapp/app/js/services/jobfilters.js
+++ b/webapp/app/js/services/jobfilters.js
@@ -166,7 +166,7 @@ treeherder.factory('thJobFilters', [
     };
 
     var _getFiltersOrDefaults = function(field) {
-        var filters = $location.search()[_withPrefix(field)];
+        var filters = _.clone($location.search()[_withPrefix(field)]);
         if (filters) {
             return _toArray(filters);
         } else if (DEFAULTS.hasOwnProperty(field)) {
@@ -485,7 +485,8 @@ treeherder.factory('thJobFilters', [
     var _matchesDefaults = function(field, values) {
         $log.debug("_matchesDefaults", field, values);
         if (DEFAULTS.hasOwnProperty(field)) {
-            return _.intersection(DEFAULTS[field].values, values).length === DEFAULTS[field].values.length;
+            return values.length === DEFAULTS[field].values.length &&
+                   _.intersection(DEFAULTS[field].values, values).length === DEFAULTS[field].values.length;
         }
         return false;
     };

--- a/webapp/app/js/services/jobfilters.js
+++ b/webapp/app/js/services/jobfilters.js
@@ -123,7 +123,6 @@ treeherder.factory('thJobFilters', [
     $rootScope.$on('$locationChangeSuccess', function() {
 
         var newFilterParams = getNewFilterParams();
-
         if (!_.isEqual(cachedFilterParams, newFilterParams)) {
             cachedFilterParams = newFilterParams;
             _refreshFilterCaches();

--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -9,17 +9,31 @@
      data-id="{{::resultset.id}}">
 
     <div class="result-set-title">
-      <span class="result-set-title-left">
-        <span class="btn btn-default btn-sm glyphicon glyphicon-download" ng-show="isLoadingJobs"></span>
-        <span>
-          <a href="{{::revisionResultsetFilterUrl}}"
-             title="open this resultset"
-             ignore-job-clear-on-click>{{::resultsetDateStr}}</a> - </span>
-        <th-author author="{{::resultset.author}}"></th-author>
-      </span>
-      <span>
+      <span class="result-set-left">
+        <span class="result-set-title-left">
+          <span class="btn btn-default btn-sm glyphicon glyphicon-download" ng-show="isLoadingJobs"></span>
+          <span>
+            <a href="{{::revisionResultsetFilterUrl}}"
+               title="open this resultset"
+               ignore-job-clear-on-click>{{::resultsetDateStr}}</a> - </span>
+          <th-author author="{{::resultset.author}}"></th-author>
+        </span>
         <span class="revision-text">{{::resultset.revision}}</span>
-        <span class="btn btn-default btn-sm btn-resultset"
+      </span>
+      <th-result-counts class="result-counts"></th-result-counts>
+      <span class="result-set-buttons">
+
+        <span class="btn btn-sm btn-resultset"
+              tabindex="0" role="button"
+              title="cancel all jobs in this resultset"
+              ng-show="currentRepo.repository_group.name == 'try' || user.is_staff"
+              ignore-job-clear-on-click
+              ng-click="cancelAllJobs(resultset.revision)">
+          <span class="fa fa-times-circle cancel-job-icon dim-quarter"
+                ignore-job-clear-on-click></span>
+        </span>
+
+        <span class="btn btn-sm btn-resultset"
               tabindex="0" role="button"
               title="pin all visible jobs in this resultset"
               ignore-job-clear-on-click
@@ -30,29 +44,8 @@
 
         <th-action-button ng-hide="isLoadingJobs"></th-action-button>
 
-        <span class="btn btn-default btn-sm btn-resultset"
-              tabindex="0" role="button"
-              title="cancel all jobs in this resultset"
-              ng-show="currentRepo.repository_group.name == 'try' || user.is_staff"
-              ignore-job-clear-on-click
-              ng-click="cancelAllJobs(resultset.revision)">
-          <span class="fa fa-times-circle cancel-job-icon dim-quarter"
-                ignore-job-clear-on-click></span>
-        </span>
       </span>
 
-      <span class="btn btn-default btn-sm btn-resultset revision-button"
-            tabindex="0" role="button"
-            title="show revisions"
-            ignore-job-clear-on-click
-            ng-click="toggleRevisions()">
-        <i class="fa fa-code-fork fa-lg" ignore-job-clear-on-click
-           result-set-fa-icon"></i>
-        <span ng-if="resultset.revision_count <= 20" ignore-job-clear-on-click>
-            {{::resultset.revision_count}}</span>
-        <span ng-if="resultset.revision_count > 20">&gt20</span>
-      </span>
-      <th-result-counts class="result-counts"/>
     </div>
     <div class="result-set-body" th-clone-jobs ></div>
 </div>

--- a/webapp/app/partials/main/thActionButton.html
+++ b/webapp/app/partials/main/thActionButton.html
@@ -1,9 +1,12 @@
     <span class="dropdown">
-        <a class="btn btn-default btn-sm btn-resultset dropdown-toggle"
-           data-hover="dropdown" data-delay="1000" href="#">
+        <a class="btn btn-sm btn-resultset dropdown-toggle"
+           title="Action menu"
+           data-hover="dropdown"
+           data-delay="1000"
+           href="#">
             <b class="caret"></b>
         </a>
-        <ul class="dropdown-menu pull-left">
+        <ul class="dropdown-menu pull-right">
             <li><a target="_blank" ignore-job-clear-on-click
                    href="https://tbpl.mozilla.org/mcmerge/?cset={{::resultset.revision}}&tree={{::repoName}}">mcMerge</a></li>
             <li><a target="_blank" ignore-job-clear-on-click

--- a/webapp/app/partials/main/thResultCounts.html
+++ b/webapp/app/partials/main/thResultCounts.html
@@ -1,11 +1,9 @@
     <span class="btn btn-default btn-sm btn-resultset result-status-total-count"
           tabindex="0" role="button"
-          title="total job count - toggle jobs"
-          ignore-job-clear-on-click
-          ng-click="toggleJobs()">
-        <i class="fa fa-list fa-lg result-set-fa-icon" ignore-job-clear-on-click></i>
-        <span class="result-status-total-value" ignore-job-clear-on-click></span>
+          title="total job count - toggle jobs">
+            <i class="fa fa-list fa-lg result-set-fa-icon"></i>
+            <span class="result-status-total-value"></span>
     </span>
-    <span class="result-status-count-group" ignore-job-clear-on-click>
+    <span class="result-status-count-group">
         <th-result-status-count ng-repeat="resultStatus in statusList"/>
     </span>

--- a/webapp/app/partials/main/thResultCounts.html
+++ b/webapp/app/partials/main/thResultCounts.html
@@ -1,9 +1,5 @@
-    <span class="btn btn-default btn-sm btn-resultset result-status-total-count"
-          tabindex="0" role="button"
-          title="total job count - toggle jobs">
-            <i class="fa fa-list fa-lg result-set-fa-icon"></i>
-            <span class="result-status-total-value"></span>
-    </span>
-    <span class="result-status-count-group">
-        <th-result-status-count ng-repeat="resultStatus in statusList"/>
-    </span>
+<span class="result-set-progress">
+    <span ng-if="percentComplete == 100">- Complete -</span>
+    <span ng-if="percentComplete < 100"
+          title="Proportion of jobs that are complete">{{percentComplete}}% - {{inProgress}} in progress</span>
+</span>

--- a/webapp/app/partials/main/thWatchedRepoNavPanel.html
+++ b/webapp/app/partials/main/thWatchedRepoNavPanel.html
@@ -23,38 +23,13 @@
                        ng-class="::exclusionStateClass"></i>
                 </span>
 
-                <!--Collapse Resultsets Button-->
+                <!--Toggle Revisions Button-->
                 <span class="btn-group">
                     <span class="btn btn-view-nav btn-sm btn-collapse-resultsets"
-                          title="Collapse/expand all result sets"
+                          title="Show/hide revision list"
                           tabindex="0" role="button"
-                          ng-click="toggleAllJobsAndRevisions()"><i class="fa fa-list"></i>
+                          ng-click="toggleAllRevisions()"><i class="fa fa-code-fork"></i>
                     </span>
-
-                    <!--Jobs and Revisions Menu Button-->
-                    <span class="btn btn-view-nav btn-sm dropdown-toggle
-                                 save-btn-dropdown btn-jobs-revisions"
-                          title="Jobs and revisions"
-                          data-toggle="dropdown"><i class="fa fa-angle-down"></i>
-                    </span>
-                    <ul class="dropdown-menu pull-right" role="menu">
-                        <li>
-                            <a href="" prevent-default-on-left-click  ng-click="toggleAllRevisions(false)">
-                                <span class="fa fa-code-fork"></span> Collapse all revisions</a>
-                        </li>
-                        <li>
-                            <a href="" prevent-default-on-left-click  ng-click="toggleAllRevisions(true)">
-                            <span class="fa fa-code-fork"></span> Expand all revisions</a>
-                        </li>
-                        <li>
-                            <a href="" prevent-default-on-left-click  ng-click="toggleAllJobs(false)">
-                                <span class="fa fa-ellipsis-v"></span> Collapse all jobs</a>
-                        </li>
-                        <li>
-                            <a href="" prevent-default-on-left-click  ng-click="toggleAllJobs(true)">
-                            <span class="fa fa-th"></span> Expand all jobs</a>
-                        </li>
-                    </ul>
                 </span>
 
                 <!--Search Field-->


### PR DESCRIPTION
**READY FOR MERGE**

This removes the status counts and replaces them with a % progress and count of "in progress" jobs like so:
Before:
![screenshot 2015-02-06 15 45 16](https://cloud.githubusercontent.com/assets/419924/6089417/2c34f26a-ae17-11e4-9f38-5a7d0f305e6f.png)
 
After:
![screenshot 2015-02-06 15 41 37](https://cloud.githubusercontent.com/assets/419924/6089408/0845ee18-ae17-11e4-91e4-78f38acfca59.png)


This also attempts to "remove clutter" from the resultset status bar.

Also fixed:
* global collapse button just collapses revisions, not everything.  remove drop-down.
* cleaned up resultset buttons and moved right.
* global filtering of coalesced (was not functioning)
* Fixed counts of pending vs. coalesced that was off
* removed counting code in ``clonejobs.js`` because ``resultset_store`` already does it
* made failed jobs have transparent background when classified
* removed dead code from clonejobs for showing only revisions without jobs.