### PR TITLE
Bug 1087349 - fix platform duplication on guessed platform names

### DIFF
--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -242,16 +242,22 @@ treeherder.provider('thEvents', function() {
 });
 
 treeherder.provider('thAggregateIds', function() {
+
+    var escape = function(id) {
+        return id.replace(/(:|\.|\[|\]|,)/g, "\\$1").replace(/\s+/g, '');
+    };
+
     var getPlatformRowId = function(
-        repoName, resultsetId, platformName, platformOptions){
-        return  repoName +
-                resultsetId +
-                platformName +
-                platformOptions;
+        repoName, resultsetId, platformName, platformOptions) {
+        // ensure there are no invalid characters in the id (like spaces, etc)
+        return escape(repoName +
+                      resultsetId +
+                      platformName +
+                      platformOptions);
     };
 
     var getResultsetTableId = function(repoName, resultsetId, revision){
-        return repoName + resultsetId + revision;
+        return escape(repoName + resultsetId + revision);
     };
 
     this.$get = function() {


### PR DESCRIPTION
This fixes [Bug 1087349](https://bugzilla.mozilla.org/show_bug.cgi?id=1087349)

In these cases, there was a space in the aggregate platformId that was generated.  Then when we went to find that with JQuery to see if we should replace or add a new one, the space caused it to never be found (spaces are invalid).  So we added the new platform row.  

This fix ensures there are never spaces in the aggregate ids we generate.