### PR TITLE
Bug 1089737 - Tweak next/prev shortcut comment

### DIFF
--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -76,12 +76,12 @@ treeherder.controller('MainCtrl', [
                 $scope.$evalAsync($scope.toggleInProgress());
             });
 
-            // Shortcut: select previous job (upcoming feature, PR326)
+            // Shortcut: select previous job
             Mousetrap.bind('left', function() {
                 $rootScope.$emit(thEvents.changeSelection,'previous');
             });
 
-            // Shortcut: select next job (upcoming feature, PR326)
+            // Shortcut: select next job
             Mousetrap.bind('right', function() {
                 $rootScope.$emit(thEvents.changeSelection,'next');
             });


### PR DESCRIPTION
Supplemental to @dewgeek 's work in bug [1089737](https://bugzilla.mozilla.org/show_bug.cgi?id=1089737) nothing major, but this part of my comment was intended for removal before landing, so it looks the same as all the other shortcut comments.

Adding @camd for review.

Tested on OSX:
FF Release **35.0.1**
Chrome Latest Release **40.0.2214.115** (64-bit)