### PR TITLE
Bug 1141203 - Print a friendly error message when port is already in use when web-server.js is run.

### DIFF
--- a/webapp/scripts/web-server.js
+++ b/webapp/scripts/web-server.js
@@ -43,7 +43,7 @@ HttpServer.prototype.start = function(port) {
   console.log("Starting web server at http://localhost:" + port + "/");
   this.server.listen(port).on('error', function(err) {
     if (err.code === "EADDRINUSE") {
-      console.error("\033[31mPort %d is already in use, can't start web server.", port);
+      console.error("\033[31mPort %d is already in use, can't start web server.\033[0m", port);
     }
   });
 };

--- a/webapp/scripts/web-server.js
+++ b/webapp/scripts/web-server.js
@@ -40,8 +40,12 @@ function HttpServer(handlers) {
 
 HttpServer.prototype.start = function(port) {
   this.port = port;
-  this.server.listen(port);
-  util.puts('Http Server running at http://localhost:' + port + '/');
+  console.log("Starting web server at http://localhost:" + port + "/");
+  this.server.listen(port).on('error', function(err) {
+    if (err.code === "EADDRINUSE") {
+      console.error("\033[31mPort %d is already in use, can't start web server.", port);
+    }
+  });
 };
 
 HttpServer.prototype.parseUrl_ = function(urlString) {


### PR DESCRIPTION
Adds a simple 'error' event listener to HttpServer.start. If
error code is "EADDRINUSE", the port is already in use, so prints
a message saying the port is in use, instead of just throwing out
the error.

As discussed in Bugzilla, I've added the necessary changes. I've changed util.puts() to console.log() though, as it's deprecated. If there is any specific reason to keep it at util.puts(), I can just change it back. Changed the color of the error message to red as well.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/467)
<!-- Reviewable:end -->
