### PR TITLE
Bug 1144748 - Improve readability of help shortcuts with keyboard icons

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1724,6 +1724,20 @@ fieldset[disabled] .btn-repo.active {
     overflow: auto;
 }
 
+/* Used in Help but for general use */
+.kbd {
+    display: inline-block;
+    padding: 3px 5px;
+    font: 11px/10px Consolas,"Liberation Mono",Menlo,Courier,monospace;
+    color: #555;
+    vertical-align: middle;
+    background-color: #fcfcfc;
+    border-width: 1px;
+    border-style: solid;
+    border-color: #ccc #ccc #bbb;
+    border-radius: 3px;
+}
+
 .panel-spacing table {
     width: 100%;
 }

--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -112,38 +112,41 @@
             <div class="panel-heading"><h3>Keyboard shortcuts</h3></div>
             <div class="panel-body panel-spacing">
                 <table id="shortcuts">
-                    <tr><th>esc</th>
+                    <tr><td class="kbd">esc</td>
                     <td>Close all open job or filter panels</td></tr>
-                    <tr><th>f</th>
+                    <tr><td class="kbd">f</td>
                     <td>Enter a filter for platforms and jobs</td></tr>
-                    <tr><th>&larr;</th>
+                    <tr><td class="kbd">&larr;</td>
                     <td>Select previous job</td></tr>
-                    <tr><th>&rarr;</span></th>
+                    <tr><td class="kbd">&rarr;</span></td>
                     <td>Select next job</td></tr>
-                    <tr><th>k<span> or </span>p</th>
+                    <tr><td><span class="kbd">k</span> or <span class="kbd">p</span></td>
                     <td>Select previous unclassified failure</td></tr>
-                    <tr><th>j<span> or </span>n</th>
+                    <tr><td><span class="kbd">j</span> or <span class="kbd">n</span></td>
                     <td>Select next unclassified failure</td></tr>
-                    <tr><th>r</span></th>
+                    <tr><td class="kbd">r</span></td>
                     <td>Retrigger selected job</td></tr>
-                    <tr><th>ctrl<span> or </span>cmd</span></th>
+                    <tr><td><span class="kbd">ctrl</span> or <span class="kbd">cmd</span></td>
                     <td>Add job to the pinboard during click selection</td></tr>
-                    <tr><th>spacebar</th>
+                    <tr><td class="kbd">spacebar</td>
                     <td>Add a selected job to the pinboard</td></tr>
-                    <tr><th>b</th>
+                    <tr><td class="kbd">b</td>
                     <td>Add a selected job to the pinboard + enter related bug</td></tr>
-                    <tr><th>c</th>
+                    <tr><td class="kbd">c</td>
                     <td>Add a selected job to the pinboard + enter classification</td></tr>
-                    <tr><th>ctrl<span>+</span>enter</th>
+                    <tr><td><span class="kbd">ctrl</span><span class="kbd">enter</span></td>
                     <td>Save pinboard classification and related bugs</td></tr>
-                    <tr><th>ctrl<span>+</span>shift<span>+</span>u</th>
-                    <td>Clear the pinboard</td></tr>
-                    <tr><th>i</th>
+                    <tr>
+                      <td><span class="kbd">ctrl</span><span class="kbd">shift
+                        </span><span class="kbd">u</span></td>
+                      <td>Clear the pinboard</td>
+                    </tr>
+                    <tr><td class="kbd">i</td>
                     <td>Toggle in-progress (running/pending) jobs</td></tr>
-                    <tr><th>u</th>
+                    <tr><td class="kbd">u</td>
                     <td>Show only unclassified failures</td></tr>
-                    <tr><th><span>(hover) + </span>ctrl/cmd<span>+</span>c</th>
-                    <td>Copy logviewer or raw log icon links to clipboard</td></tr>
+                    <tr><td><span class="kbd">ctrl/cmd</span>+<span class="kbd">c</td>
+                    <td>Copy logviewer or raw log icon links on hover</td></tr>
                 </table>
             </div>
         </div>


### PR DESCRIPTION
This update fixes Bugzilla bug [1144748](https://bugzilla.mozilla.org/show_bug.cgi?id=1144748).

In it we improve the readability of the shortcuts in Help. I just created a non-specific `kbd` class which we could use anywhere, but referenced its current use in treeherder.css.

Here's the before:

![shortcutshelpcurrent](https://cloud.githubusercontent.com/assets/3660661/6715558/b04011fc-cd75-11e4-90e4-f6cf7a62ce3a.jpg)

Here's the after:

![shortcutshelpproposed](https://cloud.githubusercontent.com/assets/3660661/6715565/b88c9e7a-cd75-11e4-8811-964a1810c2ef.jpg)

Everything seems fine on both browsers.

Tested on OSX 10.9.5:
FF Release **36.0.1**
Chrome Latest Release **41.0.2272.89** (64-bit)

Adding @edmorley for review.