### PR TITLE
Bug 1087349 - replace characters instead of escaping them

### DIFF
--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -244,7 +244,7 @@ treeherder.provider('thEvents', function() {
 treeherder.provider('thAggregateIds', function() {
 
     var escape = function(id) {
-        return id.replace(/(:|\.|\[|\]|,)/g, "\\$1").replace(/\s+/g, '');
+        return id.replace(/(:|\[|\]|\?|,|\.|\s+)/g, '-');
     };
 
     var getPlatformRowId = function(


### PR DESCRIPTION
Ends up escaping characters in DOM ids didn’t work well.  This now
replaces them with hyphens, which DOES work well.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/469)
<!-- Reviewable:end -->
