### PR TITLE
Bug 1137927 - Persist job details panel when jobs are pinned

### DIFF
--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -43,7 +43,7 @@ treeherder.controller('MainCtrl', [
             // Suppress for various UI elements so selection is preserved
             var ignoreClear = element.hasAttribute("ignore-job-clear-on-click");
 
-            if (!ignoreClear) {
+            if (!ignoreClear && !thPinboard.hasPinnedJobs()) {
                 $scope.closeJob();
             }
         };


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1137927](https://bugzilla.mozilla.org/show_bug.cgi?id=1137927).

In it, the the job panel will persist if the user clicks in an empty main page area, if there are jobs pinned.

The **esc** shortcut and the [x] close icon will continue to work as normal, closing the job panel whether or not jobs are pinned.

There are no visible changes, but here's a screen grab of the scenario:

![persistjobpanelpinnedjobs](https://cloud.githubusercontent.com/assets/3660661/6584037/cbfcd570-c73e-11e4-8cd8-eaed144feefa.jpg)

It's an interesting UX change, I think we want to expose users to it on dev, before pushing it to stage/prod. Without prior knowledge of the change in behavior, it may feel a bit strange for users.

Tested on OSX 10.9.5:
FF Release **36.0.1**
Chrome Latest Release **41.0.2272.76** (64-bit)

Adding @wlach for review and @edmorley for visibility.