### PR TITLE
Bug 1102851 - Relinkify logviewer revision and reduce run-data font

### DIFF
--- a/webapp/app/css/logviewer.css
+++ b/webapp/app/css/logviewer.css
@@ -66,7 +66,9 @@ body {
     background-color: #FFF;
     padding: 20px 5px 4px;
     display: table-row;
+    font-size: 12px;
 }
+
 .run-data .break-word{
     -ms-word-break: break-all;
     word-break: break-all;
@@ -95,6 +97,7 @@ body {
     -o-user-select: text;
     user-select: text;
     white-space: normal;
+    font-size: 12px;
 }
 
 .logviewer-step.selected {
@@ -128,12 +131,10 @@ body {
 
 .logviewer-stepbar .raw-log {
     padding-right: 5px;
-    font-size: 12px;
 }
 
 .logviewer-stepbar input[type="checkbox"] {
     margin: 0;
-    vertical-align: middle;
 }
 
 .lv-line-no.label {
@@ -146,7 +147,7 @@ body {
     padding: 26px 0 0 20px;
     font-weight: bold;
     font-family: sans-serif;
-    font-size: 14px;
+    font-size: 12px;
 }
 
 .lv-log-msg-step {
@@ -170,5 +171,4 @@ body {
 .job-header{
     max-height:270px;
     overflow-y:auto;
-    margin-bottom:20px;
 }

--- a/webapp/app/logviewer.html
+++ b/webapp/app/logviewer.html
@@ -18,11 +18,10 @@
                         <tr ng-repeat="(label, value) in artifact.header">
                             <th ng-cloak>{{label}}</th>
                             <td ng-if="label == 'revision'" class="break-word">
-                                {{value}}
                                 <a href="{{logRevisionFilterUrl}}"
-                                   title="open resultset"
+                                   title="Open resultset"
                                    class="repo-link"
-                                   ng-cloak>link</a>
+                                   ng-cloak>{{value}}</a>
                             </td>
                             <td ng-if="label == 'starttime'"
                                 ng-cloak class="break-word">{{logDisplayDate}}</td>


### PR DESCRIPTION
This change is supplemental to broader work requested in Bugzilla bug [1102851](https://bugzilla.mozilla.org/show_bug.cgi?id=1102851).

Nothing major here, but for some reason, I think accidental, we unlinked the logviewer run-data revision SHA in this commit https://github.com/mozilla/treeherder-ui/commit/c7d10090a01e13f11438fd60ffe3b470e4f7a15d . I wanted to re-link it. While I was there I reduced the font sizes in the upper data blocks. It makes more real estate for the log lines below, and reduces the frequency of vertical overflow in the first data block.

Here's the before and after:

![rundatacurrent](https://cloud.githubusercontent.com/assets/3660661/6546820/57c3c2aa-c599-11e4-8d83-e876ef4fca87.jpg)

![rundataproposed](https://cloud.githubusercontent.com/assets/3660661/6546821/5ea877dc-c599-11e4-970a-04099178737c.jpg)

It seems to still be readable in testing on a lower res Windows machine and on my retina mbp.

There are other issues to be sorted (among many) but this addresses some small annoyances and will dovetail with work in [PR408](https://github.com/mozilla/treeherder-ui/pull/408), which I'd like us to land first.

After that I can rebase this on top of PR408  before potential merge. I may be able to economize the css changes here, depending on the font size changes landed in 408.

Tested on OSX 10.9.5:
FF Release **36.0.1**
Chrome Latest Release **41.0.2272.76** (64-bit)

Adding @camd for review and @edmorley for visibility.