### PR TITLE
Bug 1057260 - Display full Job name in retrigger notification

### DIFF
--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -270,7 +270,7 @@ treeherder.controller('PluginCtrl', [
                             return thBuildApi.retriggerJob($scope.repoName, requestId);
                         }
                     }).then(function() {
-                        thNotify.send("Retriggered job (" + $scope.job.job_type_symbol + ")",
+                        thNotify.send("Retriggered job: " + $scope.jobSearchStr,
                                       'success');
                     }).catch(function(e) {
                         // Generic error eg. the user doesn't have LDAP access


### PR DESCRIPTION
This fixes Bugzilla bug [1057260](https://bugzilla.mozilla.org/show_bug.cgi?id=1057260).

Per the bug request, this provides the full job name, in the retrigger success notification.

Here's current production:

![retriggerjobcurrent](https://cloud.githubusercontent.com/assets/3660661/7401043/f4a45198-ee8e-11e4-837f-64e877801313.jpg)

Here's proposed:

![retriggerjobfullname](https://cloud.githubusercontent.com/assets/3660661/7401051/09b3d2b6-ee8f-11e4-8ac3-34a120f6e42e.jpg)

The implication of this change is at narrow browser widths, retrigger notifications may end up again partly obscuring parts of the job table.

Everything seems to print fine on both browsers, as one would expect. 

Tested on OSX 10.10.3:
FF Release **37.0.2**
Chrome Latest Release **42.0.2311.90** (64-bit)

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/496)
<!-- Reviewable:end -->
