### PR TITLE
Bug 1157426 - string filtering more precise

### DIFF
--- a/webapp/app/js/services/main.js
+++ b/webapp/app/js/services/main.js
@@ -239,8 +239,8 @@ treeherder.factory('thJobSearchStr', [
             return thPlatformName(job.platform) + ' ' +
                 job.platform_option + ' ' +
                 (job.job_group_name === 'unknown' ? '' : job.job_group_name + ' ') +
-                (job.job_group_symbol === '?' ? '' : job.job_group_symbol + ' ') +
                 job.job_type_name + ' ' +
-                job.job_type_symbol;
+                (job.job_group_symbol === '?' ? '' : job.job_group_symbol) +
+                "(" + job.job_type_symbol + ")";
         };
 }]);


### PR DESCRIPTION
Fixes [Bug 1157426](https://bugzilla.mozilla.org/show_bug.cgi?id=1157426)

A trivial fix to make things better for the Sheriffs.

This just joins the group symbol with the job symbol so that they are
looked at together.  This makes sure we don’t find a symbol like “8”
that’s also within a SHA.  So string filtering becomes much more
precise.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/484)
<!-- Reviewable:end -->
