### PR TITLE
Bug 1154378 - Make the Cancel btn in job details full opacity

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -500,8 +500,8 @@ th-watched-repo {
     color: #0de00d !important;
 }
 
-.dim-half {
-    opacity: 0.5;
+.icon-red:hover {
+    color: #fa4444 !important;
 }
 
 .dim-quarter {

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -80,10 +80,11 @@
           </li>
           <li ng-show="canCancel()">
             <a title="Cancel this job"
+               class="icon-red"
                href="" prevent-default-on-left-click
                target="_blank"
                ng-click="cancelJob()">
-              <span class="fa fa-times-circle cancel-job-icon dim-half"></span>
+              <span class="fa fa-times-circle cancel-job-icon"></span>
             </a>
           </li>
           <li>


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1154378](https://bugzilla.mozilla.org/show_bug.cgi?id=1154378).

So, back during work in PR https://github.com/mozilla/treeherder-ui/pull/309 I made the Cancel button in the job details bar a bit less prominent since it is mildly 'destructive', for lack of a better term. James requested it be the same intensity as all the other buttons in the row, so this makes that change.

Here's current:

![currentcancelbtn](https://cloud.githubusercontent.com/assets/3660661/7143433/a6ac7cf0-e2ad-11e4-814d-579bf237d216.jpg)

And here's after:

![cancelbtnrequested](https://cloud.githubusercontent.com/assets/3660661/7143439/aef3b054-e2ad-11e4-9bbf-2ec3fa269acc.jpg)

While I was there I put a hover color on the cancel button, like retrigger's green. I think I recall Ed suggesting that awhile back. I picked a color, but if folks have a particular hue/shade they prefer let me know :) Red over dark is always a bit problematic.

![cancelcolor](https://cloud.githubusercontent.com/assets/3660661/7144290/93e9d4d2-e2b2-11e4-8d1a-c727f4788cd4.jpg)

I left the main Cancel All in the resultset bar without that hover color change, for now.

Tested on OSX 10.9.5:
FF Release **37.0.1**
Chrome Latest Release **41.0.2272.118** (64-bit)

Adding @wlach for review and @maurodoglio and @jgraham for visibility.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/466)
<!-- Reviewable:end -->
