### PR TITLE
Bug 1136232 - More gracefully handle disabled sessionStorage

### DIFF
--- a/webapp/app/js/models/repository.js
+++ b/webapp/app/js/models/repository.js
@@ -99,15 +99,15 @@ treeherder.factory('ThRepositoryModel', [
                     $rootScope.repos = data;
 
                     _.each(data, addRepoAsUnwatched);
+                    if (name) {
+                        setCurrent(name);
+                    }
+
                     var storedWatched = JSON.parse(sessionStorage.getItem("thWatchedRepos"));
                     if (_.isArray(storedWatched) && _.contains(storedWatched, name)) {
                         _.each(storedWatched, function (repo) {
                             watchRepo(repo);
                         });
-                    }
-
-                    if (name) {
-                        setCurrent(name);
                     }
                     watchedReposUpdated();
                 });

--- a/webapp/app/js/models/repository.js
+++ b/webapp/app/js/models/repository.js
@@ -66,7 +66,7 @@ treeherder.factory('ThRepositoryModel', [
         });
         watchedRepos[repoName] = repos[repoName];
         updateTreeStatus(repoName);
-        watchedReposUpdated();
+        saveWatchedRepos();
 
         $log.debug("watchedRepo", repoName, repos[repoName]);
     };
@@ -74,7 +74,7 @@ treeherder.factory('ThRepositoryModel', [
     var unwatchRepo = function(name) {
         $log.debug("unwatchRepo", name, watchedRepos);
         delete watchedRepos[name];
-        watchedReposUpdated();
+        saveWatchedRepos();
     };
 
     var get_uri = function(){
@@ -109,7 +109,7 @@ treeherder.factory('ThRepositoryModel', [
                             watchRepo(repo);
                         });
                     }
-                    watchedReposUpdated();
+                    saveWatchedRepos();
                 });
         } else {
             setCurrent(name);
@@ -162,7 +162,7 @@ treeherder.factory('ThRepositoryModel', [
         }
     };
 
-    var watchedReposUpdated = function() {
+    var saveWatchedRepos = function() {
         try {
             sessionStorage.setItem("thWatchedRepos", JSON.stringify(_.keys(watchedRepos)));
         } catch (e) {
@@ -269,7 +269,7 @@ treeherder.factory('ThRepositoryModel', [
 
         loadWatchedRepos: loadWatchedRepos,
 
-        watchedReposUpdated: watchedReposUpdated,
+        saveWatchedRepos: saveWatchedRepos,
 
         unwatchRepo: unwatchRepo,
 

--- a/webapp/app/js/models/repository.js
+++ b/webapp/app/js/models/repository.js
@@ -103,7 +103,7 @@ treeherder.factory('ThRepositoryModel', [
                         setCurrent(name);
                     }
 
-                    var storedWatched = JSON.parse(sessionStorage.getItem("thWatchedRepos"));
+                    var storedWatched = loadWatchedRepos();
                     if (_.isArray(storedWatched) && _.contains(storedWatched, name)) {
                         _.each(storedWatched, function (repo) {
                             watchRepo(repo);
@@ -153,8 +153,21 @@ treeherder.factory('ThRepositoryModel', [
 
     };
 
+    var loadWatchedRepos = function() {
+        try {
+            return JSON.parse(sessionStorage.getItem("thWatchedRepos"));
+        } catch (e) {
+            // sessionStorage is disabled/not supported.
+            return {};
+        }
+    };
+
     var watchedReposUpdated = function() {
-        sessionStorage.setItem("thWatchedRepos", JSON.stringify(_.keys(watchedRepos)));
+        try {
+            sessionStorage.setItem("thWatchedRepos", JSON.stringify(_.keys(watchedRepos)));
+        } catch (e) {
+            // sessionStorage is disabled/not supported.
+        }
     };
 
     var getCurrentTreeStatus = function() {
@@ -253,6 +266,8 @@ treeherder.factory('ThRepositoryModel', [
         repos: repos,
 
         watchedRepos: watchedRepos,
+
+        loadWatchedRepos: loadWatchedRepos,
 
         watchedReposUpdated: watchedReposUpdated,
 


### PR DESCRIPTION
Some users set dom.storage.enabled to false to disable local storage for privacy reasons. Let's handle this more gracefully. In the future when we use local storage for more features, we'll want to break this out to somewhere common and use a shim of some sorts, but for now this will do.