### PR TITLE
Bug 1140054 - Update Show/hide hidden jobs tooltip to exclusion

### DIFF
--- a/webapp/app/partials/main/thWatchedRepoNavPanel.html
+++ b/webapp/app/partials/main/thWatchedRepoNavPanel.html
@@ -15,7 +15,7 @@
 
                 <!--Hidden Jobs Button-->
                 <span class="btn btn-view-nav btn-sm btn-right-navbar"
-                      title="Show/hide hidden jobs"
+                      title="Show/hide excluded jobs"
                       tabindex="0" role="button"
                       ng-click="toggleExcludedJobs()">
                     <i class="fa"


### PR DESCRIPTION
This fixes Bugzilla bug [1140054](https://bugzilla.mozilla.org/show_bug.cgi?id=1140054).

Nothing exciting, just updating the Show/hide tooltip so it is consistent with the terminology used elsewhere on the platform for exclusion.

![showhideproposed](https://cloud.githubusercontent.com/assets/3660661/6513072/610a4d70-c346-11e4-8e32-6a94475ad390.jpg)

Tested on OSX 10.9.5:
FF Release **35.0.1**
Chrome Latest Release **40.0.2214.115** (64-bit)

Adding @wlach for review.