### PR TITLE
Bug 1073409 - Only display first line of each commit message

### DIFF
--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -122,7 +122,7 @@
                     <span title="{{name}}: {{email}}">{{name|initials}}</span>
                     <span title="{{escaped_comment}}">
                         <span class="revision-comment">
-                            <em>{{comments_bug_link}}</em>
+                            <em>{{escaped_comment_linkified}}</em>
                         </span>
                     </span>
                 </span>

--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -331,7 +331,7 @@ treeherder.directive('thCloneJobs', [
                 }
                 revision.name = userTokens[0].trim();
                 revision.escaped_comment = _.escape(revision.comments);
-                revision.comments_bug_link = linkifyBugsFilter(revision.escaped_comment);
+                revision.escaped_comment_linkified = linkifyBugsFilter(revision.escaped_comment);
                 revisionHtml = revisionInterpolator(revision);
                 ulEl.append(revisionHtml);
             }

--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -330,7 +330,8 @@ treeherder.directive('thCloneJobs', [
                     revision.email = userTokens[1];
                 }
                 revision.name = userTokens[0].trim();
-                revision.escaped_comment = _.escape(revision.comments);
+                // Only use the first line of the full commit message.
+                revision.escaped_comment = _.escape(revision.comments.split('\n')[0]);
                 revision.escaped_comment_linkified = linkifyBugsFilter(revision.escaped_comment);
                 revisionHtml = revisionInterpolator(revision);
                 ulEl.append(revisionHtml);


### PR DESCRIPTION
Two parts:
1) Rename comments_bug_link to escaped_comment_linkified - to make the relation with 'escaped_comment' clearer.
2) Only display first line of each commit message - to make the list of commit messages shown for each push less cluttered. In the future, bug 1061283 will change the API so that there are separate fields for the first line and full comment message strings, so at that point we'll switch to using those instead.