### PR TITLE
Bug 1153361 - Change the default repo to mozilla-inbound

### DIFF
--- a/webapp/app/js/controllers/jobs.js
+++ b/webapp/app/js/controllers/jobs.js
@@ -22,7 +22,7 @@ treeherderApp.controller('JobsCtrl', [
             ThResultSetStore.fetchResultSets($scope.repoName, count, keepFilters);
         };
 
-        // set the default repo to mozilla-central if not specified
+        // set to the default repo if one not specified
         if ($routeParams.hasOwnProperty("repo") &&
             $routeParams.repo !== "") {
             $rootScope.repoName = $routeParams.repo;

--- a/webapp/app/js/values.js
+++ b/webapp/app/js/values.js
@@ -122,6 +122,6 @@ treeherder.value("thRepoGroupOrder", {
     "qa automation tests": 6
 });
 
-treeherder.value("thDefaultRepo", "mozilla-central");
+treeherder.value("thDefaultRepo", "mozilla-inbound");
 
 treeherder.value("thDateFormat", "EEE MMM d, H:mm:ss");

--- a/webapp/test/unit/controllers/jobs.tests.js
+++ b/webapp/test/unit/controllers/jobs.tests.js
@@ -12,7 +12,8 @@ describe('JobsCtrl', function(){
     beforeEach(module('treeherder.app'));
 
     beforeEach(inject(function ($injector, $rootScope, $controller) {
-        var projectPrefix = '/api/project/mozilla-central/';
+        var activeRepo = 'mozilla-central';
+        var projectPrefix = '/api/project/' + activeRepo + '/';
 
         $httpBackend = $injector.get('$httpBackend');
         jasmine.getJSONFixtures().fixturesPath='base/test/mock';
@@ -58,6 +59,7 @@ describe('JobsCtrl', function(){
         );
 
         jobsScope = $rootScope.$new();
+        jobsScope.repoName = activeRepo;
         jobsScope.setRepoPanelShowing = function(tf) {
                 // no op in the tests.
         };


### PR DESCRIPTION
Since more people are likely to want to view mozilla-inbound than mozilla-central. In the future we'll likely replace the homepage with a profile/overview page of some sorts, but for now this seems preferable.