### PR TITLE
Bug 1149576 -  Adjust the max-pin count error message for clarity

### DIFF
--- a/webapp/app/js/controllers/filters.js
+++ b/webapp/app/js/controllers/filters.js
@@ -161,7 +161,8 @@ treeherder.controller('FilterPanelCtrl', [
             }
             var shownJobs = ThResultSetStore.getAllShownJobs(
                 $rootScope.repoName,
-                thPinboard.spaceRemaining()
+                thPinboard.spaceRemaining(),
+                thPinboard.maxNumPinned
             );
             thPinboard.pinJobs(shownJobs);
 

--- a/webapp/app/js/controllers/jobs.js
+++ b/webapp/app/js/controllers/jobs.js
@@ -182,6 +182,7 @@ treeherder.controller('ResultSetCtrl', [
             var shownJobs = ThResultSetStore.getAllShownJobs(
                 $rootScope.repoName,
                 thPinboard.spaceRemaining(),
+                thPinboard.maxNumPinned,
                 $scope.resultset.id,
                 $scope.resultStatusFilters
             );

--- a/webapp/app/js/models/resultsets_store.js
+++ b/webapp/app/js/models/resultsets_store.js
@@ -226,7 +226,8 @@ treeherder.factory('ThResultSetStore', [
         }
     };
 
-    var getAllShownJobs = function(repoName, maxSize, resultsetId, resultStatusFilters) {
+    var getAllShownJobs = function(repoName, spaceRemaining, maxSize, resultsetId,
+                                   resultStatusFilters) {
         var shownJobs = [];
 
         var addIfShown = function(jMap) {
@@ -236,10 +237,9 @@ treeherder.factory('ThResultSetStore', [
             if (jMap.job_obj.visible) {
                 shownJobs.push(jMap.job_obj);
             }
-            if (_.size(shownJobs) === maxSize) {
-                thNotify.send("Max size reached.  Using the first " + maxSize,
-                              "danger",
-                              true);
+            if (_.size(shownJobs) === spaceRemaining) {
+                thNotify.send("Max pinboard size of " + maxSize + " reached.",
+                              "danger", true);
                 return true;
             }
             return false;


### PR DESCRIPTION
This fixes Bugzilla bug [1149576](https://bugzilla.mozilla.org/show_bug.cgi?id=1149576).

This adjusts the max pin count message, so when the user hits the limit on a re-pin, we no longer tell them about how many we added or not. Example workflow:

* pin All
* manually un-pin 1 job
* pin All again

Here's the current appearance:

![current](https://cloud.githubusercontent.com/assets/3660661/6946891/52e00c4a-d871-11e4-92f8-179ff91b17f3.jpg)

Here's the proposed:

![proposed](https://cloud.githubusercontent.com/assets/3660661/6946897/5b13193e-d871-11e4-8c35-ad6696d77fb4.jpg)

I considered injecting thPinboard into the various job and filter controllers, but instead decided to pass the maxSize as a new param, and rename the old max size as the `spaceRemaining` param, since that is what it is, upstream.

I thought this might be more economical than more injection. Everything seems fine in the Resultset pin-all, and the Filter Panel pin-all workflows.

`getAllShownJobs` seems to be only used with `pinAllShownJobs` so I am assuming the referencing "pinboard size" in the message will be fine for now.

Tested on OSX 10.9.5:
FF Release **36.0.4**
Chrome Latest Release **41.0.2272.104** (64-bit)

Adding @camd for review.