### PR TITLE
Bug 1154808 - Case-adjust job panel tab title/tooltips

### DIFF
--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -230,21 +230,21 @@
       <nav class="navbar navbar-dark">
         <ul class="nav navbar-nav tab-headers">
           <li ng-class="{'active': tabService.selectedTab == 'failureSummary'}">
-            <a title="show Failure summary"
+            <a title="Show failure summary"
                href="" prevent-default-on-left-click
                ng-click="tabService.showTab('failureSummary', job.id)">
               Failure summary
             </a>
           </li>
           <li ng-class="{'active': tabService.selectedTab == 'annotations'}">
-            <a title="show Annotations"
+            <a title="Show annotations"
                href="" prevent-default-on-left-click
                ng-click="tabService.showTab('annotations', job.id)">
               Annotations
             </a>
           </li>
           <li ng-class="{'active': tabService.selectedTab == 'similarJobs'}">
-            <a title="show Similar jobs"
+            <a title="Show similar jobs"
                href="" prevent-default-on-left-click
                ng-click="tabService.showTab('similarJobs', job.id)">
               Similar jobs
@@ -252,7 +252,7 @@
           </li>
           <li ng-if="tabService.tabs.talos.enabled"
               ng-class="{'active': tabService.selectedTab == 'talos'}">
-            <a title="show talos job details"
+            <a title="Show Talos job details"
                href="" prevent-default-on-left-click
                ng-click="tabService.showTab('talos', job.id)">
               Talos


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1154808](https://bugzilla.mozilla.org/show_bug.cgi?id=1154808).

More polish, but I couldn't help myself... making these tips conform to the general convention of leading capital, lower case trailing. I left Talos upper-case, as sort of a proper name.

Current:

![current](https://cloud.githubusercontent.com/assets/3660661/7165273/970918b8-e374-11e4-8813-d8b7b642e9ac.jpg)

Proposed (general, and Talos):

![generalproposed](https://cloud.githubusercontent.com/assets/3660661/7165284/a55a05da-e374-11e4-8191-a036a9cd8d4d.jpg)

![talosproposed](https://cloud.githubusercontent.com/assets/3660661/7165285/a75d6d72-e374-11e4-9472-cb302e6e32d0.jpg)

Tested on OSX 10.9.5:
FF Release **37.0.1**
Chrome Latest Release **41.0.2272.118** (64-bit)

Adding @camd for this massive review :)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/471)
<!-- Reviewable:end -->
