### PR TITLE
Bug 1149348 - Maintain tier-2 job groupings

### DIFF
--- a/webapp/app/js/models/resultsets_store.js
+++ b/webapp/app/js/models/resultsets_store.js
@@ -896,7 +896,10 @@ treeherder.factory('ThResultSetStore', [
         var name = job.job_group_name;
         var symbol = job.job_group_symbol;
         if (job.tier && job.tier !== 1) {
-            var tierLabel = "Tier-" + job.tier;
+            if (symbol === "?") {
+                symbol = "";
+            }
+            var tierLabel = symbol + "[Tier-" + job.tier + "]";
             name = tierLabel;
             symbol = tierLabel;
         }


### PR DESCRIPTION
Fixes [Bug 1149348](https://bugzilla.mozilla.org/show_bug.cgi?id=1149348)

This would improve the categorization of Tier-2 jobs by visually retaining their job groupings, but still distinguishing them as Tier-2:

![screenshot 2015-03-30 16 17 55](https://cloud.githubusercontent.com/assets/419924/6909375/4708f170-d6fa-11e4-92e8-0df92ea49951.png)

