### PR TITLE
Bug 1146651 - Remove legacy per-resultset filter code

### DIFF
--- a/webapp/app/js/controllers/jobs.js
+++ b/webapp/app/js/controllers/jobs.js
@@ -167,8 +167,7 @@ treeherder.controller('ResultSetCtrl', [
         };
 
         /**
-         * Pin all jobs that pass the GLOBAL filters.  Ignores toggling at
-         * the result set level.
+         * Pin all jobs that pass the global filters.
          *
          * If optional resultsetId is passed in, then only pin jobs from that
          * resultset.
@@ -195,30 +194,7 @@ treeherder.controller('ResultSetCtrl', [
         };
 
         /**
-         * When the user clicks one of the resultStates on the resultset line,
-         * then toggle what is showing for just this resultset.
-         *
-         * @param resultStatus - Which resultStatus to toggle.
-         */
-        $scope.toggleResultSetResultStatusFilter = function(resultStatus) {
-            var idx = $scope.resultStatusFilters.indexOf(resultStatus);
-            if (idx < 0) {
-                $scope.resultStatusFilters.push(resultStatus);
-            } else {
-                $scope.resultStatusFilters.splice(idx, 1);
-            }
-
-            $rootScope.$emit(
-                thEvents.resultSetFilterChanged, $scope.resultset
-                );
-
-            $log.debug("toggled: ", resultStatus);
-            $log.debug("resultStatusFilters", $scope.resultStatusFilters);
-        };
-
-        /**
-         * Whether or not a job should be shown based on the global and local
-         * filters.
+         * Whether or not a job should be shown based on the global filters.
          * @param job
          */
         $scope.showJob = function(job) {

--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -833,15 +833,6 @@ treeherder.directive('thCloneJobs', [
             });
 
         $rootScope.$on(
-            thEvents.resultSetFilterChanged, function(ev, rs){
-                if(rs.id === scope.resultset.id){
-                    _.bind(
-                        filterJobs, scope, element, scope.resultStatusFilters
-                        )();
-                }
-            });
-
-        $rootScope.$on(
             thEvents.jobsLoaded, function(ev, platformData){
                 _.bind(updateJobs, scope, platformData)();
             });

--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -206,9 +206,6 @@ treeherder.provider('thEvents', function() {
             // fired when a global filter has changed
             globalFilterChanged: "status-filter-changed-EVT",
 
-            // fired when filtering on a specific resultset has changed
-            resultSetFilterChanged: "resultset-filter-changed-EVT",
-
             toggleRevisions: "toggle-revisions-EVT",
 
             toggleAllRevisions: "toggle-all-revisions-EVT",


### PR DESCRIPTION
This fixes Bugzilla bug [1146651](https://bugzilla.mozilla.org/show_bug.cgi?id=1146651)

This removes references to per-resultset filters and related code. `resultSetFilterChanged` appeared it could be retired also. `resultStatusFilters` is still used for global filters.

Everything seems fine running locally, adding and removing Global filters, adding and removing custom text filters via 'Filter Platforms & Jobs' on both browsers.

I also tweaked adjacent comments referencing local filters.

I briefly searched treeherder-service out of interest, I didn't see anything obvious there that corresponded or would need removal.

Tested on OSX 10.9.5:
FF Release **36.0.4**
Chrome Latest Release **41.0.2272.104** (64-bit)

Adding @camd for review.