### PR TITLE
Bug 1146970 - Clean up bluespace in the Failure Summary

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -762,7 +762,6 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
 }
 
 ul.failure-summary-list li {
-    padding-left: 2px;
     font-size: 11px;
     background: #ccfaff;
 }
@@ -772,16 +771,16 @@ ul.failure-summary-list li .btn-xs {
 }
 
 .failure-summary-line-empty {
-    padding: 2px 2px 0px;
+    padding: 2px 4px 0px;
     background: #ffffff;
 }
 
 .failure-summary-line {
-    padding: 2px 2px 0px;
+    padding: 2px 4px 0px;
 }
 
 .failure-summary-bugs {
-    padding: 0px 0px 0px 14px;
+    padding: 0px 0px 0px 18px;
 }
 
 /* We override global anchor color to replicate TBPL here */
@@ -798,7 +797,7 @@ ul.failure-summary-list li .btn-xs {
 
 /* We override global anchor color to replicate TBPL here */
 .show-hide-more {
-    padding: 0px 0px 0px 35px;
+    padding: 0px 0px 0px 37px;
     color: #0000ee;
 }
 


### PR DESCRIPTION
This fixes Bugzilla bug [1146970](https://bugzilla.mozilla.org/show_bug.cgi?id=1146970).

More LHF, I've been staring at this for months :) This removes the annoying blue space created by the `ul` when no failures or similar conditions exist, and no bugs are posted.

Here's the before:

![failuresummarycurrent](https://cloud.githubusercontent.com/assets/3660661/6807021/59cabadc-d222-11e4-9b83-071dbfa02903.jpg)

Here's the after:

![failuresummaryproposed](https://cloud.githubusercontent.com/assets/3660661/6807218/86460052-d223-11e4-9b77-58d89aa22af7.jpg)

I took care to compensate for the change in all the other `li`s, and did a lot of blink testing to make sure the layout elements are identical to what they were before:

![failuresummarywithfailure](https://cloud.githubusercontent.com/assets/3660661/6807093/da7edbfe-d222-11e4-98e5-17f4b7b5469f.jpg)

Everything seems fine and the other Annotation and Similar Jobs panels appear unaffected, as one would expect.

Tested on OSX 10.9.5:
FF Release **36.0.4**
Chrome Latest Release **41.0.2272.104** (64-bit)

Adding @wlach for review.