### PR TITLE
Bug 1112652 -  Communicate the resultset date link is a permalink/url

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -376,6 +376,12 @@ th-watched-repo {
 
 }
 
+.result-set-superscript {
+    vertical-align: super;
+    font-size: 0.625em;
+    margin-left: -0.2em;
+}
+
 .result-set {
     padding-bottom: 0px;
     margin-left: 0;
@@ -397,7 +403,7 @@ th-watched-repo {
 }
 
 .result-set-title-left {
-    flex: 0 0 23.5em;
+    flex: 0 0 24.2em;
     overflow: hidden;
     text-overflow: ellipsis;
     padding-right: 10px;

--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -14,8 +14,9 @@
           <span class="btn btn-default btn-sm glyphicon glyphicon-download" ng-show="isLoadingJobs"></span>
           <span>
             <a href="{{::revisionResultsetFilterUrl}}"
-               title="open this resultset"
-               ignore-job-clear-on-click>{{::resultsetDateStr}}</a> - </span>
+               title="View only this resultset"
+               ignore-job-clear-on-click>{{::resultsetDateStr}}
+              <span class="fa fa-external-link result-set-superscript"></span></a> - </span>
           <th-author author="{{::resultset.author}}"></th-author>
         </span>
         <span class="revision-text">{{::resultset.revision}}</span>


### PR DESCRIPTION
This tweak hopefully addresses the bulk of Bugzilla bug [1112652](https://bugzilla.mozilla.org/show_bug.cgi?id=1112652), or enough we address the use problem of discoverability of a sharable url, for a single resultset.

Here's the before:

![screen shot 2015-03-21 at 2 08 54 pm](https://cloud.githubusercontent.com/assets/3660661/6766230/3b28bf52-cfd4-11e4-8c9c-4d6d62c88d64.png)

Here's the after:

![screen shot 2015-03-21 at 12 53 30 pm](https://cloud.githubusercontent.com/assets/3660661/6766232/42fcae0a-cfd4-11e4-8457-d6334080d610.png)

I went through a variety of other wordings, some which I've included in case folks like anything better:

* "View only this resultset and url"
* "View only this resultset url"
* "View this resultset url"

Feel free to let me know if prefer any of those, or propose others, and I'll adjust :)

Tested on OSX 10.9.5:
FF Release **36.0.1**
Chrome Latest Release **41.0.2272.89** (64-bit)

Adding @wlach for review and @armenzg and @KWierso for visibility.