### PR TITLE
Bug 1126525 - Link sm/hazard Help job descriptions to wikis

### DIFF
--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -156,27 +156,63 @@
                 <tr><th>S</th>
                 <td>Static Checking Build</td></tr>
                 <tr><th>SM</th>
-                <td>SpiderMonkey</td></tr>
+                  <td>
+                    <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
+                       SpiderMonkey</a>
+                  </td>
+                </tr>
                 <tr><th>arm</th>
-                <td>SpiderMonkey ARM Simulator Build</td></tr>
+                  <td>
+                    <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
+                       SpiderMonkey</a> ARM Simulator Build
+                  </td>
+                </tr>
                 <tr><th>d</th>
-                <td>SpiderMonkey DTrace Build</td></tr>
+                  <td>
+                    <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
+                       SpiderMonkey</a> DTrace Build
+                  </td>
+                </tr>
                 <tr><th>e</th>
-                <td>SpiderMonkey Fail-On-Warnings Build</td></tr>
+                  <td>
+                    <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
+                       SpiderMonkey</a> Fail-On-Warnings Build
+                  </td>
+                </tr>
                 <tr><th>exr</th>
-                <td>SpiderMonkey Exact Rooting Shell Build</td></tr>
+                  <td>
+                    <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
+                       SpiderMonkey</a> Exact Rooting Shell Build
+                  </td>
+                </tr>
                 <tr><th>ggc</th>
-                <td>SpiderMonkey GGC Shell Build</td></tr>
+                  <td>
+                    <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
+                       SpiderMonkey</a> GGC Shell Build
+                  </td>
+                </tr>
                 <tr><th>H</th>
-                <td>SpiderMonkey Hazard Analysis Build</td></tr>
+                  <td>SpiderMonkey
+                    <a href="https://wiki.mozilla.org/Javascript:Hazard_Builds">
+                       Hazard</a> Analysis Build
+                  </td>
+                </tr>
                 <tr><th>r</th>
-                <td>SpiderMonkey Root Analysis Build</td></tr>
+                  <td>
+                    <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
+                       SpiderMonkey</a> Root Analysis Build
+                  </td>
+                </tr>
                 <tr><th>N</th>
                 <td>Nightly</td></tr>
                 <tr><th>Dxr</th>
                 <td>DXR Index Build</td></tr>
                 <tr><th>H</th>
-                <td>Hazard Analysis Build</td></tr>
+                  <td>
+                    <a href="https://wiki.mozilla.org/Javascript:Hazard_Builds">
+                       Hazard</a> Analysis Build
+                  </td>
+                </tr>
                 <tr><th>V</th>
                 <td>Valgrind Build</td></tr>
                 <tr><th>Xr</th>


### PR DESCRIPTION
This fixes Bugzilla bug [1126525](https://bugzilla.mozilla.org/show_bug.cgi?id=1126525).

This links the Spidermonkey and Hazard descriptors in the Help, to their respective wikis. Here's the after:

![spiderhazardlinks](https://cloud.githubusercontent.com/assets/3660661/6445837/c26b6c94-c0d4-11e4-928e-f2c8f16ac5f8.jpg)

I chose not to link the single line "Spidermonkey Hazard" separately as "Spidermonkey" and "Hazard", for clarity. Since it seems to be a Hazard build, and there are lots of Spidermonkey links present.

If its well received we can consider doing it with other jobs not specified, if they have similar wikis available.

Tested on OSX 10.9.5:
FF Release **35.0.1**
Chrome Latest Release **40.0.2214.115** (64-bit)

Adding @edmorley for review and feedback.