### PR TITLE
Bug 1139565 - Add more polish to the Help build/job tables

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1753,6 +1753,25 @@ fieldset[disabled] .btn-repo.active {
     font-weight: normal;
 }
 
+.help-btn-sm tr > th > button {
+    font-size: 13px;
+    padding: 0px 2px;
+    margin-top: 1px;
+    border: 1px solid;
+    border-radius: 3px;
+    color: #b3b3b3;
+    cursor: auto;
+    background: #fff;
+}
+
+.help-btn-sm tr > th > button:focus {
+    outline: 0;
+}
+
+.help-btn-desc tr > td {
+    vertical-align: bottom;
+}
+
 .help-btn {
     margin: 2px;
     border: 2px solid;

--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -150,220 +150,220 @@
     <div class="panel panel-default">
         <div class="panel-heading"><h3>Builds</h3></div>
         <div class="panel-body panel-spacing">
-            <table id="legend-builds">
-                <tr><th>B</th>
+            <table id="legend-builds" class="help-btn-sm help-btn-desc">
+                <tr><th><button>B</button></th>
                 <td>Build</td></tr>
-                <tr><th>Bn</th>
+                <tr><th><button>Bn</button></th>
                 <td>Non-Unified Build</td></tr>
-                <tr><th>S</th>
+                <tr><th><button>S</button></th>
                 <td>Static Checking Build</td></tr>
-                <tr><th>SM</th>
+                <tr><th><button>SM</button></th>
                   <td>
                     <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
                        SpiderMonkey</a>
                   </td>
                 </tr>
-                <tr><th>arm</th>
+                <tr><th><button>arm</button></th>
                   <td>
                     <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
                        SpiderMonkey</a> ARM Simulator Build
                   </td>
                 </tr>
-                <tr><th>p</th>
+                <tr><th><button>p</button></th>
                   <td>
                     <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
                        SpiderMonkey</a> Plain Shell Build
                   </td>
                 </tr>
-                <tr><th>d</th>
+                <tr><th><button>d</button></th>
                   <td>
                     <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
                        SpiderMonkey</a> DTrace Build
                   </td>
                 </tr>
-                <tr><th>e</th>
+                <tr><th><button>e</button></th>
                   <td>
                     <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
                        SpiderMonkey</a> Fail-On-Warnings Build
                   </td>
                 </tr>
-                <tr><th>exr</th>
+                <tr><th><button>exr</button></th>
                   <td>
                     <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
                        SpiderMonkey</a> Exact Rooting Shell Build
                   </td>
                 </tr>
-                <tr><th>cgc</th>
+                <tr><th><button>cgc</button></th>
                   <td>
                     <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
                        SpiderMonkey</a> Compacting GC Shell Build
                   </td>
                 </tr>
-                <tr><th>ggc</th>
+                <tr><th><button>ggc</button></th>
                   <td>
                     <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
                        SpiderMonkey</a> GGC Shell Build
                   </td>
                 </tr>
-                <tr><th>H</th>
+                <tr><th><button>H</button></th>
                   <td>SpiderMonkey
                     <a href="https://wiki.mozilla.org/Javascript:Hazard_Builds">
                        Hazard</a> Analysis Build
                   </td>
                 </tr>
-                <tr><th>r</th>
+                <tr><th><button>r</button></th>
                   <td>
                     <a href="https://wiki.mozilla.org/Javascript:Automation_Builds">
                        SpiderMonkey</a> Root Analysis Build
                   </td>
                 </tr>
-                <tr><th>N</th>
+                <tr><th><button>N</button></th>
                 <td>Nightly</td></tr>
-                <tr><th>Dxr</th>
+                <tr><th><button>Dxr</button></th>
                 <td>DXR Index Build</td></tr>
-                <tr><th>H</th>
+                <tr><th><button>H</button></th>
                   <td>
                     <a href="https://wiki.mozilla.org/Javascript:Hazard_Builds">
                        Hazard</a> Analysis Build
                   </td>
                 </tr>
-                <tr><th>V</th>
+                <tr><th><button>V</button></th>
                 <td>Valgrind Build</td></tr>
-                <tr><th>Xr</th>
+                <tr><th><button>Xr</button></th>
                 <td>XULRunner Nightly</td></tr>
-                <tr><th>Bo</th>
+                <tr><th><button>Bo</button></th>
                 <td>AddressSanitizer Opt Build</td></tr>
-                <tr><th>Bd</th>
+                <tr><th><button>Bd</button></th>
                 <td>AddressSanitizer Debug Build</td></tr>
-                <tr><th>No</th>
+                <tr><th><button>No</button></th>
                 <td>AddressSanitizer Opt Nightly</td></tr>
-                <tr><th>Nd</th>
+                <tr><th><button>Nd</button></th>
                 <td>AddressSanitizer Debug Nightly</td></tr>
-                <tr><th>N</th>
+                <tr><th><button>N</button></th>
                 <td>L10n Nightly</td></tr>
-                <tr><th>L10n</th>
+                <tr><th><button>L10n</button></th>
                 <td>L10n Repack</td></tr>
-                <tr><th>B</th>
+                <tr><th><button>B</button></th>
                 <td>B2G Emulator Image Build</td></tr>
-                <tr><th>Bn</th>
+                <tr><th><button>Bn</button></th>
                 <td>B2G Emulator Image Non-Unified Build</td></tr>
-                <tr><th>N</th>
+                <tr><th><button>N</button></th>
                 <td>B2G Emulator Image Nightly</td></tr>
-                <tr><th>Dolphin</th>
+                <tr><th><button>Dolphin</button></th>
                 <td>Dolphin Device Image</td></tr>
-                <tr><th>B</th>
+                <tr><th><button>B</button></th>
                 <td>Dolphin Device Image Build</td></tr>
-                <tr><th>Be</th>
+                <tr><th><button>Be</button></th>
                 <td>Dolphin Device Image Build (Engineering)</td></tr>
-                <tr><th>N</th>
+                <tr><th><button>N</button></th>
                 <td>Dolphin Device Image Nightly</td></tr>
-                <tr><th>Ne</th>
+                <tr><th><button>Ne</button></th>
                 <td>Dolphin Device Image Nightly (Engineering)</td></tr>
-                <tr><th>Flame</th>
+                <tr><th><button>Flame</button></th>
                 <td>Flame Device Image</td></tr>
-                <tr><th>B</th>
+                <tr><th><button>B</button></th>
                 <td>Flame Device Image Build</td></tr>
-                <tr><th>Be</th>
+                <tr><th><button>Be</button></th>
                 <td>Flame Device Image Build (Engineering)</td></tr>
-                <tr><th>N</th>
+                <tr><th><button>N</button></th>
                 <td>Flame Device Image Nightly</td></tr>
-                <tr><th>Ne</th>
+                <tr><th><button>Ne</button></th>
                 <td>Flame Device Image Nightly (Engineering)</td></tr>
-                <tr><th>Flame-KK</th>
+                <tr><th><button>Flame-KK</button></th>
                 <td>Flame KitKat Device Image</td></tr>
-                <tr><th>B</th>
+                <tr><th><button>B</button></th>
                 <td>Flame KitKat Device Image Build</td></tr>
-                <tr><th>Be</th>
+                <tr><th><button>Be</button></th>
                 <td>Flame KitKat Device Image Build (Engineering)</td></tr>
-                <tr><th>N</th>
+                <tr><th><button>N</button></th>
                 <td>Flame KitKat Device Image Nightly</td></tr>
-                <tr><th>Ne</th>
+                <tr><th><button>Ne</button></th>
                 <td>Flame KitKat Device Image Nightly (Engineering)</td></tr>
-                <tr><th>Buri/Hamachi</th>
+                <tr><th><button>Buri/Hamachi</button></th>
                 <td>Buri/Hamachi Device Image</td></tr>
-                <tr><th>B</th>
+                <tr><th><button>B</button></th>
                 <td>Hamachi Device Image Build</td></tr>
-                <tr><th>Be</th>
+                <tr><th><button>Be</button></th>
                 <td>Hamachi Device Image Build (Engineering)</td></tr>
-                <tr><th>N</th>
+                <tr><th><button>N</button></th>
                 <td>Hamachi Device Image Nightly</td></tr>
-                <tr><th>Ne</th>
+                <tr><th><button>Ne</button></th>
                 <td>Hamachi Device Image Nightly (Engineering)</td></tr>
-                <tr><th>Helix</th>
+                <tr><th><button>Helix</button></th>
                 <td>Helix Device Image</td></tr>
-                <tr><th>B</th>
+                <tr><th><button>B</button></th>
                 <td>Helix Device Image Build</td></tr>
-                <tr><th>Be</th>
+                <tr><th><button>Be</button></th>
                 <td>Helix Device Image Build (Engineering)</td></tr>
-                <tr><th>N</th>
+                <tr><th><button>N</button></th>
                 <td>Helix Device Image Nightly</td></tr>
-                <tr><th>Ne</th>
+                <tr><th><button>Ne</button></th>
                 <td>Helix Device Image Nightly (Engineering)</td></tr>
-                <tr><th>Inari</th>
+                <tr><th><button>Inari</button></th>
                 <td>Inari Device Image</td></tr>
-                <tr><th>B</th>
+                <tr><th><button>B</button></th>
                 <td>Inari Device Image Build</td></tr>
-                <tr><th>Be</th>
+                <tr><th><button>Be</button></th>
                 <td>Inari Device Image Build (Engineering)</td></tr>
-                <tr><th>N</th>
+                <tr><th><button>N</button></th>
                 <td>Inari Device Image Nightly</td></tr>
-                <tr><th>Ne</th>
+                <tr><th><button>Ne</button></th>
                 <td>Inari Device Image Nightly (Engineering)</td></tr>
-                <tr><th>Leo</th>
+                <tr><th><button>Leo</button></th>
                 <td>Leo Device Image</td></tr>
-                <tr><th>B</th>
+                <tr><th><button>B</button></th>
                 <td>Leo Device Image Build</td></tr>
-                <tr><th>Be</th>
+                <tr><th><button>Be</button></th>
                 <td>Leo Device Image Build (Engineering)</td></tr>
-                <tr><th>N</th>
+                <tr><th><button>N</button></th>
                 <td>Leo Device Image Nightly</td></tr>
-                <tr><th>Ne</th>
+                <tr><th><button>Ne</button></th>
                 <td>Leo Device Image Nightly (Engineering)</td></tr>
-                <tr><th>Nexus 4</th>
+                <tr><th><button>Nexus 4</button></th>
                 <td>Nexus 4 Device Image</td></tr>
-                <tr><th>B</th>
+                <tr><th><button>B</button></th>
                 <td>Nexus 4 Device Image Build</td></tr>
-                <tr><th>Be</th>
+                <tr><th><button>Be</button></th>
                 <td>Nexus 4 Device Image Build (Engineering)</td></tr>
-                <tr><th>N</th>
+                <tr><th><button>N</button></th>
                 <td>Nexus 4 Device Image Nightly</td></tr>
-                <tr><th>Ne</th>
+                <tr><th><button>Ne</button></th>
                 <td>Nexus 4 Device Image Nightly (Engineering)</td></tr>
-                <tr><th>Tarako</th>
+                <tr><th><button>Tarako</button></th>
                 <td>Tarako Device Image</td></tr>
-                <tr><th>B</th>
+                <tr><th><button>B</button></th>
                 <td>Tarako Device Image Build</td></tr>
-                <tr><th>Be</th>
+                <tr><th><button>Be</button></th>
                 <td>Tarako Device Image Build (Engineering)</td></tr>
-                <tr><th>N</th>
+                <tr><th><button>N</button></th>
                 <td>Tarako Device Image Nightly</td></tr>
-                <tr><th>Ne</th>
+                <tr><th><button>Ne</button></th>
                 <td>Tarako Device Image Nightly (Engineering)</td></tr>
-                <tr><th>Unagi</th>
+                <tr><th><button>Unagi</button></th>
                 <td>Unagi Device Image</td></tr>
-                <tr><th>B</th>
+                <tr><th><button>B</button></th>
                 <td>Unagi Device Image Build</td></tr>
-                <tr><th>Be</th>
+                <tr><th><button>Be</button></th>
                 <td>Unagi Device Image Build (Engineering)</td></tr>
-                <tr><th>N</th>
+                <tr><th><button>N</button></th>
                 <td>Unagi Device Image Nightly</td></tr>
-                <tr><th>Ne</th>
+                <tr><th><button>Ne</button></th>
                 <td>Unagi Device Image Nightly (Engineering)</td></tr>
-                <tr><th>Wasabi</th>
+                <tr><th><button>Wasabi</button></th>
                 <td>Wasabi Device Image</td></tr>
-                <tr><th>B</th>
+                <tr><th><button>B</button></th>
                 <td>Wasabi Device Image Build</td></tr>
-                <tr><th>N</th>
+                <tr><th><button>N</button></th>
                 <td>Wasabi Device Image Nightly</td></tr>
-                <tr><th>Unknown</th>
+                <tr><th><button>Unknown</button></th>
                 <td>Unknown Device Image</td></tr>
-                <tr><th>B</th>
+                <tr><th><button>B</button></th>
                 <td>Unknown B2G Device Image Build</td></tr>
-                <tr><th>Be</th>
+                <tr><th><button>Be</button></th>
                 <td>Unknown B2G Device Image Build (Engineering)</td></tr>
-                <tr><th>N</th>
+                <tr><th><button>N</button></th>
                 <td>Unknown B2G Device Image Nightly</td></tr>
-                <tr><th>Ne</th>
+                <tr><th><button>Ne</button></th>
                 <td>Unknown B2G Device Image Nightly (Engineering)</td></tr>
             </table>
         </div>
@@ -375,144 +375,144 @@
     <div class="panel panel-default">
         <div class="panel-heading"><h3>Tests</h3></div>
         <div class="panel-body panel-spacing">
-            <table id="legend-tests">
-                <tr><th>Mb</th>
+            <table id="legend-tests" class="help-btn-sm help-btn-desc">
+                <tr><th><button>Mb</button></th>
                 <td>Mozbase Unit Tests</td></tr>
-                <tr><th>M</th>
+                <tr><th><button>M</button></th>
                 <td>Mochitest</td></tr>
-                <tr><th>bc</th>
+                <tr><th><button>bc</button></th>
                 <td>Mochitest Browser Chrome</td></tr>
-                <tr><th>dt</th>
+                <tr><th><button>dt</button></th>
                 <td>Mochitest DevTools Browser Chrome</td></tr>
-                <tr><th>gl</th>
+                <tr><th><button>gl</button></th>
                 <td>Mochitest WebGL</td></tr>
-                <tr><th>JP</th>
+                <tr><th><button>JP</button></th>
                 <td>Mochitest Jetpack</td></tr>
-                <tr><th>mc</th>
+                <tr><th><button>mc</button></th>
                 <td>Mochitest Metro Browser Chrome</td></tr>
-                <tr><th>oth</th>
+                <tr><th><button>oth</button></th>
                 <td>Mochitest Other</td></tr>
-                <tr><th>M-e10s</th>
+                <tr><th><button>M-e10s</button></th>
                 <td>Mochitest e10s</td></tr>
-                <tr><th>M-csb</th>
+                <tr><th><button>M-csb</button></th>
                 <td>Mochitest csb</td></tr>
-                <tr><th>M-oop</th>
+                <tr><th><button>M-oop</button></th>
                 <td>Mochitest OOP</td></tr>
-                <tr><th>rc</th>
+                <tr><th><button>rc</button></th>
                 <td>Robocop</td></tr>
-                <tr><th>w</th>
+                <tr><th><button>w</button></th>
                 <td>Webapprt Content</td></tr>
-                <tr><th>wc</th>
+                <tr><th><button>wc</button></th>
                 <td>Webapprt Chrome</td></tr>
-                <tr><th>C</th>
+                <tr><th><button>C</button></th>
                 <td>Crashtest</td></tr>
-                <tr><th>Cipc</th>
+                <tr><th><button>Cipc</button></th>
                 <td>Crashtest IPC</td></tr>
-                <tr><th>J</th>
+                <tr><th><button>J</button></th>
                 <td>JSReftest</td></tr>
-                <tr><th>R</th>
+                <tr><th><button>R</button></th>
                 <td>Reftest</td></tr>
-                <tr><th>R-e10s</th>
+                <tr><th><button>R-e10s</button></th>
                 <td>Reftest e10s</td></tr>
-                <tr><th>Rs-oop</th>
+                <tr><th><button>Rs-oop</button></th>
                 <td>Reftest Sanity OOP</td></tr>
-                <tr><th>Ripc</th>
+                <tr><th><button>Ripc</button></th>
                 <td>Reftest IPC</td></tr>
-                <tr><th>Ro</th>
+                <tr><th><button>Ro</button></th>
                 <td>Reftest OMTC</td></tr>
-                <tr><th>Rs</th>
+                <tr><th><button>Rs</button></th>
                 <td>Reftest Sanity</td></tr>
-                <tr><th>Ru</th>
+                <tr><th><button>Ru</button></th>
                 <td>Reftest Unaccelerated</td></tr>
-                <tr><th>W</th>
+                <tr><th><button>W</button></th>
                 <td>W3C Web Platform Tests</td></tr>
-                <tr><th>Wr</th>
+                <tr><th><button>Wr</button></th>
                 <td>W3C Web Platform Reftests</td></tr>
-                <tr><th>I</th>
+                <tr><th><button>I</button></th>
                 <td>Android Instrumentation Tests</td></tr>
-                <tr><th>Ba</th>
+                <tr><th><button>Ba</button></th>
                 <td>Android Instrumentation Background</td></tr>
-                <tr><th>Br</th>
+                <tr><th><button>Br</button></th>
                 <td>Android Instrumentation Browser</td></tr>
-                <tr><th>Cpp</th>
+                <tr><th><button>Cpp</button></th>
                 <td>CPP Unit Tests</td></tr>
-                <tr><th>Jit</th>
+                <tr><th><button>Jit</button></th>
                 <td>JIT Tests</td></tr>
-                <tr><th>JP</th>
+                <tr><th><button>JP</button></th>
                 <td>Jetpack SDK Test</td></tr>
-                <tr><th>Gb</th>
+                <tr><th><button>Gb</button></th>
                 <td>Gaia Build Test</td></tr>
-                <tr><th>Gbu</th>
+                <tr><th><button>Gbu</button></th>
                 <td>Gaia Build Unit Test</td></tr>
-                <tr><th>Gij</th>
+                <tr><th><button>Gij</button></th>
                 <td>Gaia JS Integration Test</td></tr>
-                <tr><th>Gij-oop</th>
+                <tr><th><button>Gij-oop</button></th>
                 <td>Gaia JS Integration Test OOP</td></tr>
-                <tr><th>Gip</th>
+                <tr><th><button>Gip</button></th>
                 <td>Gaia Python Integration Tests</td></tr>
-                <tr><th>a</th>
+                <tr><th><button>a</button></th>
                 <td>Gaia Python Accessibility Integration Tests</td></tr>
-                <tr><th>f</th>
+                <tr><th><button>f</button></th>
                 <td>Gaia Python Functional Integration Tests</td></tr>
-                <tr><th>u</th>
+                <tr><th><button>u</button></th>
                 <td>Gaia Python Integration Unit Tests</td></tr>
-                <tr><th>Gip-oop</th>
+                <tr><th><button>Gip-oop</button></th>
                 <td>Gaia Python Integration Tests OOP</td></tr>
-                <tr><th>Gu</th>
+                <tr><th><button>Gu</button></th>
                 <td>Gaia Unit Test</td></tr>
-                <tr><th>Gu-oop</th>
+                <tr><th><button>Gu-oop</button></th>
                 <td>Gaia Unit Test OOP</td></tr>
-                <tr><th>Li</th>
+                <tr><th><button>Li</button></th>
                 <td>Linter Test</td></tr>
-                <tr><th>Mn</th>
+                <tr><th><button>Mn</button></th>
                 <td>Marionette Framework Unit Tests</td></tr>
-                <tr><th>Mnw</th>
+                <tr><th><button>Mnw</button></th>
                 <td>Marionette WebAPI Tests</td></tr>
-                <tr><th>S</th>
+                <tr><th><button>S</button></th>
                 <td>Android x86 Test Set</td></tr>
-                <tr><th>Sets</th>
+                <tr><th><button>Sets</button></th>
                 <td>Android x86 Test Combos</td></tr>
-                <tr><th>X</th>
+                <tr><th><button>X</button></th>
                 <td>XPCShell</td></tr>
-                <tr><th>Z</th>
+                <tr><th><button>Z</button></th>
                 <td>Mozmill</td></tr>
-                <tr><th>T</th>
+                <tr><th><button>T</button></th>
                 <td>Talos Performance</td></tr>
-                <tr><th>T-e10s</th>
+                <tr><th><button>T-e10s</button></th>
                 <td>Talos Performance e10s</td></tr>
-                <tr><th>cm</th>
+                <tr><th><button>cm</button></th>
                 <td>Talos canvasmark</td></tr>
-                <tr><th>c</th>
+                <tr><th><button>c</button></th>
                 <td>Talos chrome</td></tr>
-                <tr><th>d</th>
+                <tr><th><button>d</button></th>
                 <td>Talos dromaeojs</td></tr>
-                <tr><th>g1</th>
+                <tr><th><button>g1</button></th>
                 <td>Talos g1</td></tr>
-                <tr><th>o</th>
+                <tr><th><button>o</button></th>
                 <td>Talos other</td></tr>
-                <tr><th>p</th>
+                <tr><th><button>p</button></th>
                 <td>Talos paint</td></tr>
-                <tr><th>rck2</th>
+                <tr><th><button>rck2</button></th>
                 <td>Talos robocheck2</td></tr>
-                <tr><th>rp</th>
+                <tr><th><button>rp</button></th>
                 <td>Talos robopan</td></tr>
-                <tr><th>rpr</th>
+                <tr><th><button>rpr</button></th>
                 <td>Talos roboprovider</td></tr>
-                <tr><th>s</th>
+                <tr><th><button>s</button></th>
                 <td>Talos svg</td></tr>
-                <tr><th>tp</th>
+                <tr><th><button>tp</button></th>
                 <td>Talos tp</td></tr>
-                <tr><th>tpn</th>
+                <tr><th><button>tpn</button></th>
                 <td>Talos tp nochrome</td></tr>
-                <tr><th>ts</th>
+                <tr><th><button>ts</button></th>
                 <td>Talos ts</td></tr>
-                <tr><th>tsp</th>
+                <tr><th><button>tsp</button></th>
                 <td>Talos tspaint</td></tr>
-                <tr><th>x</th>
+                <tr><th><button>x</button></th>
                 <td>Talos xperf</td></tr>
-                <tr><th>U</th>
+                <tr><th><button>U</button></th>
                 <td>Unknown Unit Test</td></tr>
-                <tr><th>?</th>
+                <tr><th><button>?</button></th>
                 <td>Unknown</td></tr>
             </table>
         </div>


### PR DESCRIPTION
This work fixes Bugzilla bug [1139565](https://bugzilla.mozilla.org/show_bug.cgi?id=1139565).

In it we improve and make a more direct association with what the users see in Help, with what they see in the platform. Here's the before:

![jobcodesbefore](https://cloud.githubusercontent.com/assets/3660661/6491908/7851b040-c27e-11e4-938c-bf0ed321ee4b.jpg)

And proposed:

![jobcodesproposed](https://cloud.githubusercontent.com/assets/3660661/6491916/86a7edee-c27e-11e4-8cee-c0433844e62d.jpg)

I used a style evocative of the running state/color, but slightly less dark, so the columns don't compete so much with their adjacent text. But so they are still readable. I'd be interested to know how that luminance looks on other folks machines to make sure it's ok.

Tested on OSX 10.9.5:
FF Release **35.0.1**
Chrome Latest Release **40.0.2214.115** (64-bit)

Adding @wlach for review and @edmorley for visibility.