### PR TITLE
Improve the initial setup experience for new contributors to the UI

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,42 +1,54 @@
 Installation
 ============
 
-You can run the webserver locally.  For now, static data is loaded for testing
-and development.
+You can work on the UI without needing a VM, by using web-server.js.
+There are a few limitations, since URL rewriting is not supported (and so some links will be broken), but it works well enough for quick testing. For instructions on how to serve the UI with working URL rewriting, use the treeherder-service Vagrant instructions.
 
+Cloning the Repo
+----------------
+
+* Clone the `treeherder-ui repo`_ from Github.
 
 Requirements
 ------------
 
-* node.js: http://nodejs.org/download/
+* Node.js_
 
-Execution::
+Running the web-server
+----------------------
 
-    cd webapp
-    ./scripts/web-server.js
+* Open a shell, cd into the root of the repository you just cloned and type:
 
+  .. code-block:: bash
 
-Endpoints
----------
+     cd webapp
+     cp app/js/config/sample.local.conf.js app/js/config/local.conf.js
+     ./scripts/web-server.js
 
-Once the server is running, you can nav to:
+Viewing the UI
+--------------
 
-* Jobs list: http://localhost:8000/app/index.html?tree=Try#/jobs
-* Log Viewer: http://localhost:8000/app/logviewer.html
+Once the server is running, you can navigate to:
+`<http://localhost:8000/app/index.html>`_
 
+Configuration
+=============
+
+The sample configuration makes the UI load job/push data from the production service API. If you wish to test the UI against stage/dev's service instead, adjust ``thServiceDomain`` in the config file created as part of installation:
+``webapp/app/js/config/local.conf.js``
+
+If you wish to run the full treeherder-service Vagrant project (service + UI), remember to remove local.conf.js or else change ``thServiceDomain`` within it to refer to ``vagrant``, so the UI will use the local Vagrant service API.
 
 Running the unit tests
 ======================
 
 The unit tests run with Karma: http://karma-runner.github.io/0.8/config/configuration-file.html
 
-
 Requirements
 ------------
 
-* [node.js](http://nodejs.org/download/)
+* Node.js_
 * karma: ``sudo npm install -g karma``
-
 
 Execution::
 
@@ -44,7 +56,7 @@ Execution::
     ./scripts/test.sh
 
 Build
------
+=====
 * Install grunt ``sudo npm install grunt``
 * Install the ``devDependencies`` in ``package.json``
 * Run the following command in ``treeherder-ui``:
@@ -54,25 +66,5 @@ Build::
 
 This will create a ``dist`` directory in ``treeherder-ui`` where concatenated and minified js, css, and application assets can be served from.
 
-Configuration
-=============
-
-You can either run the treeherder service locally, or use a remote server.
-This setting is specified in this file:
-
-``webapp/app/js/config/local.conf.js``
-
-A sample copy of this file is located here:
-
-``webapp/app/js/config/sample.local.conf.js``
-
-Copy the sample file to ``local.conf.js`` and make your custom settings.
-If you want to run the UI using the node web server shipped with it, you need to change this line::
-    
-    window.thServiceDomain = "";
-
-to::
-
-    window.thServiceDomain = "https://treeherder.mozilla.org";
-
-If instead you want to run the whole application (service + UI) locally, you can leave the default value.
+.. _treeherder-ui repo: https://github.com/mozilla/treeherder-ui
+.. _Node.js: http://nodejs.org/download/

--- a/webapp/app/js/config/sample.local.conf.js
+++ b/webapp/app/js/config/sample.local.conf.js
@@ -4,16 +4,15 @@
 
 'use strict';
 
-/* window.thServiceDomain holds a reference to a backend service
- * for result data. This can be one of:
- *
- * -  http://local.treeherder.mozilla.org (local vagrant)
- * -  http://treeherder-dev.allizom.org (dev)
- * -  https://treeherder.allizom.org (stage)
- * -  https://treeherder.mozilla.org (production) */
+/* window.thServiceDomain holds a reference to a back-end service
+ * used to retrieve job result data. Valid settings are  */
+var production = "https://treeherder.mozilla.org";
+var stage = "https://treeherder.allizom.org";
+var dev = "http://treeherder-dev.allizom.org";
+var vagrant = "";
 
-// By default the service domain is the current host name.
-window.thServiceDomain = "";
+// Set the service
+window.thServiceDomain = production;
 
 //treeherder.config(['$logProvider', 'ThLogConfigProvider',
 //    function($logProvider, ThLogConfigProvider) {

--- a/webapp/config/karma.conf.js
+++ b/webapp/config/karma.conf.js
@@ -27,7 +27,6 @@ module.exports = function (config) {
             'app/js/directives/**/*.js',
             'app/js/models/**/*.js',
             'app/js/services/**/*.js',
-            'app/js/config/sample.local.conf.js',
             'app/plugins/**/*.js',
             'test/vendor/jasmine-jquery.js',
             'test/unit/**/*.js',


### PR DESCRIPTION
* The sample config is optional, so don't use it for tests …
We want the sample config to now point at the production service API to make the first-run experience for new contributors easier. However the tests use the sample config as part of the test run, so this breaks them. However since the sample config is now optional, we can just not use it at all during the tests to fix the failures.

* Improve the API back-end prefs in the sample local config …
It's now easier to switch between the API back-ends and harder to make typos. The default backend has also been changed to production (instead of using the same host), since local.conf.js is now optional, so if someone just wants to use the same host as the UI for the back-end, then they can just not create local.conf.js in the first place. But for those who _do_ want to use production (eg those using web-server.js), initial setup is now a single |cp sample.local.conf.js local.conf.js| rather than also having to edit the file afterwards.

* Clean up the treeherder-ui installation instructions