### PR TITLE
Bug 1140734 - Add more polish to logviewer log lines

### DIFF
--- a/webapp/app/css/logviewer.css
+++ b/webapp/app/css/logviewer.css
@@ -38,17 +38,23 @@ body {
     width: 100%;
     overflow: auto;
     bottom: 0;
-    padding: 20px 15px 0;
+    font-family: monospace;
+    font-size: small;
     white-space: nowrap;
-    background: #EFEFEF;
+    background: #f8f8f8;
+}
+
+.lv-log-container > div:nth-child(even) {
+    background: #fff;
 }
 
 .lv-log-line {
     width: 100%;
+    padding: 0 18px;
 }
 
-.text-danger .lv-line-number {
-    background: #e74c3c !important;
+.text-danger {
+    color: #db0000;
 }
 
 .lv-line-highlight {
@@ -137,7 +143,10 @@ body {
 
 .lv-log-msg {
     position: relative;
+    padding: 26px 0 0 20px;
     font-weight: bold;
+    font-family: sans-serif;
+    font-size: 14px;
 }
 
 .lv-log-msg-step {


### PR DESCRIPTION
This work fixes Bugzilla bug [1140734](https://bugzilla.mozilla.org/show_bug.cgi?id=1140734).

In it we convert the log lines to fixed-width, and hopefully add some subtle readability improvements. Here's the before:

![loglinescurrent](https://cloud.githubusercontent.com/assets/3660661/6542779/741a7844-c4d2-11e4-947b-4b7e14cee63b.jpg)

Here's the after:

![fixedwidthlogproposed](https://cloud.githubusercontent.com/assets/3660661/6542785/9aaa20ea-c4d2-11e4-856c-7c8ad05dfc30.jpg)

And I went with a slightly stronger red to help the errors pop a bit better than they did before:

![errorcolorproposed](https://cloud.githubusercontent.com/assets/3660661/6542790/b10c132a-c4d2-11e4-8728-bac56c73ce0c.jpg)

I also reduced the log line text size to small. I am hopeful that is still readable on all systems, since it gives us more content per page.

I have some other enhancement ideas, but we can leave those for later.

I had to make a css addition to the load help message "Click a log step above to view", so it remains sans serif. During the color change for errors I removed a css reference to `lv-line-number` since we aren't currently drawing them and that class doesn't appear to be referenced in the repo.

I checked in with @KWierso in channel with the above and the change seemed to be well received. Perhaps we can put it up on dev/stage after review iterations, and let the sheriffs evaluate it there.

Tested on OSX 10.9.5:
FF Release **36.0.1**
Chrome Latest Release **41.0.2272.76** (64-bit)

Adding @camd for review and @edmorley for visibility.