### PR TITLE
Bug 1151337-Perfherder graphs should use OptionCollection model

### DIFF
--- a/webapp/app/js/perf.js
+++ b/webapp/app/js/perf.js
@@ -30,9 +30,9 @@ perf.factory('getSeriesSummary', [ function() {
 }]);
 
 perf.controller('PerfCtrl', [ '$state', '$stateParams', '$scope', '$rootScope', '$location',
-                              '$modal', 'thServiceDomain', '$http', '$q', '$timeout', 'getSeriesSummary',
+                              '$modal', 'thServiceDomain', '$http', '$q', '$timeout', 'getSeriesSummary', 'ThOptionCollectionModel',
   function PerfCtrl($state, $stateParams, $scope, $rootScope, $location, $modal,
-                    thServiceDomain, $http, $q, $timeout, getSeriesSummary) {
+                    thServiceDomain, $http, $q, $timeout, getSeriesSummary, ThOptionCollectionModel) {
 
     var availableColors = [ 'red', 'green', 'blue', 'orange', 'purple' ];
 
@@ -650,12 +650,14 @@ perf.controller('PerfCtrl', [ '$state', '$stateParams', '$scope', '$rootScope', 
 
     var optionCollectionMap = {};
 
-    $http.get(thServiceDomain + '/api/optioncollectionhash').then(
-      function(response) {
-        response.data.forEach(function(dict) {
-          optionCollectionMap[dict.option_collection_hash] =
-            dict.options.map(function(option) {
-              return option.name; }).join(" ");
+    ThOptionCollectionModel.get_list().success(
+      function(optCollectionData) {
+          // gather the string representations of option collections
+        _.each(optCollectionData, function(optColl) {
+          optionCollectionMap[optColl.option_collection_hash] =
+            _.uniq(_.map(optColl.options, function(option) {
+              return option.name;
+            })).sort().join();
         });
       }).then(function() {
         if ($stateParams.series) {

--- a/webapp/app/perf.html
+++ b/webapp/app/perf.html
@@ -36,6 +36,9 @@
   <script src="vendor/mousetrap.min.js"></script>
   <script src="js/treeherder.js"></script>
   <script src="js/providers.js"></script>
+  <script src="js/models/option_collection.js"></script>
+  <script src="js/services/main.js"></script>
+  <script src="js/services/log.js"></script>
   <script src="js/perf.js"></script>
   <!-- endbuild -->
 


### PR DESCRIPTION
Replaced http.get call with option collection model service call in perf module

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/468)
<!-- Reviewable:end -->
