### PR TITLE
Bug 1113873 - Support existence of struct log summary artifact

### DIFF
--- a/webapp/app/js/controllers/jobs.js
+++ b/webapp/app/js/controllers/jobs.js
@@ -136,7 +136,7 @@ treeherder.controller('ResultSetCtrl', [
                 success(function(data) {
                     if (data.hasOwnProperty("artifacts")) {
                         data.artifacts.forEach(function(artifact) {
-                            if (artifact.name === "Structured Log") {
+                            if (artifact.name === "text_log_summary") {
                                 window.open(thUrl.getLogViewerUrl(artifact.id));
                             }
                         });

--- a/webapp/app/js/controllers/logviewer.js
+++ b/webapp/app/js/controllers/logviewer.js
@@ -153,7 +153,7 @@ logViewer.controller('LogviewerCtrl', [
 
         $scope.init = function() {
             $log.debug(ThJobArtifactModel.get_uri());
-            ThJobArtifactModel.get_list({job_id: $scope.job_id, name: 'Structured Log'})
+            ThJobArtifactModel.get_list({job_id: $scope.job_id, name: 'text_log_summary'})
             .then(function(artifactList){
                 if(artifactList.length > 0){
                     $scope.artifact = artifactList[0].blob;

--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -125,7 +125,9 @@ treeherder.controller('PluginCtrl', [
                         }, []);
                     }
                     // the fourth result comes from the jobLogUrl artifact
-                    $scope.job_log_urls = results[3];
+                    // filter to only the builds-4h logs
+                    $scope.job_log_urls = _.where(results[3], {name: 'builds-4h'});
+
                     var logsNotParsed = [];
                     $scope.jobLogsAllParsed = _.every($scope.job_log_urls, function(jlu) {
                         if(jlu.parse_status === 'pending'){

--- a/webapp/app/plugins/similar_jobs/controller.js
+++ b/webapp/app/plugins/similar_jobs/controller.js
@@ -136,7 +136,7 @@ treeherder.controller('SimilarJobsPluginCtrl', [
 
                 //retrieve the list of error lines
                 ThJobArtifactModel.get_list({
-                    name: "Structured Log",
+                    name: "text_log_summary",
                     job_id: $scope.similar_job_selected.id
                 })
                 .then(function(artifact_list){


### PR DESCRIPTION
When the Service is generating the structured log summary artifact, the
UI needs to handle that it will come back in the
endpoint for log artifacts. This change will just ignore the new
artifact.