### PR TITLE
Bug 1082771 - Add a static "Infrastructure" menu that links to existing dashboards

### DIFF
--- a/webapp/app/partials/main/thGlobalTopNavPanel.html
+++ b/webapp/app/partials/main/thGlobalTopNavPanel.html
@@ -19,6 +19,18 @@
                 </span>
             </span>
 
+            <!-- Infra Menu -->
+            <span class="repo-menu dropdown">
+                <button id="infraLabel" title="Infrastructure Status" role="button"
+                        href="#" data-toggle="dropdown" data-target="#"
+                        class="btn btn-view-nav btn-right-navbar nav-repo-btn">Infra
+                    <span class="fa fa-angle-down lightgray"></span>
+                </button>
+                <ul class="dropdown-menu repo-dropdown-menu" role="menu" aria-labelledby="infraLabel"
+                    ng-include="'partials/main/thInfraMenu.html'">
+                </ul>
+            </span>
+
             <!-- Repos Menu -->
             <span ng-controller="RepositoryMenuCtrl" >
                 <!--<span class="repo-menu dropdown keep-open">-->

--- a/webapp/app/partials/main/thGlobalTopNavPanel.html
+++ b/webapp/app/partials/main/thGlobalTopNavPanel.html
@@ -5,6 +5,7 @@
     <div class="navbar-collapse collapse th-global-navbar">
         <!-- nav begin -->
         <span class="navbar-right">
+            <!-- Sheriffing Button -->
             <span ng-show="user.is_staff">
                 <span class="btn btn-view-nav btn-right-navbar nav-menu-btn"
                       ng-class="{'active': (isSheriffPanelShowing)}"
@@ -18,24 +19,21 @@
                 </span>
             </span>
 
+            <!-- Repos Menu -->
             <span ng-controller="RepositoryMenuCtrl" >
                 <!--<span class="repo-menu dropdown keep-open">-->
                 <span th-repo-dropdown-container class="repo-menu dropdown">
-                    <!-- Repo Button -->
                     <button id="repoLabel" title="Watch a repo" role="button"
                             href="#" data-toggle="dropdown" data-target="#"
                             class="btn btn-view-nav btn-right-navbar nav-repo-btn">Repos
                         <span class="fa fa-angle-down lightgray"></span>
                     </button>
-
-                    <!-- Repo Menu -->
                     <ul class="dropdown-menu repo-dropdown-menu" role="menu" aria-labelledby="repoLabel">
                         <span ng-repeat="(group_order, group) in groupedRepos()">
                             <li role="presentation" class="divider" ng-hide="$first"></li>
                             <li role="presentation" class="dropdown-header">{{::group.name}}</li>
                             <th-repo-menu-item ng-repeat="repo in group.repos | orderBy : 'name'" ></th-repo-menu-item>
                         </span>
-
                     </ul>
                 </span>
             </span>

--- a/webapp/app/partials/main/thGlobalTopNavPanel.html
+++ b/webapp/app/partials/main/thGlobalTopNavPanel.html
@@ -38,46 +38,46 @@
 
                     </ul>
                 </span>
-
-                <!-- Global Filter Button -->
-                <span class="btn btn-view-nav btn-right-navbar nav-menu-btn"
-                      title="Global job filters"
-                      ng-class="{'active': (isFilterPanelShowing)}"
-                      ng-click="setFilterPanelShowing(!isFilterPanelShowing)"
-                      tabindex="0"
-                      role="button"><span>Filters</span>
-                    <i class="fa fa-angle-down lightgray"
-                       ng-hide="isFilterPanelShowing"></i>
-                    <i class="fa fa-angle-up lightgray"
-                       ng-show="isFilterPanelShowing"></i>
-                </span>
-
-                <!-- Help Button -->
-                <a class="btn btn-view-nav nav-help-btn"
-                   title="Treeherder help" href="help.html" target="_blank">
-                    <span class="fa fa-question-circle lightgray nav-help-icon"></span></a>
-
-                <!-- Settings Button - currently suppressed -->
-                <span ng-show="false"
-                      class="btn btn-view-nav btn-right-navbar nav-menu-btn"
-                      ng-class="{'active': (isSettingsPanelShowing)}"
-                      ng-click="setSettingsPanelShowing(!isSettingsPanelShowing)"
-                      tabindex="0"
-                      role="button"><span>Settings</span>
-                    <i class="fa fa-angle-down lightgray"
-                       ng-hide="isSettingsPanelShowing"></i>
-                    <i class="fa fa-angle-up lightgray"
-                       ng-show="isSettingsPanelShowing"></i>
-                </span>
-
-                <!-- User Field if logged in -->
-                <span class="btn btn-right-navbar th-username"
-                      ng-if="user.email">
-                    {{user.email}}</span>
-
-                <!-- Login/Register Button -->
-                <persona-buttons></persona-buttons>
             </span>
+
+            <!-- Global Filter Button -->
+            <span class="btn btn-view-nav btn-right-navbar nav-menu-btn"
+                  title="Global job filters"
+                  ng-class="{'active': (isFilterPanelShowing)}"
+                  ng-click="setFilterPanelShowing(!isFilterPanelShowing)"
+                  tabindex="0"
+                  role="button"><span>Filters</span>
+                <i class="fa fa-angle-down lightgray"
+                   ng-hide="isFilterPanelShowing"></i>
+                <i class="fa fa-angle-up lightgray"
+                   ng-show="isFilterPanelShowing"></i>
+            </span>
+
+            <!-- Help Button -->
+            <a class="btn btn-view-nav nav-help-btn"
+               title="Treeherder help" href="help.html" target="_blank">
+                <span class="fa fa-question-circle lightgray nav-help-icon"></span></a>
+
+            <!-- Settings Button - currently suppressed -->
+            <span ng-show="false"
+                  class="btn btn-view-nav btn-right-navbar nav-menu-btn"
+                  ng-class="{'active': (isSettingsPanelShowing)}"
+                  ng-click="setSettingsPanelShowing(!isSettingsPanelShowing)"
+                  tabindex="0"
+                  role="button"><span>Settings</span>
+                <i class="fa fa-angle-down lightgray"
+                   ng-hide="isSettingsPanelShowing"></i>
+                <i class="fa fa-angle-up lightgray"
+                   ng-show="isSettingsPanelShowing"></i>
+            </span>
+
+            <!-- User Field if logged in -->
+            <span class="btn btn-right-navbar th-username"
+                  ng-if="user.email">
+                {{user.email}}</span>
+
+            <!-- Login/Register Button -->
+            <persona-buttons></persona-buttons>
         </span>
 
     </div>

--- a/webapp/app/partials/main/thInfraMenu.html
+++ b/webapp/app/partials/main/thInfraMenu.html
@@ -1,0 +1,44 @@
+<li>
+    <a href="https://secure.pub.build.mozilla.org/buildapi/pending"
+       target="_blank">BuildAPI: Pending</a>
+</li>
+<li>
+    <a href="https://secure.pub.build.mozilla.org/buildapi/running"
+       target="_blank">BuildAPI: Running</a>
+</li>
+<li>
+    <a href="http://builddata.pub.build.mozilla.org/reports/pending/pending.html"
+       target="_blank">Graphs: Pending</a>
+</li>
+<li>
+    <a href="http://builddata.pub.build.mozilla.org/reports/pending/running.html"
+       target="_blank">Graphs: Running</a>
+</li>
+<li>
+    <a href="https://www.hostedgraphite.com/da5c920d/grafana/#/dashboard/temp/5d509a54d0b496d184023bab35c17d0f41e6c607"
+       target="_blank">EC2 Dashboard</a>
+</li>
+<li>
+    <a href="https://secure.pub.build.mozilla.org/builddata/reports/slave_health/"
+       target="_blank">Slave Health</a>
+</li>
+<li>
+    <a href="https://api.pub.build.mozilla.org/clobberer/"
+       target="_blank">Clobberer</a>
+</li>
+<li>
+    <a href="https://treestatus.mozilla.org/"
+       target="_blank">TreeStatus</a>
+</li>
+<li>
+    <a href="https://nigelbabu.github.io/hgstats/"
+       target="_blank">HgStats</a>
+</li>
+<li>
+    <a href="http://status.taskcluster.net/"
+       target="_blank">TaskCluster</a>
+</li>
+<li>
+    <a href="http://futurama.theautomatedtester.co.uk"
+       target="_blank">Futurama</a>
+</li>


### PR DESCRIPTION
Suggestions welcome for additions/removals/re-ordering of links.
@tojonmz I'm sure you'll have some styling ideas for this - I don't know whether it's best to land as is - and then let you do your (awesome) thing - or iterate here? I don't mind either way - though with the PTO might be hard to get this landed before TBPL end of life if we aim for styling perfection here :-)

![screenshot](https://cloud.githubusercontent.com/assets/501702/6757775/846463fa-cf2b-11e4-8725-ffb72594598e.png)