### PR TITLE
Bug 1141533 - Enable cache busting for perf.min.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,6 +68,12 @@ module.exports = function(grunt) {
                 file: 'dist/js/logviewer.min.js',
                 cleanup: true
             },
+            perfjs: {
+                replace: ['dist/**/*.html'],
+                replacement: 'perf.min.js',
+                file: 'dist/js/perf.min.js',
+                cleanup: true
+            },
             indexcss: {
                 replace: ['dist/**/*.html'],
                 replacement: 'index.min.css',


### PR DESCRIPTION
All of the other js files are given filenames containing their hashes, during the grunt build, in order to prevent over-caching. This makes us do the same for perf.min.js too.