### PR TITLE
Bug 1135743 - Update job details Filter job title

### DIFF
--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -141,7 +141,7 @@
       <ul class="content-spacer">
         <li class="small">
           <label>Job:</label>
-          <a title="Filter jobs like these in a new tab"
+          <a title="Filter jobs like these"
              href="{{buildbotJobnameHref}}"
              prevent-default-on-left-click
              ng-click="filterByBuildername(buildbotJobname)">


### PR DESCRIPTION
This fixes Bugzilla bug [1135743](https://bugzilla.mozilla.org/show_bug.cgi?id=1135743).

With the recent work to make less launching of new tabs, I think this title needed a little update. I mused about trying to wordsmith it further, but eventually decided just to remove the tab reference for now.

Everything seems fine with the change.

Tested on OSX:
FF Release **35.0.1**
Chrome Latest Release **40.0.2214.115** (64-bit)

Adding @edmorley for visibility and review.
