### PR TITLE
Bug 1143666 - Add a shortcut for retrigger job

### DIFF
--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -124,11 +124,13 @@
                     <td>Select previous unclassified failure</td></tr>
                     <tr><th>j<span> or </span>n</th>
                     <td>Select next unclassified failure</td></tr>
+                    <tr><th>r</span></th>
+                    <td>Retrigger selected job</td></tr>
                     <tr><th>ctrl<span> or </span>cmd</span></th>
                     <td>Add job to the pinboard during click selection</td></tr>
                     <tr><th>spacebar</th>
                     <td>Add a selected job to the pinboard</td></tr>
-                    <tr><th>r</th>
+                    <tr><th>b</th>
                     <td>Add a selected job to the pinboard + enter related bug</td></tr>
                     <tr><th>c</th>
                     <td>Add a selected job to the pinboard + enter classification</td></tr>

--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -56,9 +56,10 @@ treeherder.controller('MainCtrl', [
                 'n',     // Select next unclassified failure
                 'k',     // Select previous unclassified failure
                 'p',     // Select previous unclassified failure
+                'r',     // Retrigger selected job
                 'space', // Pin selected job to pinboard
                 'u',     // Display only unclassified failures
-                'r',     // Pin selected job and add related bug
+                'b',     // Pin selected job and add related bug
                 'c',     // Pin selected job and add classification
                 'f',     // Enter a custom job or platform filter
                 'left',  // Select previous job
@@ -109,6 +110,16 @@ treeherder.controller('MainCtrl', [
                 $rootScope.$emit(thEvents.selectPreviousUnclassifiedFailure);
             });
 
+            // Shortcut: retrigger selected job
+            Mousetrap.bind('r', function() {
+                if ($scope.selectedJob) {
+                    $scope.$evalAsync(
+                        $rootScope.$emit(thEvents.jobRetrigger,
+                                         $rootScope.selectedJob)
+                    );
+                }
+            });
+
             // Shortcut: pin selected job to pinboard
             Mousetrap.bind('space', function(ev) {
                 // If a job is selected add it otherwise
@@ -129,7 +140,7 @@ treeherder.controller('MainCtrl', [
             });
 
             // Shortcut: pin selected job to pinboard and add a related bug
-            Mousetrap.bind('r', function(ev) {
+            Mousetrap.bind('b', function(ev) {
                 if ($scope.selectedJob) {
                     $rootScope.$emit(thEvents.addRelatedBug,
                                      $rootScope.selectedJob);

--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -185,6 +185,9 @@ treeherder.provider('thEvents', function() {
             // fired with a selected job on ctrl/cmd-click or spacebar
             jobPin: "job-pin-EVT",
 
+            // fired with a selected job on 'r'
+            jobRetrigger: "job-retrigger-EVT",
+
             // fired when the user middle-clicks on a job to view the log
             jobContextMenu: "job-context-menu-EVT",
 

--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -330,6 +330,10 @@ treeherder.controller('PluginCtrl', [
             }
         };
 
+        $rootScope.$on(thEvents.jobRetrigger, function(event, job) {
+            $scope.retriggerJob();
+        });
+
         $rootScope.$on(thEvents.jobsClassified, function(event, job) {
             $scope.updateClassifications();
         });


### PR DESCRIPTION
This fixes Bugzilla bug [1143666](https://bugzilla.mozilla.org/show_bug.cgi?id=1143666).

This adds the '**r**' shortcut for retriggering a selected job. It also re-maps the add-related-bugs shortcut, which was '**r**', to '**b**'.

Everything seems to be working ok locally, but for a variety of unrelated reasons (local vagrant issue, LDAP access) I can't actually issue a retrigger. I just used a console print to make sure the shortcut was getting there with no lag, and it also correctly gave me the log-in warning balloon if I wasn't logged in.

![retriggerscenario](https://cloud.githubusercontent.com/assets/3660661/6692778/2d26a536-cca5-11e4-9e53-79ae656b47f1.jpg)

The add-related-bugs shortcut seems to continue to work fine using its new '**b**', and integration testing with other pinboard shortcuts and next/prev job navigation, seems fine.

If you can try my branch and actually retrigger a job or two with your own LDAP access using the shortcut, that would be awesome. :)

(sort of) Tested on OSX 10.9.5:
FF Release **36.0.1**
Chrome Latest Release **41.0.2272.89** (64-bit)

Adding @edmorley for review.