### PR TITLE
Bug 1143092 - Make job-btn duration start-end, not requested-end

### DIFF
--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -58,12 +58,12 @@ treeherder.directive('thCloneJobs', [
         var jobStatus = thResultStatus(job);
         var hoverText = job.job_type_name;
 
-        if( (jobStatus === 'pending') || (jobStatus === 'running') ){
+        if ((jobStatus === 'pending') || (jobStatus === 'running')) {
             hoverText += " - still " + jobStatus + ", check the job detail panel for a ETA";
 
-        }else {
+        } else {
             //The job is complete, compute duration
-            var duration = Math.round((job.end_timestamp - job.submit_timestamp) / 60);
+            var duration = Math.round((job.end_timestamp - job.start_timestamp) / 60);
             hoverText += jobStatus + " - " + duration + " mins";
         }
 


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1143092](https://bugzilla.mozilla.org/show_bug.cgi?id=1143092).

This makes the job button duration value on a completed job, consistent with the job details pane, and the similar jobs pane. The job button is now start-end, not requested-end, which makes all three match.

Here's the after (change in the tooltip):

![durationcurrentjobproposed](https://cloud.githubusercontent.com/assets/3660661/6654709/ab2e61cc-caab-11e4-89cc-e5c31ae644db.jpg)

Everything seems fine on a variety of jobs, in several different repos, on both browsers tested.

I did a bit of linting while I was there.

Tested on OSX 10.9.5:
FF Release **36.0.1**
Chrome Latest Release **41.0.2272.89** (64-bit)

Adding @lightsofapollo for review.