### PR TITLE
Bug 1147389 - Purge some redundant padding in Failure Summary css

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -755,7 +755,6 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
 }
 
 #bottom-center-panel ul.failure-summary-list{
-    padding-left: 0;
     overflow: auto;
     width: 100%;
     margin-bottom: 0;


### PR DESCRIPTION
World's shortest PR :), see Bugzilla bug [1147389](https://bugzilla.mozilla.org/show_bug.cgi?id=1147389) for details.

There wasn't really any other current work I could logically tie this to, so opened it separately.

Everything seems fine on both FF and Chrome.

Tested on OSX 10.9.5:
FF Release **36.0.4**
Chrome Latest Release **41.0.2272.104** (64-bit)

Adding @wlach for review.