### PR TITLE
Bug 1149687 - Make Talos results single column

### DIFF
--- a/webapp/app/plugins/talos/main.html
+++ b/webapp/app/plugins/talos/main.html
@@ -3,25 +3,24 @@
   <ul>
     <li>Datazilla:
       <ul>
-        <li ng-repeat="(k,v) in line.value.datazilla"><a href="{{::v.url}}" target="_blank">{{::k}}</a>
+        <li ng-repeat="(k,v) in line.value.datazilla">
+          <a href="{{::v.url}}" target="_blank">{{::k}}</a>
         </li>
       </ul>
     </li>
 
     <li>Graphserver:
       <ul>
-        <li ng-repeat="(k,v) in line.value.graphserver">{{::k}}:<a href="{{::v.url}}"
-                                                                 target="_blank">{{::v.result}}</a>
+        <li ng-repeat="(k,v) in line.value.graphserver">{{::k}}:
+          <a href="{{::v.url}}" target="_blank">{{::v.result}}</a>
         </li>
       </ul>
     </li>
+
+    <li ng-repeat="line in job_details"
+        ng-if="line.content_type == 'link' && line.value.substr(-8) == '.sps.zip'">
+      <a href="http://people.mozilla.com/~bgirard/cleopatra/?zippedProfile={{line.url}}"
+         target="_blank">Open {{line.value}} in Cleopatra</a>
+    </li>
   </ul>
 </span>
-
-<ul>
-  <li ng-repeat="line in job_details"
-      ng-if="line.content_type == 'link' && line.value.substr(-8) == '.sps.zip'">
-    <a href="http://people.mozilla.com/~bgirard/cleopatra/?zippedProfile={{line.url}}"
-       target="_blank">Open {{line.value}} in Cleopatra</a>
-  </li>
-</ul>


### PR DESCRIPTION
This fixes Bugzilla bug [1149687](https://bugzilla.mozilla.org/show_bug.cgi?id=1149687).

Like Daniel indicated in the bug, the bulleted lists were getting spread out (recent regression?), and we want a single column for Talos results, so this change protects the last ul from being styled as a flex container.

Here's before:

![current](https://cloud.githubusercontent.com/assets/3660661/6929612/2c43225e-d7ca-11e4-949c-21599845347b.jpg)

Here's after:

![proposed](https://cloud.githubusercontent.com/assets/3660661/6929615/32371f08-d7ca-11e4-9b53-1673c9e98151.jpg)

Tested on OSX 10.9.5:
FF Release **36.0.4**
Chrome Latest Release **41.0.2272.104** (64-bit)

Adding @wlach for review.