### PR TITLE
Bug 1156501 - Failure summary race condition

### DIFF
--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -155,14 +155,14 @@ treeherder.controller('PluginCtrl', [
                                 function(parseLogResponse){return parseLogResponse.status === 200;}
                             )){
                                 selectJobRetryPromise = $timeout(function(){
+                                    // the failure summary tab update must also be triggered here,
+                                    // otherwise it will never update.
+                                    thTabs.tabs.failureSummary.update();
+                                    // refetch the job data details
                                     selectJobAndRender(job_id);
                                 }, 5000);
                             }
                         });
-                    } else {
-                        // if all logs are parsed, then update the failure summary tab
-                        // because there may now be failures or bug suggestions
-                        thTabs.tabs.failureSummary.update();
                     }
                     $scope.lvUrl = thUrl.getLogViewerUrl($scope.job.id);
                     $scope.lvFullUrl = location.origin + "/" + $scope.lvUrl;


### PR DESCRIPTION
This is kind of a complex race condition.

By having this code in the main body of ``selectJob``, when switching jobs, if log parsing is complete, then it will call the ``update()`` here, as well as in the ``thTab``.  That's a waste, plus the race condition comes in that the first call to update in the removed ``else`` section of the diff is called in the ``then`` section of a ``$q.all``.

It is possible that, when switching quickly from job X to job Y to job Z, you call the failure summary ajax call on job Y, then on Z, but Z comes back first.  Then when Y comes back, it replaces the data that should be showing for Z.

This change is much safer, because it won't ``update()`` here unless you're waiting on the page for the log parsing to complete.  And the ``selectJobRetryPromise`` is cancelled when the ``selectJobAndRender`` function is called.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/480)
<!-- Reviewable:end -->
