### PR TITLE
Bug 1082771 - Add headings/separators to the infra menu

### DIFF
--- a/webapp/app/partials/main/thInfraMenu.html
+++ b/webapp/app/partials/main/thInfraMenu.html
@@ -1,3 +1,4 @@
+<li role="presentation" class="dropdown-header">Buildbot</li>
 <li>
     <a href="https://secure.pub.build.mozilla.org/buildapi/pending"
        target="_blank">BuildAPI: Pending</a>
@@ -26,6 +27,8 @@
     <a href="https://api.pub.build.mozilla.org/clobberer/"
        target="_blank">Clobberer</a>
 </li>
+<li role="presentation" class="divider"></li>
+<li role="presentation" class="dropdown-header">Other</li>
 <li>
     <a href="https://treestatus.mozilla.org/"
        target="_blank">TreeStatus</a>


### PR DESCRIPTION
I managed to accidentally remove these from the original PR before landing.