### PR TITLE
Bug 1124266 - Allow a larger max size for job details panel

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -551,7 +551,7 @@ div#bottom-panel {
     font-size: 12px;
 
     height: 35%;
-    max-height: 35%;
+    max-height: 75%;
     flex: none;
     -webkit-flex: none;
 
@@ -836,36 +836,37 @@ ul.failure-summary-list li .btn-xs {
 }
 
 #pinned-job-list{
+    position: relative;
     flex: auto;
     -webkit-flex: auto;
-    padding: 5px;
+    margin: 7px 7px 10px;
 }
 
 #pinned-job-list .content{
+    position: absolute;
+    width: 100%;
+    height: 100%;
     padding: 2px;
-    margin: 2px;
-    background-color: #FFFFFF;
-    min-height: 80px;
-    max-height: 120px;
     overflow: auto;
+    background-color: #FFFFFF;
 }
 
 #pinboard-related-bugs{
-    width: 215px;
-    padding: 5px;
+    position: relative;
+    width: 200px;
     flex: none;
     -webkit-flex: none;
-    min-width: 215px;
+    margin: 7px 7px 10px;
 }
 
 #pinboard-related-bugs .content {
+    position: absolute;
+    height: 100%;
+    width: 200px;
     padding: 2px;
-    margin: 2px;
-    background-color: #FFFFFF;
-    min-height: 80px;
-    max-height: 120px;
     overflow-x: hidden;
     color: black;
+    background-color: #FFFFFF;
 }
 
 #pinboard-related-bugs a {


### PR DESCRIPTION
This work fixes Bugzilla bug [1124266](https://bugzilla.mozilla.org/show_bug.cgi?id=1124266).

In it, we allow the user a resizable job details panel, up to 75 percent of the content height. For the last half year or so, it had been fixed at 35 percent and not adjustable. While there, I also made the two dynamic content containers in the pinboard (pinboard content, related bugs) adjust on the fly to the user's panel size.

Here's the pinboard specifically, before and after. Some minor tweaks, generally the same but slight optimization in height for more content space:

![pinboardcurrent](https://cloud.githubusercontent.com/assets/3660661/6114645/936b3dd8-b06d-11e4-829f-f9c3428a6614.jpg)

![pinboardproposed](https://cloud.githubusercontent.com/assets/3660661/6114651/97ad93fa-b06d-11e4-94b7-98b92a53bff9.jpg)

Here is the proposed default launch size of the job panel (unchanged):

![jobpanelpinboarddefaultlaunchsize](https://cloud.githubusercontent.com/assets/3660661/6114660/af2ac34a-b06d-11e4-8cba-ce849a0110c6.jpg)

Here is the maximum size of 75 percent, which requires manual interaction:

![jobpanelpinboard75pct](https://cloud.githubusercontent.com/assets/3660661/6114681/d4716a96-b06d-11e4-9f2d-80a85a1b489f.jpg)

And here is an example of a larger screen and content, in use at that size:

![jobpanelpinboard75pctlarge](https://cloud.githubusercontent.com/assets/3660661/6114698/e9ed3738-b06d-11e4-91c9-b313974bea99.jpg)

There may be some groovey flexbox way of ensuring the pinboard containers when empty fill their parent containers, but this approach seemed to work fine. I also did a bit of rearranging of the property orders.

Everything seems to be working on on windows, but if you could have a bash on other OS's that would be great. Dynamic resizing seems to work well for me.

Tested on Windows:
FF Release **35.0.01**
Chrome Latest Release **40.0.2214.111 m**

Adding @wlach for review and @camd and @lizzard for visibility.