### PR TITLE
Bug 1150159 - Make retrigger check for login w/non-sticky warning

### DIFF
--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -242,25 +242,28 @@ treeherder.controller('PluginCtrl', [
         };
 
         $scope.retriggerJob = function() {
-            // The logic here is somewhat complicated because we need to support
-            // two use cases the first is the case where we notify a system
-            // other then buildbot that a retrigger has been requested. The
-            // second is when we have the buildapi id and need to send a request
-            // to the self serve api (which does not listen over pulse!).
-            ThJobModel.retrigger($scope.repoName, $scope.job.id).then(function() {
-                // XXX: Remove this after 1134929 is resolved.
-                var requestId = getBuildbotRequestId();
-                if (requestId) {
-                    return thBuildApi.retriggerJob($scope.repoName, requestId);
-                }
-            }).then(function() {
-              thNotify.send("Retrigger success");
-            }).catch(function(e){
-                thNotify.send(
-                    ThModelErrors.format(e, "Unable to send retrigger"),
-                    "danger", true
-                );
-            });
+            if ($scope.user.loggedin) {
+                // The logic here is somewhat complicated because we need to support
+                // two use cases the first is the case where we notify a system
+                // other then buildbot that a retrigger has been requested. The
+                // second is when we have the buildapi id and need to send a request
+                // to the self serve api (which does not listen over pulse!).
+                ThJobModel.retrigger($scope.repoName, $scope.job.id).then(function() {
+                    // XXX: Remove this after 1134929 is resolved.
+                    var requestId = getBuildbotRequestId();
+                    if (requestId) {
+                        return thBuildApi.retriggerJob($scope.repoName, requestId);
+                    }
+                }).then(function() {
+                    thNotify.send("Retrigger success");
+                }).catch(function(e) {
+                    thNotify.send(
+                        ThModelErrors.format(e, "Unable to send retrigger"),
+                                             'danger', true);
+                });
+            } else {
+                thNotify.send("Must be logged in to retrigger a job", 'danger')
+            }
         };
 
         $scope.cancelJob = function() {


### PR DESCRIPTION
This fixes Bugzilla bug [1150159](https://bugzilla.mozilla.org/show_bug.cgi?id=1150159)

This prevents us from going farther down the code path to thModelErrors(?) which produces a persistent error message, and instead we test for `user.loggedin` on retrigger. This addresses the UX issue raised on IRC, in which James logged in, but the dialogue annoyingly remained up even after he had logged in.

I figured we'd just present a normal non-sticky which will disappear in 5000ms. By the time the user has started the login process, it will be gone.

Here's the before:

![currentsticky](https://cloud.githubusercontent.com/assets/3660661/6974319/b3520f94-d95f-11e4-8ffe-da356aafe751.jpg)

Here's the proposed (non sticky launched):

![proposednotsticky](https://cloud.githubusercontent.com/assets/3660661/6974328/bc693198-d95f-11e4-80a6-59fa631d2da8.jpg)

There is a whole lot of interesting stuff that went on in the past several month to handle LDAP/HTTP auth stuff which I don't profess to grok, but I've included it here for reference:

* [Bug 1136738](https://bugzilla.mozilla.org/show_bug.cgi?id=1136738) - [pull](https://github.com/mozilla/treeherder-ui/pull/387/files)

Everything seems fine with the scope fix here though. Interactive and keyboard shortcut retriggers seem fine in the failure case when not logged in, on both browsers. I didn't put the the same test upstream in controllers/main at the shortcut invocation, but I can replicate it there if desired.

Tested on OSX 10.9.5:
FF Release **36.0.4**
Chrome Latest Release **41.0.2272.104** (64-bit)

Adding @edmorley for review and @jgraham for visibility.