### PR TITLE
Bug 1159664 - Remove superfluous format param from resultset API calls

### DIFF
--- a/webapp/app/js/compareperf.js
+++ b/webapp/app/js/compareperf.js
@@ -126,7 +126,7 @@ perf.controller('CompareResultsCtrl', [
     //TODO: duplicated in comparesubtestctrl
     function verifyRevision(project, revision, rsid) {
       var uri = thServiceDomain + '/api/project/' + project +
-          '/resultset/?format=json&full=false&revision=' +
+          '/resultset/?full=false&revision=' +
           revision;
 
       return $http.get(uri).then(function(response) {
@@ -197,7 +197,7 @@ perf.controller('CompareSubtestResultsCtrl', [
     //TODO: duplicated from comparectrl
     function verifyRevision(project, revision, rsid) {
       var uri = thServiceDomain + '/api/project/' + project +
-          '/resultset/?format=json&full=false&revision=' +
+          '/resultset/?full=false&revision=' +
           revision;
 
       return $http.get(uri).then(function(response) {

--- a/webapp/app/js/graphs.js
+++ b/webapp/app/js/graphs.js
@@ -585,7 +585,7 @@ perf.controller('GraphsCtrl', [ '$state', '$stateParams', '$scope', '$rootScope'
         $q.all($scope.seriesList.map(function(series, i) {
           if (series.visible) {
            return $http.get(thServiceDomain + "/api/project/" + series.projectName +
-             "/resultset/?format=json&revision=" + rev).then(
+             "/resultset/?revision=" + rev).then(
             function(response) {
               if (response.data.results.length > 0) {
                 var result_set_id = response.data.results[0].id;

--- a/webapp/app/js/models/resultset.js
+++ b/webapp/app/js/models/resultset.js
@@ -37,8 +37,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location', '$q'
         getResultSetsFromChange: function(repoName, revision, locationParams) {
             locationParams = convertDates(locationParams);
             _.extend(locationParams, {
-                fromchange:revision,
-                format:'json'
+                fromchange:revision
             });
 
             return $http.get(
@@ -54,8 +53,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location', '$q'
             keep_filters = _.isUndefined(keep_filters) ? true : keep_filters;
 
             var params = {
-                full: full,
-                format: "json"
+                full: full
             };
 
             if (count > 0) {
@@ -99,7 +97,7 @@ treeherder.factory('ThResultSetModel', ['$rootScope', '$http', '$location', '$q'
             );
         },
         get: function(uri) {
-            return $http.get(thServiceDomain + uri, {params: {format: "json"}});
+            return $http.get(thServiceDomain + uri);
         },
         getResultSetJobsUpdates: function(resultSetIdList, repoName, exclusionProfile, lastModified){
             if(angular.isDate(lastModified)){

--- a/webapp/test/mock/resultset_list.json
+++ b/webapp/test/mock/resultset_list.json
@@ -3,8 +3,7 @@
     "count": 10,
     "filter_params": {
       "count": "10",
-      "full": "true",
-      "format": "json"
+      "full": "true"
     },
     "repository": "mozilla-inbound"
   },

--- a/webapp/test/unit/controllers/jobs.tests.js
+++ b/webapp/test/unit/controllers/jobs.tests.js
@@ -22,7 +22,7 @@ describe('JobsCtrl', function(){
             getJSONFixture('repositories.json')
         );
 
-        $httpBackend.whenGET(projectPrefix + 'resultset/?count=10&format=json&full=true').respond(
+        $httpBackend.whenGET(projectPrefix + 'resultset/?count=10&full=true').respond(
             getJSONFixture('resultset_list.json')
         );
 

--- a/webapp/test/unit/models/resultsets.tests.js
+++ b/webapp/test/unit/models/resultsets.tests.js
@@ -40,7 +40,7 @@ describe('ThResultSetStore', function(){
             }
         );
 
-        $httpBackend.whenGET(foregroundPrefix + '/resultset/?count=10&format=json&full=true').respond(
+        $httpBackend.whenGET(foregroundPrefix + '/resultset/?count=10&full=true').respond(
             getJSONFixture('resultset_list.json')
         );
 


### PR DESCRIPTION
Since it's not even checked by the API.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/497)
<!-- Reviewable:end -->
