### PR TITLE
Bug 1133021 - Linkify all bugs and prs in revision commit messages

### DIFF
--- a/webapp/app/js/filters.js
+++ b/webapp/app/js/filters.js
@@ -40,22 +40,32 @@ treeherder.filter('stripHtml', function() {
 treeherder.filter('linkifyBugs', function() {
     return function(input) {
         var str = input || '';
-        var bug_matches = /.*-- ([0-9]+)|.*bug-([0-9]+)|.*Bug ([0-9]+)/ig.exec(str);
-        var pr_matches = /PR#([0-9]+)/i.exec(str);
         var clear_attr = 'ignore-job-clear-on-click';
-        if (pr_matches) {
-            var pr_url = "https://github.com/mozilla-b2g/gaia/pull/" + pr_matches[1];
-            var pr_hyperlink = '<a href="' + pr_url + '" ' + clear_attr + '>' +
-                               pr_matches[1] + '</a>';
-            str = str.replace(pr_matches[1], pr_hyperlink);
-        }
+
+        var bug_matches = str.match(/-- ([0-9]+)|bug.([0-9]+)/ig);
+        var pr_matches = str.match(/PR#([0-9]+)/ig);
+
+        // Settings
+        var bug_title = 'bugzilla.mozilla.org';
+        var bug_url = '<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=$1" ' +
+            'data-bugid=$1 ' + 'title=' + bug_title + '>$1</a>';
+        var pr_title = 'github.com';
+        var pr_url = '<a href="https://github.com/mozilla-b2g/gaia/pull/$1" ' +
+            'data-prid=$1 ' + 'title=' + pr_title + '>$1</a>';
+
         if (bug_matches) {
-            var bug_match = bug_matches[1] || bug_matches[2] || bug_matches[3];
-            var bug_url = "https://bugzilla.mozilla.org/show_bug.cgi?id=" + bug_match;
-            var bug_hyperlink = '<a href="' + bug_url + '" ' + clear_attr + '>' +
-                                bug_match + '</a>';
-            str = str.replace(bug_match, bug_hyperlink);
+            // Separate passes to preserve prefix
+            str = str.replace(/Bug ([0-9]+)/g, "Bug " + bug_url);
+            str = str.replace(/bug ([0-9]+)/g, "bug " + bug_url);
+            str = str.replace(/-- ([0-9]+)/g, "-- " + bug_url);
         }
+
+        if (pr_matches) {
+            // Separate passes to preserve prefix
+            str = str.replace(/PR#([0-9]+)/g, "PR#" + pr_url);
+            str = str.replace(/pr#([0-9]+)/g, "pr#" + pr_url);
+        }
+
         return str;
     };
 });


### PR DESCRIPTION
This work fixes Bugzilla bug [1133021](https://bugzilla.mozilla.org/show_bug.cgi?id=1133021).

This linkifies all bugs and pull requests in a given commit message that match the following prefixes:

* "Bug ", "bug ", "-- "
* "PR#" "pr#"

Here's the before with an example test case (note also the commit-title populating the bug/pr links):

![commitlinkscurrent](https://cloud.githubusercontent.com/assets/3660661/6737868/ce23efa2-ce44-11e4-8eb3-d32daeaa60f2.jpg)

Here's the after:

![commitlinksproposed](https://cloud.githubusercontent.com/assets/3660661/6737884/e280880c-ce44-11e4-96e5-d16a208b9cf8.jpg)

I've tested a variety of different messages (no bugs, single bugs/prs, multiple bugs/prs, identical bugs/prs, identically-prefixed bugs/prs, the originally reported bug revision ) and everything seems to be ok.

I tried a bunch of different implementations: loops, a function with passed params, doing the replace in one shot (problematic with "-- " and the $n param in the url vars), specifying the .replace string as a [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter) which also doesn't seem compatible with $n use.

So instead we just check if we have pr or bug match, and do a separate pass for each case. We incur minor cost, but probably no more than if we tested for conditions.

We now inject a generic bmo/github title for each issue type. The overall span retains its own tooltip commit summary on hover. Initially I did it to avoid a bmo/github API to get the "Summary", which was outside the scope of the bug anyway. I think a generic title makes more sense. It tells the user what the link is, and doesn't confuse them with what could be a very similar tooltip to the commit span.

I've left some test values in this initial commit for testing, which I will remove prior to merge. Everything appears to be ok on both Firefox and Chrome. Please beat it up as much as possible and with other commit message sequences :)

Tested on OSX 10.9.5:
FF Release **36.0.1**
Chrome Latest Release **41.0.2272.89** (64-bit)

Adding @wlach for review/branch testing, and @edmorley for visibility.