### PR TITLE
Bug 1151023 - Nojobs option

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1775,6 +1775,12 @@ fieldset[disabled] .btn-repo.active {
     border-radius: 3px;
 }
 
+.queryparam {
+    display: inline-block;
+    font: 12px Consolas,"Liberation Mono",Menlo,Courier,monospace;
+    color: #555;
+}
+
 .panel-spacing table {
     width: 100%;
 }

--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -546,6 +546,40 @@
         </div>
     </div>
 </div>
+<div class="col-xs-12">
+    <div class="panel panel-default">
+            <div class="panel-heading"><h3>URL Query String Parameters</h3></div>
+            <div class="panel-body panel-spacing">
+                <table id="queryparams">
+                    <tr>
+                      <td><span class="queryparam">nojobs</span></td>
+                      <td>Load result sets and revisions without loading any job results.</td>
+                      <td><span class="queryparam">&nojobs</span></td>
+                    </tr>
+                    <tr>
+                      <td><span class="queryparam">fromchange</span></td>
+                      <td>Specify the earliest revision hash in the resultset range.</td>
+                      <td><span class="queryparam">&fromchange=a12ca6c8b89b</span></td>
+                    </tr>
+                    <tr>
+                      <td><span class="queryparam">tochange</span></td>
+                      <td>Specify the latest revision hash in the resultset range.</td>
+                      <td><span class="queryparam">&tochange=3215c7fc090b</span></td>
+                    </tr>
+                    <tr>
+                      <td><span class="queryparam">startdate</span></td>
+                      <td>Specify the earliest date in the resultset range.</td>
+                      <td><span class="queryparam">&startdate=2015-02-18</span></td>
+                    </tr>
+                    <tr>
+                      <td><span class="queryparam">enddate</span></td>
+                      <td>Specify the latest date in the resultset range.</td>
+                      <td><span class="queryparam">&enddate=2015-02-21</span></td>
+                    </tr>
+                </table>
+            </div>
+    </div>
+</div>
 </div>
 
 <div class="panel-footer help-footer">

--- a/webapp/app/js/models/resultsets_store.js
+++ b/webapp/app/js/models/resultsets_store.js
@@ -52,7 +52,8 @@ treeherder.factory('ThResultSetStore', [
         'tochange',
         'startdate',
         'enddate',
-        'exclusion_profile'
+        'exclusion_profile',
+        'nojobs'
     ];
 
     var registerResultSetPollers = function() {
@@ -829,6 +830,13 @@ treeherder.factory('ThResultSetStore', [
                     appendResultSets(repoName, {results: []});
                 }).
             then(function(){
+                // if ``nojobs`` is on the query string, then don't load jobs.
+                // this allows someone to more quickly load ranges of revisions
+                // when they don't care about the specific jobs and results.
+                if ($location.search().nojobs) {
+                    return;
+                }
+
                 var jobsPromiseList = ThResultSetModel.getResultSetJobs(
                     resultsets,
                     repoName,


### PR DESCRIPTION
This fixes [Bug 1151023](https://bugzilla.mozilla.org/show_bug.cgi?id=1151023)

Add query string param to UI to skip loading jobs.  This makes it much faster when a user just wants to see the revisions in a large number of resultsets.

![screenshot 2015-04-06 08 29 28](https://cloud.githubusercontent.com/assets/419924/7006566/162fc1d6-dc37-11e4-98ff-07e857b3f55f.png)


Help section update:

![screenshot 2015-04-06 09 23 32](https://cloud.githubusercontent.com/assets/419924/7007446/e9e2236e-dc3e-11e4-9551-19f550d2e972.png)
