### PR TITLE
Bug 1137456 - Consolidate the pinboard save/clear-all cluster

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1027,10 +1027,6 @@ ul.failure-summary-list li .btn-xs {
     width: 70px;
 }
 
-#pinboard-controls .clear-all-spacer {
-    width: 3px;
-}
-
 .pinned-job {
     margin-bottom: 2px;
     padding: 1px 2px;
@@ -1039,10 +1035,6 @@ ul.failure-summary-list li .btn-xs {
 
 .pinned-job-close-btn {
     padding: 1px 2px 1px 2px;
-}
-
-.btn-icon-top-margin {
-    margin-top: 0.3em;
 }
 
 .annotations-panel {

--- a/webapp/app/partials/main/thPinboardPanel.html
+++ b/webapp/app/partials/main/thPinboardPanel.html
@@ -64,30 +64,22 @@
 <!-- Save UI -->
 <div id="pinboard-controls" class="btn-group-vertical"
      title="{{!hasPinnedJobs() ? 'No jobs pinned' : ''}}">
-  <span class="btn btn-xs btn-default close-btn"
-        title="Clear the entire pinboard"
-        ng-disabled="!hasPinnedJobs()"
-        ng-click="unPinAll()">
-    <span class="fa fa-minus pull-left btn-icon-top-margin
-                 clear-all-spacer"></span> clear all
-  </span>
-
   <div class="btn-group">
     <span class="btn btn-default btn-xs save-btn"
           title="Save all classification data"
           ng-click="save()"
-          ng-disabled="!hasPinnedJobs()">
-      <span class="fa fa-floppy-o pull-left btn-icon-top-margin"></span> save
+          ng-disabled="!hasPinnedJobs()">save
     </span>
     <span class="btn btn-default btn-xs dropdown-toggle save-btn-dropdown"
-          title="Save sub classifications"
-          data-toggle="dropdown"
-          ng-disabled="!hasPinnedJobs">
+          title="Additional pinboard functions"
+          ng-disabled="!hasPinnedJobs() && !hasRelatedBugs()"
+          data-toggle="dropdown">
       <span class="caret"></span>
     </span>
     <ul class="dropdown-menu pull-right" role="menu">
-      <li><a ng-click="saveClassificationOnly()"><i class="fa fa-star"></i> classification only</a></li>
-      <li><a ng-click="saveBugsOnly()"><i class="fa fa-bug"></i> bugs only</a></li>
+      <li><a ng-click="saveClassificationOnly()">Save classification only</a></li>
+      <li><a ng-click="saveBugsOnly()">Save bugs only</a></li>
+      <li><a ng-click="unPinAll()">Clear all</a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
This work fixes Bugzilla bug [1137456](https://bugzilla.mozilla.org/show_bug.cgi?id=1137456).

This consolidates the clear-all button as a drop down inside the existing menu. While there I de-cluttered and removed the `fa` icons, and also added in a check so we also expose the drop down menu if there is just a related-bug. This allows them to clear-all via the UI, like they would via the shortcut.

Here's the before:

![saveclusterpinboardcurrent](https://cloud.githubusercontent.com/assets/3660661/6598815/8ace7d44-c7dc-11e4-878e-79f2a606982f.jpg)

Here's the after (empty pinboard, and populated):

![saveclusterpinboardproposed](https://cloud.githubusercontent.com/assets/3660661/6598821/90e9ebb4-c7dc-11e4-9559-41ef54a9be78.jpg)

![saveclusterpinboardproposeddropdown](https://cloud.githubusercontent.com/assets/3660661/6598930/21a0a440-c7dd-11e4-8cbe-adac361460b3.jpg)

Everything seems to be working fine on Firefox and Chrome.

If we wanted later we could add a `hasComment()` pinboard service api or similar, and use that check also to enable the dropdown if the user types a comment into an otherwise empty pinboard panel. Perhaps we could also disable/dim the 'Save * only' menu entries if no job/bug is present. However neither of those are regressions from the current UI.

Tested on OSX 10.9.5:
FF Release **36.0.1**
Chrome Latest Release **41.0.2272.89** (64-bit)

Adding @wlach for review and @edmorley for visibility.