### PR TITLE
Travis tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - 0.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,13 @@ sudo: false
 language: node_js
 node_js:
   - 0.10
-
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-
+notifications:
+  email:
+    on_success: never
+    on_failure: always
 
 # Do not run these on the travis server at this time.
 # The end to end tests require the service to be running, but travis can't


### PR DESCRIPTION
*  	Bug 1137278 - Travis: Allow jobs to run on the new container based infra …
Travis have a newer container based stack that runs on EC2, that is both
faster & allows the use of extra features (such as dependency caching):
http://docs.travis-ci.com/user/workers/container-based-infrastructure/
*  	Bug 1140849 - Travis: Only send email notifications for failures