### PR TITLE
Bug 1134840 - Use the current result set filters when using "get next"

### DIFF
--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -101,7 +101,7 @@
      get next:
     <div class="btn-group">
         <div class="btn btn-default btn-sm"
-             ng-click="fetchResultSets(count, false)"
+             ng-click="fetchResultSets(count, true)"
              ng-repeat="count in [10, 20, 50]">{{::count}}</div>
         </div>
     </div>


### PR DESCRIPTION
The second argument to fetchResultSets() determines whether the current result set filters are preserved for the call to fetch more result sets. Previously the filters were not preserved, causing unwanted result sets to be returned (eg pushes by other authors, when the author filter was being used).