### PR TITLE
Bug 1095100 - Let "Show previous jobs" append data instead of replacing it

### DIFF
--- a/webapp/app/plugins/similar_jobs/controller.js
+++ b/webapp/app/plugins/similar_jobs/controller.js
@@ -59,7 +59,7 @@ treeherder.controller('SimilarJobsPluginCtrl', [
                                     obj.authorResultsetFilterUrl = $scope.urlBasePath + "?repo=" +
                                         $scope.repoName + "&author=" + encodeURIComponent(obj.result_set.author);
                                 });
-                                $scope.similar_jobs = data;
+                                $scope.similar_jobs = $.merge($scope.similar_jobs, data);
                                 // on the first page show the first element info by default
                                 if($scope.page === 1 && $scope.similar_jobs.length > 0){
                                     $scope.show_job_info($scope.similar_jobs[0]);
@@ -78,6 +78,7 @@ treeherder.controller('SimilarJobsPluginCtrl', [
         $scope.update_similar_jobs = function(){
             if(angular.isDefined($scope.jobLoadedPromise)){
                 $scope.jobLoadedPromise.then(function(){
+                    $scope.similar_jobs = [];
                     $scope.page = 1;
                     $scope.similar_job_selected = null;
                     $scope.get_similar_jobs();

--- a/webapp/app/plugins/similar_jobs/controller.js
+++ b/webapp/app/plugins/similar_jobs/controller.js
@@ -23,9 +23,8 @@ treeherder.controller('SimilarJobsPluginCtrl', [
         $scope.get_similar_jobs = function(){
             thTabs.tabs.similarJobs.is_loading = true;
             var options = {
-                    count: $scope.page_size +1,
-                    offset: ($scope.page-1) * $scope.page_size,
-                    full: false
+                    count: $scope.page_size + 1,
+                    offset: ($scope.page - 1) * $scope.page_size
                 };
             angular.forEach($scope.similar_jobs_filters, function(value, key){
                 if(value){

--- a/webapp/app/plugins/similar_jobs/main.html
+++ b/webapp/app/plugins/similar_jobs/main.html
@@ -34,7 +34,7 @@
                         </tr>
                     </tbody>
                 </table>
-                <a ng-if="has_next_page" href="" prevent-default-on-left-click  ng-click="show_next()">Show previous jobs</a>
+                <a class="btn btn-default btn-sm" ng-if="has_next_page" href="" prevent-default-on-left-click  ng-click="show_next()">Show previous jobs</a>
             </div>
             <div class="right_panel">
                 <form role="form" class="form form-inline">


### PR DESCRIPTION
update_similar_jobs() now resets the list on changing the selected job
get_list() now appends the new data by merging the arrays (using jQuery; I didn't want to use .concat because it's not in-place)