### PR TITLE
Bug 1061304 - Clip instead of flow job control icons

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -587,6 +587,7 @@ div#bottom-panel .navbar{
     font-size:12px;
     min-height: 33px;
     min-width: initial;
+    overflow: hidden;
     z-index: 100;
 }
 


### PR DESCRIPTION
This fixes Bugzilla bug [1061304](https://bugzilla.mozilla.org/show_bug.cgi?id=1061304).

This changes the behavior at smaller browser widths (or more job control icons in the future), to clip/hide them, rather than flow them over the job results content. Here's the before and after:

![narrownavbarbefore](https://cloud.githubusercontent.com/assets/3660661/6396186/0a894d98-bdab-11e4-8780-3136851be3bf.jpg)

![narrownavbarafter](https://cloud.githubusercontent.com/assets/3660661/6396193/0ffb4dee-bdab-11e4-8c33-7bb0cf1c585c.jpg)

We are applying this to the entire bottom navbar, as the right hand side also receives this class. There seem no ill effects from that on either browser, and presumably if we populated the bottom right side of the navbar with similar icons, we'd want that behavior anyway.

@wlach if you could give this a quick interactive test also, that would be awesome :)

Tested on OSX 10.9.5:
FF Release **35.0.1**
Chrome Latest Release **40.0.2214.115** (64-bit)

Adding @wlach for review.