### PR TITLE
Bug 1142994 - Consolidate terms and order in Job details panel

### DIFF
--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -171,13 +171,13 @@
         </li>
 
         <li class="small">
-          <label>Request Time:</label><span> {{visibleTimeFields.requestTime}}</span>
+          <label>Requested:</label><span> {{visibleTimeFields.requestTime}}</span>
         </li>
         <li class="small" ng-show="visibleTimeFields.startTime">
-          <label>Start Time:</label><span> {{visibleTimeFields.startTime}}</span>
+          <label>Started:</label><span> {{visibleTimeFields.startTime}}</span>
         </li>
         <li class="small" ng-show="visibleTimeFields.endTime">
-          <label>End Time:</label><span> {{visibleTimeFields.endTime}}</span>
+          <label>Ended:</label><span> {{visibleTimeFields.endTime}}</span>
         </li>
         <li class="small">
           <label>Duration:</label><span> {{visibleTimeFields.duration}}</span>

--- a/webapp/app/plugins/similar_jobs/main.html
+++ b/webapp/app/plugins/similar_jobs/main.html
@@ -3,7 +3,7 @@
                 <table class="table table-super-condensed table-bordered table-hover">
                     <thead>
                         <tr>
-                            <th>Job</th><th>Push timestamp</th><th>Author</th><th>Revision</th>
+                            <th>Job</th><th>Pushed</th><th>Author</th><th>Revision</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -79,22 +79,22 @@
                             </td>
                         </tr>
                         <tr>
-                            <th>Options</th>
+                            <th>Build option</th>
                             <td>
                                 {{ similar_job_selected.platform_option }}
+                            </td>
+                        </tr>
+                        <tr><th>Job name</th><td>{{ similar_job_selected.job_type_name }}</td></tr>
+                        <tr>
+                            <th>Started</th>
+                            <td>
+                                {{ similar_job_selected.start_timestamp*1000 | date:'EEE MMM d, H:mm:ss' }}
                             </td>
                         </tr>
                         <tr>
                             <th>Duration</th>
                             <td>
                                 {{ similar_job_selected.duration >= 0 ? similar_job_selected.duration + ' minute(s)' : 'unknown' }}
-                            </td>
-                        </tr>
-                        <tr><th>Job Name</th><td>{{ similar_job_selected.job_type_name }}</td></tr>
-                        <tr>
-                            <th>Start time</th>
-                            <td>
-                                {{ similar_job_selected.start_timestamp*1000 | date:'EEE MMM d, H:mm:ss' }}
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1142994](https://bugzilla.mozilla.org/show_bug.cgi?id=1142994)

Just some LHF, I had been staring at this awhile and thought I would try to declutter, consolidate terminology, and try to order Similar Jobs consistently with the Job Status pane.

Basically we remove "Time" in the job details since the adjacent value is implicitly Time. We match case of "Job Name" to "Job name" in Similar Jobs, specify the "Option" as a Build option". We also switch "Push timestamp" to Pushed, and we reorder accordingly in Similar Jobs to match the sequence in Job Status.

Here's the before:

![jobdetailscurrent](https://cloud.githubusercontent.com/assets/3660661/6641135/6a6736d0-c972-11e4-87cf-0e235ebd3643.jpg)

Here is the after:

![jobdetailsproposed](https://cloud.githubusercontent.com/assets/3660661/6641136/71df821e-c972-11e4-9cb9-4d366d5ff11d.jpg)

I am not sure if "Build option" is always a build option, or if it can be something else. In which case I will update that just to say "Option" (assuming it is always singular).

Tested on OSX 10.9.5:
FF Release **36.0.1**
Chrome Latest Release **41.0.2272.89** (64-bit)

Adding @edmorley for review.