### PR TITLE
Fix ``job`` field value for Task Cluster jobs and allow filtering

### DIFF
--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -9,12 +9,14 @@ treeherder.directive('thCloneJobs', [
     '$rootScope', '$http', 'ThLog', 'thUrl', 'thCloneHtml',
     'thServiceDomain', 'thResultStatusInfo', 'thEvents', 'thAggregateIds',
     'thJobFilters', 'thResultStatusObject', 'ThResultSetStore',
-    'ThJobModel', 'linkifyBugsFilter', 'thResultStatus', 'thPlatformNameMap',
+    'ThJobModel', 'linkifyBugsFilter', 'thResultStatus', 'thPlatformName',
+    'thJobSearchStr',
     function(
         $rootScope, $http, ThLog, thUrl, thCloneHtml,
         thServiceDomain, thResultStatusInfo, thEvents, thAggregateIds,
         thJobFilters, thResultStatusObject, ThResultSetStore,
-        ThJobModel, linkifyBugsFilter, thResultStatus, thPlatformNameMap){
+        ThJobModel, linkifyBugsFilter, thResultStatus, thPlatformName,
+        thJobSearchStr){
 
     var $log = new ThLog("thCloneJobs");
 
@@ -97,11 +99,11 @@ treeherder.directive('thCloneJobs', [
         if (direction === 'next') {
             getIndex = function(idx, jobs) {
                 return idx+1 > _.size(jobs)-1 ? 0: idx+1;
-            }
+            };
         } else if (direction === 'previous') {
             getIndex = function(idx, jobs) {
                 return idx-1 < 0 ? _.size(jobs)-1 : idx-1;
-            }
+            };
         }
 
         jobs = $(".th-view-content .job-btn");
@@ -225,10 +227,8 @@ treeherder.directive('thCloneJobs', [
             //Set the resultState
             resultState = thResultStatus(job);
 
-            job.searchStr = getPlatformName(job.platform) + ' ' +
-                job.platform_option + ' ' + job.job_group_name + ' ' +
-                job.job_group_symbol + ' ' + job.job_type_name + ' ' +
-                job.job_type_symbol + ' ' + job.ref_data_name;
+            job.searchStr = thJobSearchStr(job) + ' ' + job.ref_data_name  + ' ' +
+                job.signature;
 
             //Make sure that filtering doesn't effect the resultset counts
             //displayed
@@ -535,17 +535,6 @@ treeherder.directive('thCloneJobs', [
         }
     };
 
-    var getPlatformName = function(name){
-
-        var platformName = thPlatformNameMap[name];
-
-        if(platformName === undefined){
-            platformName = name;
-        }
-
-        return platformName;
-    };
-
     var appendPlatformRow = function(tableEl, rowEl, platformName){
 
         var tableRows = $(tableEl).find('tr');
@@ -594,7 +583,7 @@ treeherder.directive('thCloneJobs', [
             var tdEls, rowEl, platformTdEl, jobTdEl,
                 platformKey, platformName, option, tableRows;
 
-            platformName = getPlatformName(value.platformName);
+            platformName = thPlatformName(value.platformName);
 
             platformKey = ThResultSetStore.getPlatformKey(
                 value.platformName, value.platformOption
@@ -911,7 +900,7 @@ treeherder.directive('thCloneJobs', [
                 $(row).empty();
             }
 
-            name = getPlatformName(resultset.platforms[j].name);
+            name = thPlatformName(resultset.platforms[j].name);
             option = resultset.platforms[j].option;
 
             //Add platforms

--- a/webapp/app/js/services/jobfilters.js
+++ b/webapp/app/js/services/jobfilters.js
@@ -26,12 +26,12 @@ treeherder.factory('thJobFilters', [
     'thResultStatusList', 'ThLog', '$rootScope', '$location',
     'thNotify', 'thEvents', 'thFailureResults',
     'thResultStatus', 'thClassificationTypes', 'ThRepositoryModel',
-    'thPlatformNameMap',
+    'thPlatformName',
     function(
         thResultStatusList, ThLog, $rootScope, $location,
         thNotify, thEvents, thFailureResults,
         thResultStatus, thClassificationTypes, ThRepositoryModel,
-        thPlatformNameMap) {
+        thPlatformName) {
 
     var $log = new ThLog("thJobFilters");
 
@@ -476,13 +476,7 @@ treeherder.factory('thJobFilters', [
     var _getJobFieldValue = function(job, field) {
         var result = job[field];
         if (field === 'platform') {
-            var platform = thPlatformNameMap[result];
-            if (!platform) {
-                // if it's not found, then return
-                // the original string
-                platform = result;
-            }
-            result = platform + " " + job.platform_option;
+            result = thPlatformName(result) + " " + job.platform_option;
         }
         return String(result);
     };

--- a/webapp/app/js/services/main.js
+++ b/webapp/app/js/services/main.js
@@ -215,3 +215,24 @@ treeherder.factory('thNotify', [
     return thNotify;
 
 }]);
+
+treeherder.factory('thPlatformName', [
+    'thPlatformNameMap',
+    function(thPlatformNameMap) {
+
+        return function(name) {
+            return thPlatformNameMap[name] || name;
+        };
+}]);
+
+treeherder.factory('thJobSearchStr', [
+    'thPlatformName',
+    function(thPlatformName) {
+
+        return function(job) {
+            return thPlatformName(job.platform) + ' ' +
+                job.platform_option + ' ' + job.job_group_name + ' ' +
+                job.job_group_symbol + ' ' + job.job_type_name + ' ' +
+                job.job_type_symbol;
+        };
+}]);

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -141,12 +141,13 @@
       <ul class="content-spacer">
         <li class="small">
           <label>Job:</label>
-          <a title="Filter jobs like these"
-             href="{{buildbotJobnameHref}}"
+          <a title="Filter by job data strings"
+             href="{{jobSearchStrHref}}"
              prevent-default-on-left-click
-             ng-click="filterByBuildername(buildbotJobname)"
-             copy-value="{{buildbotJobname}}">
-            {{buildbotJobname}}</a>
+             ng-click="filterByJobSearchStr(jobSearchStr)"
+             copy-value="{{jobSearchStr}}">
+            {{jobSearchStr}}</a>
+        </li>
         </li>
         <li class="small">
           <label>Machine name:</label>

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -148,6 +148,14 @@
              copy-value="{{jobSearchStr}}">
             {{jobSearchStr}}</a>
         </li>
+        <li class="small">
+          <label>Filter:</label>
+          <a title="Filter by job signature SHA (more precise)"
+             href="{{jobSearchSignatureHref}}"
+             prevent-default-on-left-click
+             ng-click="filterByJobSearchStr(jobSearchSignature)"
+             copy-value="{{jobSearchSignature}}">
+            signature</a>
         </li>
         <li class="small">
           <label>Machine name:</label>


### PR DESCRIPTION
Please merge this service PR first: https://github.com/mozilla/treeherder-service/pull/447

This fixes:
* ``job`` field in the details panel for Task Cluster jobs will be accurate and not refer to last Buildbot job that was selected.
* You can filter the Task Cluster job just like you can with a Buildbot buildername.
* Adds the job ``signature`` field to the search string to make it more accurate (we were often getting many other jobs when clicking this link to filter on Buildbot jobs).