### PR TITLE
Bug 1142680 - Write a compare-talos equivalent, items 5,6,9

### DIFF
--- a/webapp/app/js/compareperf.js
+++ b/webapp/app/js/compareperf.js
@@ -31,7 +31,7 @@ perf.controller('CompareResultsCtrl', [
                               thServiceDomain, $http, $q,
                               $timeout, PhSeries, math,
                               isReverseTest, PhCompare) {
-    function displayComparision() {
+    function displayComparison() {
       $scope.testList = [];
       $scope.platformList = [];
 
@@ -46,8 +46,7 @@ perf.controller('CompareResultsCtrl', [
       PhSeries.getSeriesSummaries($scope.originalProject,
                     timeRange,
                     optionCollectionMap,
-                    {e10s: $scope.e10s,
-                     pgo: $scope.pgo}).then(
+                    {e10s: $scope.e10s}).then(
         function(originalSeriesData) {
           $scope.platformList = originalSeriesData.platformList;
           $scope.testList = originalSeriesData.testList;
@@ -69,8 +68,7 @@ perf.controller('CompareResultsCtrl', [
           PhSeries.getSeriesSummaries($scope.newProject,
                         timeRange,
                         optionCollectionMap,
-                        {e10s: $scope.e10s,
-                         pgo: $scope.pgo}).then(
+                        {e10s: $scope.e10s}).then(
             function(newSeriesData) {
               $scope.platformList = _.union($scope.platformList,
                                             newSeriesData.platformList).sort();
@@ -91,11 +89,10 @@ perf.controller('CompareResultsCtrl', [
     function displayResults(rawResultsMap, newRawResultsMap) {
       $scope.compareResults = {};
       $scope.titles = {};
+      window.document.title = "Perfherder Compare Revisions";
 
       $scope.testList.forEach(function(testName) {
         $scope.titles[testName] = testName.replace('summary ', '');
-        $scope.compareResults[testName] = [];
-
         $scope.platformList.forEach(function(platform) {
           var oldSig = _.find(Object.keys(rawResultsMap), function (sig) {
             return (rawResultsMap[sig].name == testName && rawResultsMap[sig].platform == platform)});
@@ -118,9 +115,16 @@ perf.controller('CompareResultsCtrl', [
           cmap.detailsLink = detailsLink;
           cmap.name = platform;
           cmap.hideMinorChanges = $scope.hideMinorChanges;
+          if (Object.keys($scope.compareResults).indexOf(testName) < 0)
+            $scope.compareResults[testName] = [];
           $scope.compareResults[testName].push(cmap);
         });
       });
+
+      // Remove the tests with no data, report them as well; not needed for subtests
+      $scope.testNoResults = _.difference($scope.testList, Object.keys($scope.compareResults))
+                              .map(function(name) { return ' ' + name.replace(' summary', '') }).join();
+      $scope.testList = Object.keys($scope.compareResults).sort();
     }
 
     //TODO: duplicated in comparesubtestctrl
@@ -132,7 +136,6 @@ perf.controller('CompareResultsCtrl', [
       return $http.get(uri).then(function(response) {
         var results = response.data.results;
         if (results.length > 0) {
-
           //TODO: this is a bit hacky to pass in 'original' as a text string
           if (rsid == 'original') {
             $scope.originalResultSetID = results[0].id;
@@ -141,6 +144,8 @@ perf.controller('CompareResultsCtrl', [
             $scope.newResultSetID = results[0].id;
             $scope.newTimestamp = results[0].push_timestamp;
           }
+        } else {
+          $scope.errors.push("No results found for revision " + revision + " on branch " + project);
         }
       });
     }
@@ -157,29 +162,28 @@ perf.controller('CompareResultsCtrl', [
               return option.name; }).join(" ");
         });
       }).then(function() {
-        $stateParams.pgo = Boolean($stateParams.pgo);
+        $scope.errors = PhCompare.validateInput($stateParams.originalProject, $stateParams.newProject,
+                                                $stateParams.originalRevision, $stateParams.originalProject);
+
+        if ($scope.errors.length > 0) {
+          $scope.dataLoading = false;
+          return;
+        }
+
         $stateParams.e10s = Boolean($stateParams.e10s);
         $scope.hideMinorChanges = Boolean($stateParams.hideMinorChanges);
-
-        // TODO: validate projects and revisions
         $scope.originalProject = $stateParams.originalProject;
         $scope.newProject = $stateParams.newProject;
         $scope.newRevision = $stateParams.newRevision;
         $scope.originalRevision = $stateParams.originalRevision;
-        if (!$scope.originalProject ||
-            !$scope.newProject ||
-            !$scope.originalRevision ||
-            !$scope.newRevision) {
-          //TODO: get an error to the UI
-          return;
-        }
 
         verifyRevision($scope.originalProject, $scope.originalRevision, "original").then(function () {
           verifyRevision($scope.newProject, $scope.newRevision, "new").then(function () {
-            $http.get(thServiceDomain + '/api/repository/').then(function(response) {
-              $scope.projects = response.data;
-              displayComparision();
-            });
+            if ($scope.errors.length > 0) {
+              $scope.dataLoading = false;
+              return;
+            }
+            displayComparison();
           });
         });
       });
@@ -212,6 +216,8 @@ perf.controller('CompareSubtestResultsCtrl', [
             $scope.newResultSetID = results[0].id;
             $scope.newTimestamp = results[0].push_timestamp;
           }
+        } else {
+          $scope.errors.push("No results found for revision " + revision + " on branch " + project);
         }
       });
     }
@@ -219,6 +225,10 @@ perf.controller('CompareSubtestResultsCtrl', [
     function displayResults(rawResultsMap, newRawResultsMap, timeRange) {
       $scope.compareResults = {};
       $scope.titles = {};
+
+      var subtestTitle = $scope.platformList[0].split(' ')[0];
+      subtestTitle += " " + $scope.testList[0].split(' ')[0];
+      window.document.title = subtestTitle + " subtest comparison";
 
       $scope.testList.forEach(function(testName) {
         $scope.titles[testName] = testName.replace('summary ', '');
@@ -283,101 +293,101 @@ perf.controller('CompareSubtestResultsCtrl', [
               return option.name; }).join(" ");
         });
       }).then(function() {
-        // TODO: validate projects and revisions
+        $scope.errors = PhCompare.validateInput($stateParams.originalProject, $stateParams.newProject,
+                                                $stateParams.originalRevision, $stateParams.newRevision,
+                                                $stateParams.originalSignature, $stateParams.newSignature);
+
+        if ($scope.errors.length > 0) {
+          $scope.dataLoading = false;
+          return;
+        }
+
+        $scope.hideMinorChanges = Boolean($stateParams.hideMinorChanges);
         $scope.originalProject = $stateParams.originalProject;
         $scope.newProject = $stateParams.newProject;
         $scope.newRevision = $stateParams.newRevision;
         $scope.originalRevision = $stateParams.originalRevision;
         $scope.originalSignature = $stateParams.originalSignature;
         $scope.newSignature = $stateParams.newSignature;
-        $scope.hideMinorChanges = Boolean($stateParams.hideMinorChanges);
-        if (!$scope.originalProject ||
-            !$scope.newProject ||
-            !$scope.originalRevision ||
-            !$scope.newRevision ||
-            !$scope.originalSignature ||
-            !$scope.newSignature) {
-          //TODO: get an error to the UI
-          return;
-        }
-
 
         verifyRevision($scope.originalProject, $scope.originalRevision, "original").then(function () {
           verifyRevision($scope.newProject, $scope.newRevision, "new").then(function () {
-            $http.get(thServiceDomain + '/api/repository/').then(function(response) {
-              $scope.projects = response.data;
-              $scope.pageList = [];
+            $scope.pageList = [];
 
-              var timeRange = PhCompare.getInterval($scope.originalTimestamp, $scope.newTimestamp);
-              var resultSetIds = [$scope.originalResultSetID];
+            if ($scope.errors.length > 0) {
+              $scope.dataLoading = false;
+              return;
+            }
 
-              // Optimization - if old/new branches are the same collect data in one pass
-              if ($scope.originalProject == $scope.newProject) {
-                resultSetIds = [$scope.originalResultSetID, $scope.newResultSetID];
-              }
+            var timeRange = PhCompare.getInterval($scope.originalTimestamp, $scope.newTimestamp);
+            var resultSetIds = [$scope.originalResultSetID];
 
-              PhSeries.getSubtestSummaries($scope.originalProject,
-                            timeRange,
-                            optionCollectionMap,
-                            $scope.originalSignature).then(
-                function (originalSeriesData) {
-                  $scope.testList = originalSeriesData.testList;
-                  $scope.platformList = originalSeriesData.platformList;
-                  return PhCompare.getResultsMap($scope.originalProject,
-                                       originalSeriesData.seriesList,
-                                       timeRange,
-                                       resultSetIds);
-              }).then(function(seriesMaps) {
-                  var originalSeriesMap = seriesMaps[$scope.originalResultSetID];
-                  var newSeriesMap = seriesMaps[$scope.newResultSetID];
-                  [originalSeriesMap, newSeriesMap].forEach(function (seriesMap) {
-                    // If there is no data for a given signature, handle it gracefully
-                    if (seriesMap) {
-                      Object.keys(seriesMap).forEach(function(series) {
-                        if (!_.contains($scope.pageList, seriesMap[series].name)) {
-                          $scope.pageList.push(seriesMap[series].name);
-                        }
-                      });
-                    }
-                  });
+            // Optimization - if old/new branches are the same collect data in one pass
+            if ($scope.originalProject == $scope.newProject) {
+              resultSetIds = [$scope.originalResultSetID, $scope.newResultSetID];
+            }
 
-                  // Optimization- collect all data in a single pass
-                  if (newSeriesMap) {
-                    $scope.dataLoading = false;
-                    displayResults(originalSeriesMap, newSeriesMap, timeRange);
-                    return;
+            PhSeries.getSubtestSummaries($scope.originalProject,
+                          timeRange,
+                          optionCollectionMap,
+                          $scope.originalSignature).then(
+              function (originalSeriesData) {
+                $scope.testList = originalSeriesData.testList;
+                $scope.platformList = originalSeriesData.platformList;
+                return PhCompare.getResultsMap($scope.originalProject,
+                                     originalSeriesData.seriesList,
+                                     timeRange,
+                                     resultSetIds);
+            }).then(function(seriesMaps) {
+                var originalSeriesMap = seriesMaps[$scope.originalResultSetID];
+                var newSeriesMap = seriesMaps[$scope.newResultSetID];
+                [originalSeriesMap, newSeriesMap].forEach(function (seriesMap) {
+                  // If there is no data for a given signature, handle it gracefully
+                  if (seriesMap) {
+                    Object.keys(seriesMap).forEach(function(series) {
+                      if (!_.contains($scope.pageList, seriesMap[series].name)) {
+                        $scope.pageList.push(seriesMap[series].name);
+                      }
+                    });
                   }
+                });
 
-                  PhSeries.getSubtestSummaries($scope.newProject,
-                                timeRange,
-                                optionCollectionMap,
-                                $scope.newSignature).then(
-                    function (newSeriesData) {
-                      $scope.platformList = _.union($scope.platformList,
-                                                    newSeriesData.platformList).sort();
-                      $scope.testList = _.union($scope.testList,
-                                                newSeriesData.testList).sort();
+                // Optimization- collect all data in a single pass
+                if (newSeriesMap) {
+                  $scope.dataLoading = false;
+                  displayResults(originalSeriesMap, newSeriesMap, timeRange);
+                  return;
+                }
 
-                      return PhCompare.getResultsMap($scope.newProject,
-                                           newSeriesData.seriesList,
-                                           timeRange,
-                                           [$scope.newResultSetID]);
-                  }).then(function(newSeriesMaps) {
-                    var newSeriesMap = newSeriesMaps[$scope.newResultSetID];
-                    // There is a chance that we haven't received data for the given signature/resultSet yet
-                    if (newSeriesMap) {
-                      Object.keys(newSeriesMap).forEach(function(series) {
-                        if (!_.contains($scope.pageList, newSeriesMap[series].name)) {
-                          $scope.pageList.push(newSeriesMap[series].name);
-                        }
-                      });
-                    } else {
-                      newSeriesMap = {};
-                    }
-                    $scope.dataLoading = false;
-                    displayResults(originalSeriesMap, newSeriesMap, timeRange);
-                  });
-              });
+                PhSeries.getSubtestSummaries($scope.newProject,
+                              timeRange,
+                              optionCollectionMap,
+                              $scope.newSignature).then(
+                  function (newSeriesData) {
+                    $scope.platformList = _.union($scope.platformList,
+                                                  newSeriesData.platformList).sort();
+                    $scope.testList = _.union($scope.testList,
+                                              newSeriesData.testList).sort();
+
+                    return PhCompare.getResultsMap($scope.newProject,
+                                         newSeriesData.seriesList,
+                                         timeRange,
+                                         [$scope.newResultSetID]);
+                }).then(function(newSeriesMaps) {
+                  var newSeriesMap = newSeriesMaps[$scope.newResultSetID];
+                  // There is a chance that we haven't received data for the given signature/resultSet yet
+                  if (newSeriesMap) {
+                    Object.keys(newSeriesMap).forEach(function(series) {
+                      if (!_.contains($scope.pageList, newSeriesMap[series].name)) {
+                        $scope.pageList.push(newSeriesMap[series].name);
+                      }
+                    });
+                  } else {
+                    newSeriesMap = {};
+                  }
+                  $scope.dataLoading = false;
+                  displayResults(originalSeriesMap, newSeriesMap, timeRange);
+                });
             });
           });
         });

--- a/webapp/app/js/perfapp.js
+++ b/webapp/app/js/perfapp.js
@@ -13,11 +13,11 @@ perf.config(function($stateProvider, $urlRouterProvider) {
     controller: 'GraphsCtrl'
   }).state('compare', {
     templateUrl: 'partials/perf/comparectrl.html',
-    url: '/compare?originalProject&originalRevision&newProject&newRevision&hideMinorChanges&e10s&pgo',
+    url: '/compare?originalProject&originalRevision&newProject&newRevision&hideMinorChanges&e10s',
     controller: 'CompareResultsCtrl'
   }).state('comparesubtest', {
     templateUrl: 'partials/perf/comparesubtestctrl.html',
-    url: '/comparesubtest?originalProject&originalRevision&newProject&newRevision&originalSignature&newSignature',
+    url: '/comparesubtest?originalProject&originalRevision&newProject&newRevision&originalSignature&newSignature&hideMinorChanges',
     controller: 'CompareSubtestResultsCtrl'
   }).state('comparechooser', {
     templateUrl: 'partials/perf/comparechooserctrl.html',

--- a/webapp/app/partials/perf/comparectrl.html
+++ b/webapp/app/partials/perf/comparectrl.html
@@ -15,8 +15,12 @@
       Loading all results, please wait a minute...
       <img src="img/dancing_cat.gif" />
     </div>
-    <div id="subtest-summary" ng-if="!dataLoading">
+    <div id="error" ng-if="!dataLoading && errors.length" ng-repeat="error in errors">
+      <div>{{error}}</div>
+    </div>
+    <div id="subtest-summary" ng-if="!dataLoading && !errors.length">
       <h4>Compare all data for revision {{newProject}}: {{newRevision}} to {{originalProject}}: {{originalRevision}}</h4>
+      <p ng-if="testNoResults"> tests with no results: {{testNoResults}}</p>
       <p class="help-block">Hover over each entry for more options.</p>
       <table class="table">
         <tbody ng-repeat="testName in testList">

--- a/webapp/app/partials/perf/comparesubtestctrl.html
+++ b/webapp/app/partials/perf/comparesubtestctrl.html
@@ -14,7 +14,10 @@
     Loading all results, please wait a minute...
     <img src="img/dancing_cat.gif" />
   </div>
-  <div id="subtest-summary" ng-if="!dataLoading">
+  <div id="error" ng-if="!dataLoading && errors.length" ng-repeat="error in errors">
+    <div>{{error}}</div>
+  </div>
+  <div id="subtest-summary" ng-if="!dataLoading && !errors.length">
     <h4>Subtest Summary for {{originalProject}}: {{originalRevision}} compared to {{newProject}}: {{newRevision}}, <a href="perf.html#/compare?originalProject={{originalProject}}&originalRevision={{originalRevision}}&newProject={{newProject}}&newRevision={{newRevision}}">click here</a> to see all tests and platforms</h4>
     <p class="help-block">Hover over each entry for more options.</p>
       <table class="table">


### PR DESCRIPTION
Show PGO data, after IRC discussion with avih, pgo will be shown by default with no option to ignore it.  This will not be seen on a try vs. try, but try vs. m-c will show pgo data for m-c and N/A for try.

For tests that have no data on original or new revisions, we will remove those header rows and print a list at the top of the page for tests with no data, otherwise all data will be shown below.

In addition, there are basic error messages printed out for invalid branches or revisions!  It is basic, not fancy, but it at least doesn't leave the user scratching their head.

Lastly the window.document.title is update for compare and subtest compare!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/500)
<!-- Reviewable:end -->
