### PR TITLE
Bug 1135862 - Allow classification dropdown save

### DIFF
--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -48,23 +48,33 @@ treeherder.controller('MainCtrl', [
             }
         };
 
-        // Disable single key shortcuts in specified shortcut events
+        // Single key shortcuts to allow in ui events (usually inputs)
+        var mousetrapExclusions = [
+            'i',     // Toggle display in-progress jobs (pending/running)
+            'j',     // Select next unclassified failure
+            'n',     // Select next unclassified failure
+            'k',     // Select previous unclassified failure
+            'p',     // Select previous unclassified failure
+            'r',     // Retrigger selected job
+            'space', // Pin selected job to pinboard
+            'u',     // Display only unclassified failures
+            'b',     // Pin selected job and add related bug
+            'c',     // Pin selected job and add classification
+            'f',     // Enter a custom job or platform filter
+            'left',  // Select previous job
+            'right'  // Select next job
+        ];
+
+        // Make the single key exclusions available
         $scope.allowKeys = function() {
-            Mousetrap.unbind([
-                'i',     // Toggle display in-progress jobs (pending/running)
-                'j',     // Select next unclassified failure
-                'n',     // Select next unclassified failure
-                'k',     // Select previous unclassified failure
-                'p',     // Select previous unclassified failure
-                'r',     // Retrigger selected job
-                'space', // Pin selected job to pinboard
-                'u',     // Display only unclassified failures
-                'b',     // Pin selected job and add related bug
-                'c',     // Pin selected job and add classification
-                'f',     // Enter a custom job or platform filter
-                'left',  // Select previous job
-                'right'  // Select next job
-            ]);
+            Mousetrap.unbind(mousetrapExclusions);
+        };
+
+        /* Unique settings for the classification dropdown to allow 'c'
+         * and 'b' and invoke those shortcuts while focused. Since we
+         * conveniently don't have those classification Names at present */
+        $scope.allowKeysClassificationDropdown = function() {
+            Mousetrap.unbind(_.without(mousetrapExclusions, 'c', 'b'));
         };
 
         // Process shortcut events

--- a/webapp/app/partials/main/thPinboardPanel.html
+++ b/webapp/app/partials/main/thPinboardPanel.html
@@ -42,7 +42,8 @@
   <div class="pinboard-label">classification</div>
   <div id="pinboard-classification-content" class="content">
     <form ng-submit="completeClassification()" class="form">
-      <select ng-model="classification.failure_classification_id"
+      <select class="mousetrap" ng-click="allowKeysClassificationDropdown()"
+              ng-model="classification.failure_classification_id"
               ng-options="item.id as item.name for item in classificationTypes.classificationOptions">
       </select>
       <!-- Classification comment -->


### PR DESCRIPTION
This work fixes Bugzilla bug [1135862](https://bugzilla.mozilla.org/show_bug.cgi?id=1135862).

More LHF, this basically allows the user to '**ctrl**+**enter**' to save a classification if the classification dropdown is focused.

Here's the new workflow showing the save now getting triggered in that state:

![saveclassificationdropdownfocusproposed](https://cloud.githubusercontent.com/assets/3660661/6785055/b843f11a-d159-11e4-92bd-42b0cfd242bd.jpg)

I also tried to support shortcuts '**c**' and '**b**' (add comment, add related bug) when the classification dropdown is focused, so the user can get at that functionality. There is some peculiarity where it only works on first invocation:

* pin a job
* select a classification type
* '**c**' and enter a comment (works)
* select another classification type
* '**c**' to edit the comment again (doesn't work)

I must be missing something obvious.

All other integration testing, other shortcut interaction, pinboard clearing, seems fine. I changed the code slightly avoid replicating the `allowKeys()` key list.

Tested on OSX 10.9.5:
FF Release **36.0.4**
Chrome Latest Release 41.0.2272.101 (64-bit)

Adding @camd for review.