### PR TITLE
Bug 1142244 - Improve readability of cancelled job colors

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1626,15 +1626,15 @@ fieldset[disabled] .btn-black.active {
 }
 
 .btn-pink {
-  color: rgba(250, 115, 172, 0.63);
+  color: #ff40d9;
   font-weight: bold;
 }
 .btn-pink:hover,
 .btn-pink:focus,
 .btn-pink:active,
 .btn-pink.active {
-  background-color: #f95a9d;
-  border-color: #f8428f;
+  background-color: #ff40d9;
+  border-color: #ff40d9;
   color: white;
 }
 .btn-pink.disabled:hover,
@@ -1649,8 +1649,8 @@ fieldset[disabled] .btn-pink:hover,
 fieldset[disabled] .btn-pink:focus,
 fieldset[disabled] .btn-pink:active,
 fieldset[disabled] .btn-pink.active {
-  background-color: #fa73ac;
-  border-color: #fa73ac;
+  background-color: #ff80e5;
+  border-color: #ff80e5;
 }
 
 .btn-repo {


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1142244](https://bugzilla.mozilla.org/show_bug.cgi?id=1142244).

This improves the readability of the cancelled job color for @AutomatedTester, and more closely matches that of TBPL. Initially we had implemented a paler pink to de-emphasize cancelled jobs. Sheriffs are fine with this change.

We start with TBPL's `#f0c` and reduce the saturation to 75% to match the same sat of blue/green jobs. So we end up at at pink of `#ff40d9`. And for the corresponding roughly 50% saturation field set color, we end up at `#ff80e5`.

Here is the before:

![cancelledjobscurrent](https://cloud.githubusercontent.com/assets/3660661/6627186/a0cc4c06-c8d2-11e4-9a42-0c0352f0dfef.jpg)

And here is proposed:

![cancelledjobsproposed](https://cloud.githubusercontent.com/assets/3660661/6627189/a5d794c6-c8d2-11e4-89d9-f742aa8ef51f.jpg)

If it's too vibrant we can always tone it down a little, if needed.

Tested on OSX 10.9.5:
FF Release **36.0.1**
Chrome Latest Release **41.0.2272.76** (64-bit)

Adding @wlach for review and @edmorley for visibility.