### PR TITLE
Bug 1156820 - Fix filter shortcut and remove select directive

### DIFF
--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -194,7 +194,7 @@ treeherderApp.controller('MainCtrl', [
                 // Prevent shortcut key overflow during focus
                 ev.preventDefault();
 
-                angular.element('#platform-job-text-search-field').trigger('click');
+                $('#platform-job-text-search-field').focus();
             });
 
             // Shortcut: escape closes any open panels and clears selected job

--- a/webapp/app/js/directives/main.js
+++ b/webapp/app/js/directives/main.js
@@ -66,19 +66,6 @@ treeherder.directive('focusMe', [
   };
 }]);
 
-// Select all text input in an html element on click.
-treeherder.directive('selectOnClick', [
-    function () {
-        return {
-            restrict: 'A',
-            link: function (scope, element, attrs) {
-                element.on('click', function () {
-                    this.select();
-                });
-        }
-    };
-}]);
-
 // Allow copy to system clipboard during hover
 treeherder.directive('copyValue', [
     function() {


### PR DESCRIPTION
This fixes Bugzilla bug [1156820](https://bugzilla.mozilla.org/show_bug.cgi?id=1156820).

This removes the now unused select-on-click directive, from this morning's removal of its behavior in the Filter input, in bug [1156758](https://bugzilla.mozilla.org/show_bug.cgi?id=1156758). It also fixes the 'f' Filter shortcut which broke during that change.

So now when you issue a 'f' shortcut with a pre-existing filter value, we get this:

![filternewbehavior](https://cloud.githubusercontent.com/assets/3660661/7257801/367fcb52-e826-11e4-865b-5da40ba576df.jpg)

And the user will now be expected to system cmd/ctrl-a to select that string (or manually drag-select it), to subsequently clear it.

I've done a solid whack of integration testing, manual interaction, clearing, click, filter shortcut invocations, shortcut clears (using the system cmd/ctrl-a to select and clear), and invocations of other shortcuts in the filter field to make sure they aren't interpreted, on both browsers. Everything seems fine.

Tested on OSX 10.10.3:
FF Release **37.0.1**
Chrome Latest Release **42.0.2311.90** (64-bit)

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/482)
<!-- Reviewable:end -->
