### PR TITLE
Bug 1121631 - Implement moustrap shortcuts

### DIFF
--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -47,6 +47,7 @@
         <script src="vendor/bootstrap.js"></script>
         <script src="vendor/angular/angular-sanitize.min.js"></script>
         <script src="vendor/angular-local-storage.min.js"></script>
+        <script src="vendor/mousetrap.min.js"></script>
         <script src="vendor/underscore-min.js"></script>
         <script src="vendor/resizer.js"></script>
 

--- a/webapp/app/partials/main/thPinboardPanel.html
+++ b/webapp/app/partials/main/thPinboardPanel.html
@@ -13,7 +13,7 @@
 <!-- Related bugs -->
 <div id="pinboard-related-bugs">
   <div class="content">
-    <a ng-click="toggleEnterBugNumber()"
+    <a ng-click="toggleEnterBugNumber(!enteringBugNumber); allowKeys()"
        class="click-able-icon"
        title="Add a related bug">
        <i class="fa fa-plus-square add-related-bugs-icon"></i>
@@ -49,8 +49,9 @@
       <div class="classification-comment-container">
         <input id="classification-comment"
                type="text"
-               class="form-control add-classification-input"
+               class="form-control add-classification-input mousetrap"
                ng-model="classification.note"
+               ng-click="allowKeys()"
                focus-this blur-this></input>
         <span class="pinboard-preload-txt classification-comment-preload-txt"
               ng-if="!classification.note">

--- a/webapp/app/plugins/pinboard.js
+++ b/webapp/app/plugins/pinboard.js
@@ -20,7 +20,7 @@ treeherder.controller('PinboardCtrl', [
 
         $rootScope.$on(thEvents.addRelatedBug, function(event, job) {
             $scope.pinJob(job);
-            $scope.toggleEnterBugNumber();
+            $scope.toggleEnterBugNumber(true);
         });
 
         $rootScope.$on(thEvents.saveClassification, function(event) {
@@ -73,6 +73,7 @@ treeherder.controller('PinboardCtrl', [
                 $scope.classification.who = $scope.user.email;
                 var classification = $scope.classification;
                 thPinboard.save(classification);
+                $scope.completeClassification();
                 $scope.classification = thPinboard.createNewClassification();
             } else {
                 thNotify.send("must be logged in to save job classifications", "danger");
@@ -104,9 +105,9 @@ treeherder.controller('PinboardCtrl', [
             return thPinboard.hasRelatedBugs();
         };
 
-        $scope.toggleEnterBugNumber = function() {
-            $scope.enteringBugNumber = !$scope.enteringBugNumber;
-            $scope.focusInput = $scope.enteringBugNumber;
+        $scope.toggleEnterBugNumber = function(tf) {
+            $scope.enteringBugNumber = tf;
+            $scope.focusInput = tf;
         };
 
         $scope.completeClassification = function() {
@@ -114,14 +115,16 @@ treeherder.controller('PinboardCtrl', [
         };
 
         $scope.saveEnteredBugNumber = function() {
-            if (!$scope.newEnteredBugNumber) {
-                $scope.toggleEnterBugNumber();
-            } else {
-                $log.debug("new bug number to be saved: ",
-                           $scope.newEnteredBugNumber);
-                thPinboard.addBug({id:$scope.newEnteredBugNumber});
-                $scope.toggleEnterBugNumber();
-                $scope.newEnteredBugNumber = "";
+            if ($scope.enteringBugNumber) {
+                if (!$scope.newEnteredBugNumber) {
+                    $scope.toggleEnterBugNumber(false);
+                } else {
+                    $log.debug("new bug number to be saved: ",
+                               $scope.newEnteredBugNumber);
+                    thPinboard.addBug({id:$scope.newEnteredBugNumber});
+                    $scope.toggleEnterBugNumber(false);
+                    $scope.newEnteredBugNumber = "";
+                }
             }
         };
 


### PR DESCRIPTION
This work fixes Bugzilla bugs [1121631](https://bugzilla.mozilla.org/show_bug.cgi?id=1121631) and [1118342](https://bugzilla.mozilla.org/show_bug.cgi?id=1118342).

This adds a few things beyond previously reverted PR https://github.com/mozilla/treeherder-ui/pull/338. Specifically it:

* addresses the slowdown in toggle unclassified
* uses `$scope.$evalAsync` for better optimization where formerly `$digest` was used
* ignores shortcuts on manual entry of classification comments with the `allowKeys()` function

An article on.Async can be found [here](http://www.bennadel.com/blog/2605-scope-evalasync-vs-timeout-in-angularjs.htm).

I've also left in some placeholders for next/previous job navigation, for @dewgeek's upcoming PR. In the event mine lands first, they can just be un-commented (and tested).

Some shortcuts as before, did not require digest or Async. Only those which needed them received them.

Everything seems to be working fine for all shortcuts in Firefox and Chrome, which the exception of toggle In-Progress, which is known to be not working at this time. I added an Async for it regardless for when it is fixed.

We'll want sheriffs to give this thorough testing on dev first, before pushes to stage or prod.

Tested on Windows:
FF Release **35.0.1**
Chrome Latest Release **40.0.2214.111 m**

Adding @camd for review and @edmorley and @rvandermeulen for visibility.