### PR TITLE
Bug 1148664 - Expire non-sticky notifications with a max queue

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1912,18 +1912,24 @@ div.similar_jobs .left_panel table tr.active > td {
 /* Avoid using the hand pointer unless we are on a link */
 div.similar_jobs .left_panel table tr { cursor: default; }
 
-#notification_box{
-    position:fixed;
-    top:70px;
-    right:10px;
+#notification_box {
+    position: fixed;
+    top: 105px;
+    left: 10px;
     z-index: 1100;
 }
 
-#notification_box div.alert{
-    margin-bottom:5px;
+#notification_box div.alert {
+    padding: 10px 16px 10px 10px;
+    margin-bottom: 5px;
 }
 
-#notification_box button.close{position:relative; top:-2px; right:-8px; color:inherit}
+#notification_box button.close {
+    position: relative;
+    top: -4px;
+    right: -8px;
+    color: inherit;
+}
 
 .add-new-filter .form-group{
     margin-bottom: 5px;

--- a/webapp/app/js/services/main.js
+++ b/webapp/app/js/services/main.js
@@ -184,12 +184,18 @@ treeherder.factory('thNotify', [
             $log.debug("received message", message);
             var severity = severity || 'info';
             var sticky = sticky || false;
+            var maxNsNotifications = 5;
             thNotify.notifications.push({
                 message: message,
                 severity: severity,
                 sticky: sticky
             });
-            if(!sticky){
+
+            if (!sticky) {
+                if (thNotify.notifications.length > maxNsNotifications) {
+                    $timeout(thNotify.shift);
+                    return;
+                }
                 $timeout(thNotify.shift, 4000, true);
             }
         },


### PR DESCRIPTION
This work fixes Bugzilla bug [1148664](https://bugzilla.mozilla.org/show_bug.cgi?id=1148664).

This prevents the UX problem of sequential notifications from tiling down the page and blocking the jobs and job panel. Specifically we now:

* enforce a maximum number of notifications (proposing 5)
* relocate them to the left side over the revision table so we don't obscure jobs
* expire/prune 'old' non-sticky notifications when new ones arrive
* reduce the height of all notifications
* align the 'X" close icon for sticky notifications to the text baseline
* use a new yellow 'warning' notification if the user retriggers before the job is loaded
* inject the job type (eg. 'B', 'Cpp') into retrigger success messages since the notifications cascade
* make the thModelErrors catch notification non-sticky
* support sticky notifications (will appear at the 'top') with co-incident non-sticky ('below', cascading)

There's lots of behaviors to check and test, some of them:

* retrigger without being logged in
* retrigger without LDAP access (my situation here)
* retrigger with full access (LDAP access)
* issue rapid retriggers before the job loads (should produce our new yellow warning message)
* issue other notifications (eg. Save Classification, PinAll, etc) in combination
* issue persistent/sticky and then issue non-sticky notifications

I've done a lot of testing, and everything seems fine so far. I wanted to use `$timeout(thNotify.shift)` directly in the for loop which prunes the non-sticky notifications, but during stress testing with many rapid notifications, it appears that `$timeout(thNotify.shift)` will start to do weird things, pruning the queue where the 4000ms timeout should not have occurred. So I chose to duplicate the `shift` code, which appears to work perfectly.

So here's what we used to have (imagine for the sake of my screen grab these were successes):

![current](https://cloud.githubusercontent.com/assets/3660661/7277309/46e9a2f8-e8dd-11e4-8884-eb1d5d782d16.jpg)

Here's is proposed (simulating a max of 5 retriggers I didn't want to actually do):

![proposed](https://cloud.githubusercontent.com/assets/3660661/7277453/2b97308c-e8de-11e4-8559-a51eeb1469c3.jpg)

Here is an example of a successful retrigger with job type identifier:

![successfulretrigger](https://cloud.githubusercontent.com/assets/3660661/7284932/d08cff4c-e90e-11e4-9e7e-84cbae566792.jpg)

Here is an edge case showing sequential retriggers before the job has loaded (it's typically sporadic and mixed in with successes):

![notyetloadedproposed](https://cloud.githubusercontent.com/assets/3660661/7277479/4accf73e-e8de-11e4-90f4-a870966884c1.jpg)

There's all sorts of fun variations you can try in testing, but everything seems to be behaving as I expect, on both browsers. Sheriffs have signed off on all behaviors and re-location.

Tested on OSX 10.9.5:
FF Release **37.0.2**
Chrome Latest Release **42.0.2311.90** (64-bit)

Adding @camd for review and @maurodoglio for visibility.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/483)
<!-- Reviewable:end -->
