### PR TITLE
Bug 1148664 - Limit notifications from blocking jobs and other UI - do not merge

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -610,6 +610,7 @@ div#bottom-panel {
     display:         flex;
     -webkit-flex-flow: column;
     flex-flow: column;
+    z-index: 1000;
 }
 
 div#bottom-panel .navbar{
@@ -623,7 +624,6 @@ div#bottom-panel .navbar{
     min-height: 33px;
     min-width: initial;
     overflow: hidden;
-    z-index: 100;
 }
 
 div#bottom-panel .navbar-nav > ul{
@@ -1045,7 +1045,7 @@ ul.failure-summary-list li .btn-xs {
 }
 
 #pinboard-controls .dropdown-menu {
-    z-index: 2000;
+    z-index: 1100;
 }
 
 #pinboard-controls .save-btn-dropdown {
@@ -1913,10 +1913,10 @@ div.similar_jobs .left_panel table tr.active > td {
 div.similar_jobs .left_panel table tr { cursor: default; }
 
 #notification_box{
-    position:fixed;
-    top:70px;
-    right:10px;
-    z-index: 1100;
+    position: fixed;
+    top: 70px;
+    right: 10px;
+    z-index: 500;
 }
 
 #notification_box div.alert{


### PR DESCRIPTION
This tweak addresses the main user problem in Bugzilla bug [1148664](https://bugzilla.mozilla.org/show_bug.cgi?id=1148664).

Perhaps we could economize on dimension, location, and frequency of the notifications later, but with this change at least the notifications on retrigger don't obscure the pinboard and job panel. So in z-index I set:

* notifications at 500
* the entire job panel at 1000 (not just its navbar)
* pinboard overlay menus at 1100 (was 2000)

The upper Filter menu still lies *below* notifications, and the top navbar menus still draw above them. No changes there.

Here's the before:

![current](https://cloud.githubusercontent.com/assets/3660661/7162325/f3a50b44-e361-11e4-98ba-d000af573475.jpg)

Here's after:

![proposed](https://cloud.githubusercontent.com/assets/3660661/7162341/07141b34-e362-11e4-93df-40cbab870e32.jpg)

Everything seems fine with various UI, but it will be worth everyone trying it on dev/stage in case there's any adjustments to be made.

Tested on OSX 10.9.5:
FF Release **37.0.1**
Chrome Latest Release **41.0.2272.118** (64-bit)

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/470)
<!-- Reviewable:end -->
