### PR TITLE
Bug 1153834 - Move job description tooltips to job details panel

### DIFF
--- a/webapp/app/js/directives/clonejobs.js
+++ b/webapp/app/js/directives/clonejobs.js
@@ -56,19 +56,11 @@ treeherder.directive('thCloneJobs', [
         };
 
     var getHoverText = function(job) {
-
-        var jobStatus = thResultStatus(job);
-        var hoverText = job.job_type_name + " - " + jobStatus;
-
+        var hoverText = job.job_type_name + " - " + thResultStatus(job);
         if (job.state === 'completed') {
             var duration = Math.round((job.end_timestamp - job.start_timestamp) / 60);
-            hoverText += " - " + duration + " mins";
+            hoverText += " (" + duration + " mins)";
         }
-
-        if (job.job_type_description !== "fill me") {
-            hoverText += " (" + job.job_type_description + ")";
-        }
-
         return hoverText;
     };
 

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -176,6 +176,8 @@
                  ng-repeat="job_log_url in job_log_urls"
                  title="Open build directory in a new tab"
                  href={{job_log_url.buildUrl}} target="_blank">{{value}}</a>
+              <span ng-switch-when="Job name"
+                 title="{{job.job_type_description}}">{{value}}</span>
               <span ng-switch-default>{{value}}</span>
           </span>
         </li>


### PR DESCRIPTION
Instead of displaying the long job description in the tooltip for every job listed in the main jobs list, instead add it as the title text for the job name in the job details panel. This avoids bloating the DOM with thousands of longer strings.

We no longer check for the placeholder string "fill me", but I don't think this matters, since we shouldn't be using that string in my opinion anyway (vs leaving it blank) and to me it's more consistent to always show a tooltip, rather than have the user wonder where it has gone.