### PR TITLE
Bug 1155321 - fix filter params for jobs not in a group

### DIFF
--- a/webapp/app/js/services/main.js
+++ b/webapp/app/js/services/main.js
@@ -231,8 +231,10 @@ treeherder.factory('thJobSearchStr', [
 
         return function(job) {
             return thPlatformName(job.platform) + ' ' +
-                job.platform_option + ' ' + job.job_group_name + ' ' +
-                job.job_group_symbol + ' ' + job.job_type_name + ' ' +
+                job.platform_option + ' ' +
+                (job.job_group_name === 'unknown' ? '' : job.job_group_name + ' ') +
+                (job.job_group_symbol === '?' ? '' : job.job_group_symbol + ' ') +
+                job.job_type_name + ' ' +
                 job.job_type_symbol;
         };
 }]);


### PR DESCRIPTION
If a job (like a build) is not in a group, then the job details string
for filtering by fields showed “unknown ?” as the job-group name and
symbol.  Those are legitimate values internally, but the user shouldn’t
see them.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/473)
<!-- Reviewable:end -->
