### PR TITLE
Bug 1133545 - Create a shortcut to focus the Filter field

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -15,6 +15,14 @@ a:visited {
     color: purple;
 }
 
+input:focus::-webkit-input-placeholder {
+    color: transparent;
+}
+
+input:focus::-moz-placeholder {
+    color: transparent;
+}
+
 #global-container {
     display: -webkit-flex;
     display:         flex;

--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -114,6 +114,8 @@
                 <table id="shortcuts">
                     <tr><th>esc</th>
                     <td>Close all open job or filter panels</td></tr>
+                    <tr><th>f</th>
+                    <td>Enter a filter for platforms and jobs</td></tr>
                     <tr><th>j<span> or </span>n</th>
                     <td>Highlight next unclassified failure</td></tr>
                     <tr><th>k<span> or </span>p</th>

--- a/webapp/app/js/controllers/filters.js
+++ b/webapp/app/js/controllers/filters.js
@@ -224,9 +224,10 @@ treeherder.controller('SearchCtrl', [
 
         $scope.search = function(ev){
             //User hit enter
-            if (ev.keyCode === 13 || $scope.searchQueryStr === "") {
+            if (ev.keyCode === 13) {
                 var filterVal = $scope.searchQueryStr === ""? null: $scope.searchQueryStr;
                 thJobFilters.replaceFilter("searchStr", filterVal);
+                $rootScope.$broadcast('blur-this', "platform-job-text-search-field");
             }
         };
     }

--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -154,9 +154,7 @@ treeherder.controller('MainCtrl', [
                 // Prevent shortcut key overflow during focus
                 ev.preventDefault();
 
-                $scope.$evalAsync(
-                    $rootScope.$broadcast('click-this', "platform-job-text-search-field")
-                );
+                angular.element('#platform-job-text-search-field').trigger('click');
             });
 
             // Shortcut: escape closes any open panels and clears selected job

--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -50,7 +50,7 @@ treeherder.controller('MainCtrl', [
 
         // Disable single key shortcuts in specified shortcut events
         $scope.allowKeys = function() {
-            Mousetrap.unbind(['i', 'j', 'n', 'k', 'p', 'space', 'u', 'r', 'c']);
+            Mousetrap.unbind(['i', 'j', 'n', 'k', 'p', 'space', 'u', 'r', 'c', 'f']);
         };
 
         // Process shortcut events
@@ -137,7 +137,6 @@ treeherder.controller('MainCtrl', [
                         $rootScope.$emit(thEvents.jobPin, $rootScope.selectedJob)
                     );
 
-
                     // Prevent shortcut key overflow during focus
                     ev.preventDefault();
 
@@ -148,6 +147,16 @@ treeherder.controller('MainCtrl', [
                     // Unbind all shortcut keys during input
                     $scope.$evalAsync($scope.allowKeys());
                 }
+            });
+
+            // Shortcut: enter a custom job or platform filter
+            Mousetrap.bind('f', function(ev) {
+                // Prevent shortcut key overflow during focus
+                ev.preventDefault();
+
+                $scope.$evalAsync(
+                    $rootScope.$broadcast('click-this', "platform-job-text-search-field")
+                );
             });
 
             // Shortcut: escape closes any open panels and clears selected job

--- a/webapp/app/js/directives/main.js
+++ b/webapp/app/js/directives/main.js
@@ -44,19 +44,6 @@ treeherder.directive('blurThis', ['$timeout', function($timeout) {
   };
 }]);
 
-// Directive clickThis which synthesizes a click in a specific element
-treeherder.directive('clickThis', ['$timeout', function($timeout) {
-  return function(scope, elem, attr) {
-      scope.$on('click-this', function(event, id) {
-        if (attr.id == id) {
-          $timeout(function() {
-            elem[0].click();
-          }, 0);
-        }
-      });
-  };
-}]);
-
 // Directive focusMe which sets a global focus state for elements
 // which listen to it via ''focus-me="focusInput'' in angular markup
 treeherder.directive('focusMe', [

--- a/webapp/app/js/directives/main.js
+++ b/webapp/app/js/directives/main.js
@@ -44,6 +44,19 @@ treeherder.directive('blurThis', ['$timeout', function($timeout) {
   };
 }]);
 
+// Directive clickThis which synthesizes a click in a specific element
+treeherder.directive('clickThis', ['$timeout', function($timeout) {
+  return function(scope, elem, attr) {
+      scope.$on('click-this', function(event, id) {
+        if (attr.id == id) {
+          $timeout(function() {
+            elem[0].click();
+          }, 0);
+        }
+      });
+  };
+}]);
+
 // Directive focusMe which sets a global focus state for elements
 // which listen to it via ''focus-me="focusInput'' in angular markup
 treeherder.directive('focusMe', [

--- a/webapp/app/partials/main/thWatchedRepoNavPanel.html
+++ b/webapp/app/partials/main/thWatchedRepoNavPanel.html
@@ -35,9 +35,10 @@
                 <!--Search Field-->
                 <span ng-controller="SearchCtrl" class="form-group form-inline">
                     <input id="platform-job-text-search-field"
-                           ng-model="searchQueryStr" ng-keyup="search($event)" type="text"
+                           ng-model="searchQueryStr" ng-keydown="search($event)" type="text"
                            class="form-control input-sm"
-                           placeholder="Filter platforms & jobs" select-on-click>
+                           placeholder="Filter platforms & jobs"
+                           click-this blur-this select-on-click>
                 </span>
             </form>
         </span>

--- a/webapp/app/partials/main/thWatchedRepoNavPanel.html
+++ b/webapp/app/partials/main/thWatchedRepoNavPanel.html
@@ -38,7 +38,7 @@
                            ng-model="searchQueryStr" ng-keydown="search($event)" type="text"
                            class="form-control input-sm"
                            placeholder="Filter platforms & jobs"
-                           click-this blur-this select-on-click>
+                           blur-this select-on-click>
                 </span>
             </form>
         </span>


### PR DESCRIPTION
This work fixes Bugzilla bug [1133545](https://bugzilla.mozilla.org/show_bug.cgi?id=1133545).

This adds the **f** key as a shortcut to focus the "Filter platforms & jobs" field. In it we:

* similarly issue a click in the shortcut rather than focus, which selects the string if it exists
* create a new `clickThis` directive to support that behavior
* no longer re-invoke the filter as soon as the cell is empty, instead only after the user hits Enter
* create a global behavior which suppresses (makes transparent) *all* placeholder text on focus

The suppression/transparency of placeholder text on click was approved by Ryan in channel. I checked and it didn't seem to have any adverse impacts in the pinboard, etc. It seems to add clarity, but we could easily remove it if needed.

Invoking an empty filter by typing Enter, was also approved by Ryan in channel. This means there is one extra keystroke to clear a filter (backspace, *Enter*), but this makes both initial input, and re-input, consistent.

There are no changes in UI appearance but here's an example of a Filter shortcut invocation with an existing filter present:

![shortcutreinvocation](https://cloud.githubusercontent.com/assets/3660661/6403238/e5ab0878-bddb-11e4-85f1-c5b7241ad1cf.jpg)

Everything seems to be working well in all my local testing, and it seems a huge improvement over having to manually go and click on the filter input every time. Focus also returns to the main panel as soon as you've hit Enter, so the usual j,k,n,p navigation and other shortcut workflows seem to work seamlessly while switching back and forth between filter states.

The only scenario a bit ambiguous, but has always been on production, is:

* enter or empty a filter but don't hit Enter
* *click away* somewhere else

Now you have an empty filter field, but a filter state which doesn’t match since it hasn’t been invoked. However this is our current behaviour on production. I spent some time trying to get both behaviors working, but could only get one (click away) or the other (enter). The input doesn't appear to blur on a click away, so we can't do an `ng-blur=search($event)` and then check for it and invoke the search in filters.js. Perhaps for later.

I've updated the Help and also added the .unbind so we don't issue a filter command when typing text in other inputs which support multi-key shortcuts during text entry (eg. comments, add-related-bugs).

Tested on OSX 10.9.5:
FF Release **35.0.1**
Chrome Latest Release **40.0.2214.115** (64-bit)

Adding @camd for review and @edmorley and @rvandermeulen for visibility.