### PR TITLE
Bug 1089737 - Unbind left/right navigation in mousetrap inputs

### DIFF
--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -50,7 +50,20 @@ treeherder.controller('MainCtrl', [
 
         // Disable single key shortcuts in specified shortcut events
         $scope.allowKeys = function() {
-            Mousetrap.unbind(['i', 'j', 'n', 'k', 'p', 'space', 'u', 'r', 'c', 'f']);
+            Mousetrap.unbind([
+                'i',     // Toggle display in-progress jobs (pending/running)
+                'j',     // Select next unclassified failure
+                'n',     // Select next unclassified failure
+                'k',     // Select previous unclassified failure
+                'p',     // Select previous unclassified failure
+                'space', // Pin selected job to pinboard
+                'u',     // Display only unclassified failures
+                'r',     // Pin selected job and add related bug
+                'c',     // Pin selected job and add classification
+                'f',     // Enter a custom job or platform filter
+                'left',  // Select previous job
+                'right'  // Select next job
+            ]);
         };
 
         // Process shortcut events


### PR DESCRIPTION
This is a supplemental fix to Bugzilla bug [1089737](https://bugzilla.mozilla.org/show_bug.cgi?id=1089737).

This unbinds the left/right keys when in any mousetrap enabled input, for example add-related-bugs or classification-comment. Without the unbind, if the user uses the left or right arrows to traverse text in those inputs, the selected job changes.

Here's an example screen grab of that workflow:

![arrowkeyrelatedbug](https://cloud.githubusercontent.com/assets/3660661/6493192/0eb8705c-c287-11e4-8c59-dd7a6e6ba36c.jpg)

I did some tidying while I was there, and a planned annotation of the unbound keys now that we have exceeded the styleguide max line length.

Everything seems to be working fine in both browsers.

Tested on OSX 10.9.5:
FF Release **35.0.1**
Chrome Latest Release **40.0.2214.115** (64-bit)

Adding @wlach for review.