### PR TITLE
Bug 1089737 - Update Help shortcuts for left/right navigation

### DIFF
--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -116,12 +116,16 @@
                     <td>Close all open job or filter panels</td></tr>
                     <tr><th>f</th>
                     <td>Enter a filter for platforms and jobs</td></tr>
-                    <tr><th>j<span> or </span>n</th>
-                    <td>Highlight next unclassified failure</td></tr>
+                    <tr><th>&larr;</th>
+                    <td>Select previous job</td></tr>
+                    <tr><th>&rarr;</span></th>
+                    <td>Select next job</td></tr>
                     <tr><th>k<span> or </span>p</th>
-                    <td>Highlight previous unclassified failure</td></tr>
+                    <td>Select previous unclassified failure</td></tr>
+                    <tr><th>j<span> or </span>n</th>
+                    <td>Select next unclassified failure</td></tr>
                     <tr><th>ctrl<span> or </span>cmd</span></th>
-                    <td>Add job to the pinboard during selection</td></tr>
+                    <td>Add job to the pinboard during click selection</td></tr>
                     <tr><th>spacebar</th>
                     <td>Add a selected job to the pinboard</td></tr>
                     <tr><th>r</th>


### PR DESCRIPTION
This is a supplemental fix for Bugzilla bug [1089737](https://bugzilla.mozilla.org/show_bug.cgi?id=1089737).

Nothing major, we just needed to update to reflect @dewgeek's recent change for prev/next job navigation. Here's the Help update:

![shortcuthelpleftrightproposed](https://cloud.githubusercontent.com/assets/3660661/6515357/3fea4c4c-c357-11e4-8b54-86ceb932cd18.jpg)

Some other minor tweaks were made in ordering and for pin-click, while I was there.

Tested on OSX 10.9.5:
FF Release **35.0.1**
Chrome Latest Release **40.0.2214.115** (64-bit)

Adding @wlach for review.