### PR TITLE
Bug 1155319 - Integrate signature into Job field to save space

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -397,7 +397,7 @@ th-watched-repo {
 
 }
 
-.result-set-superscript {
+.icon-superscript {
     vertical-align: super;
     font-size: 0.625em;
     margin-left: -0.2em;

--- a/webapp/app/partials/main/jobs.html
+++ b/webapp/app/partials/main/jobs.html
@@ -16,7 +16,7 @@
             <a href="{{::revisionResultsetFilterUrl}}"
                title="View only this resultset"
                ignore-job-clear-on-click>{{::resultsetDateStr}}
-              <span class="fa fa-external-link result-set-superscript"></span></a> - </span>
+              <span class="fa fa-external-link icon-superscript"></span></a> - </span>
           <th-author author="{{::resultset.author}}"></th-author>
         </span>
         <span class="revision-text">{{::resultset.revision}}</span>

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -141,22 +141,20 @@
       </ul>
       <ul class="content-spacer">
         <li class="small">
-          <label>Job:</label>
-          <a title="Filter by job data strings"
+          <label>Job </label>
+          <a title="Filter jobs with this unique SHA signature"
+             href="{{jobSearchSignatureHref}}"
+             prevent-default-on-left-click
+             ng-click="filterByJobSearchStr(jobSearchSignature)"
+             copy-value="{{jobSearchSignature}}">
+            (sig) <span class="fa fa-pencil-square-o icon-superscript"></span></a>
+          <label>: </label>
+          <a title="Filter jobs containing these keywords"
              href="{{jobSearchStrHref}}"
              prevent-default-on-left-click
              ng-click="filterByJobSearchStr(jobSearchStr)"
              copy-value="{{jobSearchStr}}">
             {{jobSearchStr}}</a>
-        </li>
-        <li class="small">
-          <label>Filter:</label>
-          <a title="Filter by job signature SHA (more precise)"
-             href="{{jobSearchSignatureHref}}"
-             prevent-default-on-left-click
-             ng-click="filterByJobSearchStr(jobSearchSignature)"
-             copy-value="{{jobSearchSignature}}">
-            signature</a>
         </li>
         <li class="small">
           <label>Machine name:</label>


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1155319](https://bugzilla.mozilla.org/show_bug.cgi?id=1155319).

In it we integrate **Job:** and **Filter:** into a single line in the job details panel to save space. Since over time the job details content continues to increase in size.

Here's current production:

![sigcurrentcrp](https://cloud.githubusercontent.com/assets/3660661/7354943/8ea44a22-ecec-11e4-81ec-cc4c5f106dc8.jpg)

Here's proposed:

![sigproposedcrp](https://cloud.githubusercontent.com/assets/3660661/7354948/9877e4d2-ecec-11e4-83cc-bcbf5c5e40a4.jpg)

Here's the proposed link titles. Revised slightly to be consistent with each other, but hopefully still clear about their differences.

![signaturetitleproposed](https://cloud.githubusercontent.com/assets/3660661/7355400/7ed2da66-ecef-11e4-9b9f-5740462a2818.jpg)

![jobtitleproposed](https://cloud.githubusercontent.com/assets/3660661/7355401/80c78574-ecef-11e4-85c2-1f2e6aedeeb6.jpg)

Everything seems fine on both browsers.

Tested on OSX 10.10.3:
FF Release **37.0.2**
Chrome Latest Release 42.0.2311.90 (64-bit)

Adding @camd for review and @KWierso for visibility.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/487)
<!-- Reviewable:end -->
