### PR TITLE
Bug 1139301 - Update perfherder date format

### DIFF
--- a/webapp/app/js/perf.js
+++ b/webapp/app/js/perf.js
@@ -106,7 +106,7 @@ perf.controller('PerfCtrl', [ '$state', '$stateParams', '$scope', '$rootScope', 
       $scope.tooltipContent.value = Math.round(v*1000)/1000;
       $scope.tooltipContent.deltaValue = dv.toFixed(1);
       $scope.tooltipContent.deltaPercentValue = (100 * dvp).toFixed(1);
-      $scope.tooltipContent.date = $.plot.formatDate(new Date(t), '%b %d, %y %H:%M');
+      $scope.tooltipContent.date = $.plot.formatDate(new Date(t), '%a %b %d, %H:%M:%S');
       $scope.$digest();
 
       this.plot.unhighlight();


### PR DESCRIPTION
This is supplemental to fixed bug [1139301](https://bugzilla.mozilla.org/show_bug.cgi?id=1139301).

Nothing exciting, just making the perf date format consistent with the rest of treeherder.

Not knowing how else the date  might be reused in perf I chose not to use an angular date filter; additionally, injecting a `thDateFormat` into perf appears problematic because you can't easily have two ng-apps (treeherder, perf) live and be accessed from the same values.js file. So unless ng-app=perf becomes ng-app=treeherder, it's a moot point. I chatted with @camd and he agreed.

Here's the current date style:

![perfdateformatcurrent](https://cloud.githubusercontent.com/assets/3660661/6562464/c543fcce-c66f-11e4-9c34-e50cdd31c3d7.jpg)

And proposed (same as elsewhere in Treeherder):

![perfdateformatproposed](https://cloud.githubusercontent.com/assets/3660661/6562470/d25646c4-c66f-11e4-9175-ea06d1e75b42.jpg)

I'm easy though. If there's compelling UX reasons for keeping the date format as-is for perf, that makes total sense to me.

Tested on OSX 10.9.5:
FF Release **36.0.1**
Chrome Latest Release **41.0.2272.76** (64-bit)

Adding @wlach  for review and @edmorley for visibility.