### PR TITLE
Bug 1118342 - Support ctrl+enter save when focused in add-related-bug

### DIFF
--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -127,6 +127,12 @@ treeherder.controller('MainCtrl', [
                     $scope.$evalAsync(
                         $rootScope.$broadcast('focus-this', "related-bug-input")
                     );
+
+                    /* Treat single key shortcuts as regular text during input.
+                     * This prevents invocation of single key hotkeys like 'c'
+                     * during bug number entry, which would cross focus the
+                     * comments field. We validate numbers via the markup. */
+                    $scope.$evalAsync($scope.allowKeys());
                 }
             });
 
@@ -145,7 +151,7 @@ treeherder.controller('MainCtrl', [
                         $rootScope.$broadcast('focus-this', "classification-comment")
                     );
 
-                    // Unbind all shortcut keys during input
+                    // Treat single key shortcuts as regular text during input
                     $scope.$evalAsync($scope.allowKeys());
                 }
             });

--- a/webapp/app/partials/main/thPinboardPanel.html
+++ b/webapp/app/partials/main/thPinboardPanel.html
@@ -26,7 +26,7 @@
           class="add-related-bugs-form">
       <input id="related-bug-input"
              type="number"
-             class="add-related-bugs-input"
+             class="add-related-bugs-input mousetrap"
              ng-model="$parent.newEnteredBugNumber"
              placeholder="enter bug number"
              focus-me="focusInput">


### PR DESCRIPTION
This work fixes the second half of Bugzilla bug [1118342](https://bugzilla.mozilla.org/show_bug.cgi?id=1118342).

In it, we support the shortcut **ctrl+enter** to save a classification while focused in the related bug input field (in addition to the comments field, whose functionality already exists).

To do a basic workflow:
* pin a job
* **'r'** or click on the [+] icon to open the related bugs input
* type or paste a number
* **'ctrl+enter'** to save the classification

Expected:
The classification should be saved, and the input field closed and rendered as a new bug.

Everything seems in order, I've tried as many workflows I can think of, switching contexts trying to 'c' to add a comment (we will interpret that as a regular character and validate the input as a number via the markup), changing back and forth, manual and pasted input, etc. We also now support "clear all" **ctrl+shift+u** (clearing the pinboard) or indeed any multi-key shortcut in the add related bugs field as a by product of this change - as we already did for the comments field. We "leave" the number behind in that scenario on a clear, but that isn't a change in functionality from production, it's always been that way.

Tested on OSX 10.9.5:
FF Release **35.0.1**
Chrome Latest Release **40.0.2214.115** (64-bit)

Adding @camd for review and @rvandermeulen for visibility.