### PR TITLE
Bug 1131830 - Prevent accidental logouts with a dropdown logout menu

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -105,6 +105,11 @@ th-watched-repo {
     margin-right: 4px;
 }
 
+/* Override bootstrap for flush right navbar menus */
+.navbar-collapse {
+    padding-right: 0;
+}
+
 .navbar .repo-menu-form {
     padding: 5px 10px 0;
     overflow-y: scroll;
@@ -131,8 +136,24 @@ th-watched-repo {
     font-size: 18px;
 }
 
+.nav-user-icon {
+    display: inline-block;
+    margin-right: 4px;
+    padding: 3px 4px;
+    vertical-align: text-bottom;
+    border-radius: 1px;
+    background: linear-gradient(#44adf3, #287cc2);
+}
+
+.nav-user-icon span:first-child {
+    margin: 0 auto;
+    font-size: 12px;
+    color: #fff;
+}
+
 .nav-login-btn {
     padding-left: 22px;
+    padding-right: 27px;
 }
 
 .watched-repo-main-btn {

--- a/webapp/app/partials/main/persona_buttons.html
+++ b/webapp/app/partials/main/persona_buttons.html
@@ -1,7 +1,17 @@
-<a class="btn btn-view-nav btn-right-navbar nav-login-btn"
-   ng-if="user.loggedin"
-   ng-click="logout()">
-   <span>Logout</span></a>
+<span class="dropdown"
+      ng-if="user.loggedin">
+  <button id="logoutLabel" title="Logged in as: {{user.email}}" role="button"
+          href="#" data-toggle="dropdown" data-target="#"
+          class="btn btn-view-nav btn-right-navbar nav-repo-btn">
+    <div class="nav-user-icon">
+      <span class="fa fa-user pull-left"></span>
+    </div>
+    <span class="fa fa-angle-down lightgray"></span>
+  </button>
+  <ul class="dropdown-menu" role="menu" aria-labelledby="logoutLabel"
+      ng-include="'partials/main/thLogoutMenu.html'">
+  </ul>
+</span>
 
 <a class="btn btn-view-nav btn-right-navbar nav-login-btn"
    title="Log in for additional functionality"

--- a/webapp/app/partials/main/thGlobalTopNavPanel.html
+++ b/webapp/app/partials/main/thGlobalTopNavPanel.html
@@ -21,7 +21,7 @@
 
             <!-- Infra Menu -->
             <span class="repo-menu dropdown">
-                <button id="infraLabel" title="Infrastructure Status" role="button"
+                <button id="infraLabel" title="Infrastructure status" role="button"
                         href="#" data-toggle="dropdown" data-target="#"
                         class="btn btn-view-nav btn-right-navbar nav-repo-btn">Infra
                     <span class="fa fa-angle-down lightgray"></span>
@@ -80,11 +80,6 @@
                 <i class="fa fa-angle-up lightgray"
                    ng-show="isSettingsPanelShowing"></i>
             </span>
-
-            <!-- User Field if logged in -->
-            <span class="btn btn-right-navbar th-username"
-                  ng-if="user.email">
-                {{user.email}}</span>
 
             <!-- Login/Register Button -->
             <persona-buttons></persona-buttons>

--- a/webapp/app/partials/main/thLogoutMenu.html
+++ b/webapp/app/partials/main/thLogoutMenu.html
@@ -1,0 +1,3 @@
+<li>
+    <a ng-click="logout()">Logout</a>
+</li>


### PR DESCRIPTION
This work fixes Bugzilla bug [1131830](https://bugzilla.mozilla.org/show_bug.cgi?id=1131830).

Per the bug thread with @edmorley and @KWierso, we now prevent the user from accidentally logging themselves out when working quickly near the Logout button by creating a nested menu. While there I added a bit of polish to cue the user they are logged in with Persona and also not occupy so much space. The same information is available to the user as before.

This Persona icon approach will also work nicely with an adjacent 'sheriff on duty' icon (bug [1144589](https://bug1144589.bugzilla.mozilla.org/attachment.cgi?id=8582586)), if we fix that issue also.

Here's the current appearance (logged in):

![logoutcurrent](https://cloud.githubusercontent.com/assets/3660661/6877355/c0027494-d4a6-11e4-859f-6f9b8c32aebb.jpg)

Here's proposed (logged in):

![logoutproposed](https://cloud.githubusercontent.com/assets/3660661/6877363/ce8d29aa-d4a6-11e4-8b1e-b59b83e981b8.jpg)

And on hover:

![logoutproposedtitle](https://cloud.githubusercontent.com/assets/3660661/6877413/50a9801e-d4a7-11e4-82e9-aae83c403e1d.jpg)

And posted menu:

![logoutproposedmenu](https://cloud.githubusercontent.com/assets/3660661/6877419/57a5e8f8-d4a7-11e4-9c72-7cb4118806bb.jpg)

All the dropdown menus are a bit big, that will be addressed as part of bug [1145837](https://bugzilla.mozilla.org/show_bug.cgi?id=1145837).

I intentionally added an 'Actions' divider in the menu even though we have one entry at present, given we will likely have a 'Settings' divider below it, for example for `.is_staff` users who wish to set themselves as the on-duty sheriff, or other personalized user settings.

Everything seems to be behaving fine on both browsers, and with basic integration testing.

Tested on OSX 10.9.5:
FF Release **36.0.4**
Chrome Latest Release **41.0.2272.104** (64-bit)

Adding @wlach for review