### PR TITLE
Bug 1150905 - Shorten onscreen time for non-sticky notifications

### DIFF
--- a/webapp/app/js/services/main.js
+++ b/webapp/app/js/services/main.js
@@ -190,7 +190,7 @@ treeherder.factory('thNotify', [
                 sticky: sticky
             });
             if(!sticky){
-                $timeout(thNotify.shift, 5000, true);
+                $timeout(thNotify.shift, 4000, true);
             }
         },
 


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1150905](https://bugzilla.mozilla.org/show_bug.cgi?id=1150905).

This reduces the time that a non-sticky notification appears.

I tried 4000ms, 3500, 3000, 2000, and ultimately went with 4000. It seems to give enough time for a new user who doesn't immediately look at the message to still see it and read it, while helping reduce tiled messages for existing users particularly on retrigger.

No changes visually, but here's a screen grab of a non-sticky message for reference.

![currentnonstickyappearance](https://cloud.githubusercontent.com/assets/3660661/6984750/4726b234-d9fa-11e4-8187-fde6f8c935d4.jpg)

Tested on OSX 10.9.5:
FF Release **36.0.4**
Chrome Latest Release **41.0.2272.104** (64-bit)

Adding @edmorley for review.