### PR TITLE
Bug 1155217 - Make max-pinboard count notifications not persistent

### DIFF
--- a/webapp/app/js/controllers/jobs.js
+++ b/webapp/app/js/controllers/jobs.js
@@ -175,8 +175,7 @@ treeherderApp.controller('ResultSetCtrl', [
         $scope.pinAllShownJobs = function() {
             if (!thPinboard.spaceRemaining()) {
                 thNotify.send("Pinboard is full.  Can not pin any more jobs.",
-                    "danger",
-                    true);
+                              "danger");
                 return;
             }
             var shownJobs = ThResultSetStore.getAllShownJobs(

--- a/webapp/app/js/models/resultsets_store.js
+++ b/webapp/app/js/models/resultsets_store.js
@@ -240,7 +240,7 @@ treeherder.factory('ThResultSetStore', [
             }
             if (_.size(shownJobs) === spaceRemaining) {
                 thNotify.send("Max pinboard size of " + maxSize + " reached.",
-                              "danger", true);
+                              "danger");
                 return true;
             }
             return false;

--- a/webapp/app/js/services/pinboard.js
+++ b/webapp/app/js/services/pinboard.js
@@ -59,7 +59,8 @@ treeherder.factory('thPinboard', [
                 pinnedJobs[job.id] = job;
                 api.count.numPinnedJobs = _.size(pinnedJobs);
             } else {
-                thNotify.send("Pinboard is already at maximum size of " + api.maxNumPinned, "danger", true);
+                thNotify.send("Pinboard is already at maximum size of " + api.maxNumPinned,
+                              "danger");
             }
         },
 


### PR DESCRIPTION
This eliminates persistent (sticky) warnings scoped in Bugzilla bug [1155217](https://bugzilla.mozilla.org/show_bug.cgi?id=1155217).

This is an unrelated part of other assigned work to improve notification UX.

Current:

![stickymaxcountcurrent](https://cloud.githubusercontent.com/assets/3660661/7223446/a9d6e5d2-e6ef-11e4-8a26-67ff9f0748f3.jpg)

Proposed:

![nonstickyproposed](https://cloud.githubusercontent.com/assets/3660661/7223450/b376e466-e6ef-11e4-890a-dfb4fcdbc43d.jpg)

Our persistence is 4000ms. It is the same for all notifications, however I think I might experiment with passing a duration param to support different persistence (eg. shorter for retrigger). But that is for another bug.

Tested on OSX 10.10.3:
FF Release **37.0.1**
Chrome Latest Release **42.0.2311.90** (64-bit)

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/474)
<!-- Reviewable:end -->
