### PR TITLE
Bug 1139301 - Make the date-format consistent and centralized

### DIFF
--- a/webapp/app/js/controllers/jobs.js
+++ b/webapp/app/js/controllers/jobs.js
@@ -106,12 +106,12 @@ treeherder.controller('JobsCtrl', [
 
 treeherder.controller('ResultSetCtrl', [
     '$scope', '$rootScope', '$http', 'ThLog', '$location',
-    'thUrl', 'thServiceDomain', 'thResultStatusInfo',
+    'thUrl', 'thServiceDomain', 'thResultStatusInfo', 'thDateFormat',
     'ThResultSetStore', 'thEvents', 'thJobFilters', 'thNotify',
     'thBuildApi', 'thPinboard', 'ThResultSetModel', 'dateFilter',
     function ResultSetCtrl(
         $scope, $rootScope, $http, ThLog, $location,
-        thUrl, thServiceDomain, thResultStatusInfo,
+        thUrl, thServiceDomain, thResultStatusInfo, thDateFormat,
         ThResultSetStore, thEvents, thJobFilters, thNotify,
         thBuildApi, thPinboard, ThResultSetModel, dateFilter) {
 
@@ -238,7 +238,7 @@ treeherder.controller('ResultSetCtrl', [
                                             $scope.resultset.revision;
 
         $scope.resultsetDateStr = dateFilter($scope.resultset.push_timestamp*1000,
-                                             'EEE MMM d, H:mm:ss');
+                                             thDateFormat);
 
         $scope.authorResultsetFilterUrl = $scope.urlBasePath + "?repo=" +
                                           $scope.repoName + "&author=" +

--- a/webapp/app/js/values.js
+++ b/webapp/app/js/values.js
@@ -123,3 +123,5 @@ treeherder.value("thRepoGroupOrder", {
 });
 
 treeherder.value("thDefaultRepo", "mozilla-central");
+
+treeherder.value("thDateFormat", "EEE MMM d, H:mm:ss");

--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -6,13 +6,13 @@
 
 treeherder.controller('PluginCtrl', [
     '$scope', '$rootScope', '$location', 'thUrl', 'ThJobClassificationModel',
-    'thClassificationTypes', 'ThJobModel', 'thEvents', 'dateFilter',
+    'thClassificationTypes', 'ThJobModel', 'thEvents', 'dateFilter', 'thDateFormat',
     'numberFilter', 'ThBugJobMapModel', 'thResultStatus', 'thJobFilters',
     'ThResultSetModel', 'ThLog', '$q', 'thPinboard', 'ThJobArtifactModel',
     'thBuildApi', 'thNotify', 'ThJobLogUrlModel', 'thTabs', '$timeout',
     function PluginCtrl(
         $scope, $rootScope, $location, thUrl, ThJobClassificationModel,
-        thClassificationTypes, ThJobModel, thEvents, dateFilter,
+        thClassificationTypes, ThJobModel, thEvents, dateFilter, thDateFormat,
         numberFilter, ThBugJobMapModel, thResultStatus, thJobFilters,
         ThResultSetModel, ThLog, $q, thPinboard, ThJobArtifactModel,
         thBuildApi, thNotify, ThJobLogUrlModel, thTabs, $timeout) {
@@ -181,7 +181,8 @@ treeherder.controller('PluginCtrl', [
 
                 // time fields to show in detail panel, but that should be grouped together
                 $scope.visibleTimeFields = {
-                    requestTime: dateFilter($scope.job.submit_timestamp*1000, 'short')
+                    requestTime: dateFilter($scope.job.submit_timestamp*1000,
+                                            thDateFormat)
                 };
 
                 /*
@@ -199,11 +200,11 @@ treeherder.controller('PluginCtrl', [
 
                 if ($scope.job.start_timestamp) {
                     $scope.visibleTimeFields.startTime = dateFilter(
-                        $scope.job.start_timestamp*1000, 'short');
+                        $scope.job.start_timestamp*1000, thDateFormat);
                 }
                 if ($scope.job.end_timestamp) {
                     $scope.visibleTimeFields.endTime = dateFilter(
-                        $scope.job.end_timestamp*1000, 'short');
+                        $scope.job.end_timestamp*1000, thDateFormat);
                 }
 
         };

--- a/webapp/app/plugins/similar_jobs/main.html
+++ b/webapp/app/plugins/similar_jobs/main.html
@@ -20,7 +20,7 @@
                                     </span>
                                 </button>
                             </td>
-                            <td>{{ ::similar_job.result_set.push_timestamp*1000|date:'medium' }}</td>
+                            <td>{{ ::similar_job.result_set.push_timestamp*1000 | date:'EEE MMM d, H:mm:ss' }}</td>
                             <td>
                                 <a href="{{ ::similar_job.authorResultsetFilterUrl }}">
                                     {{ ::similar_job.result_set.author }}
@@ -94,7 +94,7 @@
                         <tr>
                             <th>Start time</th>
                             <td>
-                                {{ similar_job_selected.start_time }}
+                                {{ similar_job_selected.start_timestamp*1000 | date:'EEE MMM d, H:mm:ss' }}
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
This fixes Bugzilla bug [1139301](https://bugzilla.mozilla.org/show_bug.cgi?id=1139301).

This switches the date format for the job details panel for Request, Start, and End, from **m/d/yy**, to the format highlighted below.

In addition to removing ambiguity for all users (folks who read **m/d** or **d/m**), it makes it consistent with the resultset header. We use 24hour time, but we could add an AM/PM here if we feel it is really needed.

I'm awaiting feedback from @darktrojan just to make sure he's happy with it, before we merge.


![jobdetaildateformat](https://cloud.githubusercontent.com/assets/3660661/6489758/01a7f7e2-c26f-11e4-81d1-8ad128748f48.jpg)

Tested on OSX 10.9.5:
FF Release **35.0.1**
Chrome Latest Release **40.0.2214.115** (64-bit)

Adding @edmorley for review and @darktrojan for visibility.