### PR TITLE
Bug 1094466 - Separate scroll-panels for similar jobs panel

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -659,6 +659,7 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
 
 #bottom-left-top, #bottom-center-top {
     min-height: 33px;
+    overflow-y: auto;
 }
 
 .pinned-job-count {
@@ -717,20 +718,38 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
 
 #bottom-center-bottom {
     max-height: calc(100% - 33px);
+    -webkit-flex: 1;
+    flex: 1;
+    display: -webkit-flex;
+    display: flex;
 }
 
 #bottom-center-bottom > * {
-    height: 100%;
+    -webkit-flex: 1;
+    flex: 1;
+    display: -webkit-flex;
+    display: flex;
+}
+
+#bottom-center-bottom > * > * {
+    -webkit-flex: 1;
+    flex: 1;
+    display: -webkit-flex;
+    display: flex;
 }
 
 #bottom-center-bottom > * > * > * {
-    height: 100%;
+    -webkit-flex: 1;
+    flex: 1;
+    display: -webkit-flex;
+    display: flex;
 }
 
 #bottom-center-panel ul.failure-summary-list{
-    padding-left: 0px;
-    height: 100%;
+    padding-left: 0;
     overflow: auto;
+    width: 100%;
+    margin-bottom: 0;
 }
 
 ul.failure-summary-list li {
@@ -1770,12 +1789,14 @@ fieldset[disabled] .btn-repo.active {
            flex-flow: row;
 }
 
-div.similar_jobs .right_panel{ overflow-y: auto; flex: 1 1; -webkit-flex: 1 1; }
-div.similar_jobs .right_panel form{ height:36px; background-color: #D3D3D3;}
+
+div.similar_jobs .right_panel{ border-left: 1px solid #101010; margin-right: 1px; overflow-y: auto; flex: 1 1; -webkit-flex: 1 1; }
+div.similar_jobs .right_panel form { overflow: hidden; background-color: #D3D3D3; }
+div.similar_jobs .right_panel form .checkbox input[type="checkbox"] { margin-left: 0px; position: relative; }
 div.similar_jobs .right_panel .similar_job_detail{ border-top: 1px solid #101010; }
 div.similar_jobs .right_panel .similar_job_detail table { width: 100%; overflow: hidden; }
 
-div.similar_jobs .left_panel{ overflow-y: auto; flex: 1 1; -webkit-flex: 1 1; }
+div.similar_jobs .left_panel{ overflow: auto; flex: 1 1; -webkit-flex: 1 1; }
 div.similar_jobs .left_panel table{ margin-bottom: 7px;}
 div.similar_jobs .left_panel table tr.active>td{ background-color: #D3D3D3; }
 div.similar_jobs .left_panel table tr{ cursor: pointer; }

--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -649,8 +649,7 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
            flex-flow: row;
 }
 
-#bottom-left-panel, #bottom-center-panel{
-    overflow-y: auto;
+#bottom-left-panel, #bottom-center-panel {
     background-color: #FCFCFC;
     display: -webkit-flex;
     display:         flex;
@@ -668,7 +667,6 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
 
 #bottom-left-panel {
     width:260px;
-    overflow-y: auto;
 }
 
 #bottom-left-bottom > ul {
@@ -701,7 +699,7 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
 
 #bottom-left-panel .printlines{padding-bottom: 5px;}
 
-#bottom-left-bottom, #bottom-center-bottom {
+#bottom-left-bottom {
     overflow: auto;
 }
 
@@ -717,14 +715,26 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
     border-top: none;
 }
 
-#bottom-center-panel  ul.failure-summary-list{
+#bottom-center-bottom {
+    max-height: calc(100% - 33px);
+}
+
+#bottom-center-bottom > * {
+    height: 100%;
+}
+
+#bottom-center-bottom > * > * > * {
+    height: 100%;
+}
+
+#bottom-center-panel ul.failure-summary-list{
     padding-left: 0px;
-    height:100%;
+    height: 100%;
     overflow: auto;
 }
 
 ul.failure-summary-list li {
-    padding: 0px 0px 0px 2px;
+    padding-left: 2px;
     font-size: 11px;
     background: #ccfaff;
 }
@@ -1008,7 +1018,7 @@ ul.failure-summary-list li .btn-xs {
 }
 
 .annotations-panel {
-    overflow: scroll;
+    overflow: auto;
     margin-right: 0;
 }
 
@@ -1760,16 +1770,15 @@ fieldset[disabled] .btn-repo.active {
            flex-flow: row;
 }
 
-div.similar_jobs .right_panel{ border: 1px solid #101010; flex: 1 1; -webkit-flex: 1 1; }
-div.similar_jobs .right_panel form{height:42px; background-color: #D3D3D3;}
+div.similar_jobs .right_panel{ overflow-y: auto; flex: 1 1; -webkit-flex: 1 1; }
+div.similar_jobs .right_panel form{ height:36px; background-color: #D3D3D3;}
 div.similar_jobs .right_panel .similar_job_detail{ border-top: 1px solid #101010; }
 div.similar_jobs .right_panel .similar_job_detail table { width: 100%; overflow: hidden; }
 
-div.similar_jobs .left_panel{ margin-bottom: 15px; flex: 1 1; -webkit-flex: 1 1; }
-div.similar_jobs .left_panel table{ margin-bottom: 5px;}
-div.similar_jobs .left_panel table tr.active>td{background-color: #D3D3D3;}
-div.similar_jobs .left_panel table tr{cursor: pointer;}
-
+div.similar_jobs .left_panel{ overflow-y: auto; flex: 1 1; -webkit-flex: 1 1; }
+div.similar_jobs .left_panel table{ margin-bottom: 7px;}
+div.similar_jobs .left_panel table tr.active>td{ background-color: #D3D3D3; }
+div.similar_jobs .left_panel table tr{ cursor: pointer; }
 
 #notification_box{
     position:fixed;

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -270,11 +270,8 @@
       </nav>
     </div>
     <div id="bottom-center-bottom">
-      <div ng-repeat="(tabId, tab) in tabService.tabs">
-
-          <div ng-show="tabId == tabService.selectedTab">
+      <div ng-repeat="(tabId, tab) in tabService.tabs" ng-show="tabId == tabService.selectedTab">
           <ng-include src="tab.content"></ng-include>
-        </div>
       </div>
     </div>
   </div>

--- a/webapp/app/plugins/talos/main.html
+++ b/webapp/app/plugins/talos/main.html
@@ -1,5 +1,6 @@
-<span ng-repeat="line in job_details">
-  <ul ng-if="line.content_type == 'TalosResult'">
+<span ng-repeat="line in job_details"
+      ng-if="line.content_type == 'TalosResult'">
+  <ul>
     <li>Datazilla:
       <ul>
         <li ng-repeat="(k,v) in line.value.datazilla"><a href="{{::v.url}}" target="_blank">{{::k}}</a>


### PR DESCRIPTION
This patch gets rid of overflowing for the bottom header and propagates down the content heights in a way, that the plugins can have proper scroll panes.
If we wouldn't explicitly inherit the height, it'd get calculated by its children, and therefore the scroll pane would overflow.
The change to pluginpanel.html is needed because otherwise we would have multiple div's with an explicitly set height, although their contents are display:none.