### PR TITLE
Bug 918281 - Add dedicated links to tree rules in the tree info pane

### DIFF
--- a/webapp/app/js/directives/top_nav_bar.js
+++ b/webapp/app/js/directives/top_nav_bar.js
@@ -100,6 +100,11 @@ treeherder.directive('thWatchedRepoInfoDropDown', [
                     scope.message_of_the_day = newVal.message_of_the_day;
                 }
             }, true);
+            if (attrs.rules) {
+              scope.treeRules = attrs.rules;
+            } else {
+              scope.treeRules = "https://wiki.mozilla.org/Tree_Rules";
+            }
         },
         templateUrl: 'partials/main/thWatchedRepoInfoDropDown.html'
     };

--- a/webapp/app/partials/main/thWatchedRepoInfoDropDown.html
+++ b/webapp/app/partials/main/thWatchedRepoInfoDropDown.html
@@ -16,6 +16,10 @@
         </li>
 
         <li class="watched-repo-dropdown-item">
+            <a href="{{::treeRules}}" target="_blank">tree rules</a>
+        </li>
+
+        <li class="watched-repo-dropdown-item">
             <a href="{{::pushlog}}" target="_blank">pushlog</a>
         </li>
 


### PR DESCRIPTION
This adds a dedicated section for tree rules to the tree info pane for any given repository, defaulting to a generic tree rules page in the case where there's no specific page for the current repository.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/412)
<!-- Reviewable:end -->
