### PR TITLE
Bug 1158901 - Make off-screen job details discoverable with a tab

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -734,8 +734,6 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
 
 #bottom-left-panel em.testfail{ color:red;}
 
-#bottom-left-panel .printlines{padding-bottom: 5px;}
-
 #bottom-left-bottom {
     overflow: auto;
 }
@@ -757,6 +755,7 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
     flex: 1;
     display: -webkit-flex;
     display: flex;
+    overflow: auto;
 }
 
 #bottom-center-bottom > * {
@@ -781,7 +780,6 @@ div#bottom-panel .navbar.navbar-dark .navbar-nav > li.active a:focus {
 }
 
 #bottom-center-panel ul.failure-summary-list{
-    overflow: auto;
     width: 100%;
     margin-bottom: 0;
 }
@@ -800,8 +798,12 @@ ul.failure-summary-list li .btn-xs {
     background: #ffffff;
 }
 
-.failure-summary-line {
+.job-tabs-content {
     padding: 2px 4px 0px;
+}
+
+.job-tabs-divider {
+    border-left: 1px solid lightgrey;
 }
 
 .failure-summary-bugs {

--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -126,11 +126,17 @@ treeherder.controller('PluginCtrl', [
                         // easier.
                         $scope.job_details = jobInfoArtifact.reduce(function(result, artifact) {
                           if (artifact.blob && Array.isArray(artifact.blob.job_details)) {
-                            result = result.concat(artifact.blob.job_details);
+                              result = result.concat(artifact.blob.job_details);
+                          }
+                          if ($scope.artifacts.buildapi) {
+                              $scope.artifacts.buildapi.blob.title = "Buildername";
+                              $scope.artifacts.buildapi.blob.value = $scope.artifacts.buildapi.blob.buildername;
+                              result = result.concat($scope.artifacts.buildapi.blob);
                           }
                           return result;
                         }, []);
                     }
+
                     // the fourth result comes from the jobLogUrl artifact
                     // exclude the json log URLs
                     $scope.job_log_urls = _.reject(results[3], {name: 'mozlog_json'});
@@ -189,11 +195,6 @@ treeherder.controller('PluginCtrl', [
                              $scope.job.build_os || undef
                 };
 
-                // if the buildername exists, add it as a field
-                if ($scope.artifacts.buildapi) {
-                    $scope.visibleFields.Buildername = $scope.artifacts.buildapi.blob.buildername;
-                }
-
                 // time fields to show in detail panel, but that should be grouped together
                 $scope.visibleTimeFields = {
                     requestTime: dateFilter($scope.job.submit_timestamp*1000,
@@ -221,7 +222,6 @@ treeherder.controller('PluginCtrl', [
                     $scope.visibleTimeFields.endTime = dateFilter(
                         $scope.job.end_timestamp*1000, thDateFormat);
                 }
-
         };
 
         $scope.getCountPinnedJobs = function() {

--- a/webapp/app/plugins/failure_summary/main.html
+++ b/webapp/app/plugins/failure_summary/main.html
@@ -2,7 +2,7 @@
     <ul class="list-unstyled failure-summary-list">
 
         <li ng-repeat="suggestion in suggestions">
-            <div class="failure-summary-line">
+            <div class="job-tabs-content">
                 <span>{{::suggestion.search}}</span>
             </div>
             <!--Open recent bugs-->

--- a/webapp/app/plugins/job_details/main.html
+++ b/webapp/app/plugins/job_details/main.html
@@ -1,0 +1,15 @@
+<div class="job-tabs-content">
+  <ul class="list-unstyled">
+    <li ng-repeat="line in job_details" class="small">
+      <label>{{line.title}}:</label>
+      <span ng-switch on="line.content_type">
+        <a ng-switch-when="link" title="{{line.value}}"
+           href="{{line.url}}" target="_blank">{{line.value}}</a>
+        <span ng-switch-when="raw_html" ng-bind-html="line.value"></span>
+        <span ng-switch-when="TalosResult">See talos panel</span>
+        <span title="{{line.value}}" ng-switch-when="object">{{line.value}}</span>
+        <span title="{{line.value}}" ng-switch-default>{{line.value}}</span>
+      </span>
+    </li>
+  </ul>
+</div>

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -167,7 +167,6 @@
             </a>
           </span>
         </li>
-
         <li class="small" ng-repeat="(label, value) in visibleFields">
           <label>{{label}}:</label>
           <span ng-switch on="label">
@@ -176,11 +175,10 @@
                  title="Open build directory in a new tab"
                  href={{job_log_url.buildUrl}} target="_blank">{{value}}</a>
               <span ng-switch-when="Job name"
-                 title="{{job.job_type_description}}">{{value}}</span>
+                    title="{{job.job_type_description}}">{{value}}</span>
               <span ng-switch-default>{{value}}</span>
           </span>
         </li>
-
         <li class="small">
           <label>Requested:</label><span> {{visibleTimeFields.requestTime}}</span>
         </li>
@@ -202,20 +200,7 @@
           <span>No logs</span>
         </li>
       </ul>
-      <div class="printlines">
-        <ul class="list-unstyled">
-          <li ng-repeat="line in job_details" class="small">
-            <label>{{line.title}}</label>
-            <span ng-switch on="line.content_type">
-              <a ng-switch-when="link" title="{{line.value}}" href="{{line.url}}" target="_blank">{{line.value}}</a>
-              <span ng-switch-when="raw_html" ng-bind-html="line.value"></span>
-              <span ng-switch-when="TalosResult">See talos panel</span>
-              <span title="{{line.value}}" ng-switch-when="object">{{line.value}}</span>
-              <span title="{{line.value}}" ng-switch-default>{{line.value}}</span>
-            </span>
-          </li>
-        </ul>
-      </div>
+
       <div ng-if="job_detail_loading" class="overlay">
         <div>
           <span class="fa fa-refresh fa-spin"></span>
@@ -239,6 +224,13 @@
                href="" prevent-default-on-left-click
                ng-click="tabService.showTab('annotations', job.id)">
               Annotations
+            </a>
+          </li>
+          <li ng-class="{'active': tabService.selectedTab == 'jobDetails'}">
+            <a title="Show additional job information"
+               href="" prevent-default-on-left-click
+               ng-click="tabService.showTab('jobDetails', job.id)">
+              Job details
             </a>
           </li>
           <li ng-class="{'active': tabService.selectedTab == 'similarJobs'}">
@@ -281,7 +273,9 @@
       </nav>
     </div>
     <div id="bottom-center-bottom">
-      <div ng-repeat="(tabId, tab) in tabService.tabs" ng-show="tabId == tabService.selectedTab">
+      <div ng-repeat="(tabId, tab) in tabService.tabs"
+           ng-show="tabId == tabService.selectedTab"
+           class="job-tabs-divider">
           <ng-include src="tab.content"></ng-include>
       </div>
     </div>

--- a/webapp/app/plugins/similar_jobs/main.html
+++ b/webapp/app/plugins/similar_jobs/main.html
@@ -1,6 +1,6 @@
 <div class="similar_jobs" ng-controller="SimilarJobsPluginCtrl">
             <div class="left_panel">
-                <table class="table table-super-condensed table-bordered table-hover">
+                <table class="table table-super-condensed table-hover">
                     <thead>
                         <tr>
                             <th>Job</th><th>Pushed</th><th>Author</th><th>Revision</th>

--- a/webapp/app/plugins/tabs.js
+++ b/webapp/app/plugins/tabs.js
@@ -18,6 +18,11 @@ treeherder.factory('thTabs', [
                     content: "plugins/annotations/main.html",
                     enabled: true
                 },
+                "jobDetails": {
+                    title: "Job details",
+                    content: "plugins/job_details/main.html",
+                    enabled: true
+                },
                 "similarJobs": {
                     title: "Similar jobs",
                     content: "plugins/similar_jobs/main.html",


### PR DESCRIPTION
This work fixes Bugzilla bug [1158901](https://bugzilla.mozilla.org/show_bug.cgi?id=1158901).

This makes the previously off-screen job detail content more discoverable by giving it its own "Job details" tab. We originally mused about 'Extra info' as the title, but I went with the former.

So we can now refer to two pieces of UI, "the job details pane" (where common/universal job data exists) and "the job details tab" (where more unique job data exists).

Notable changes are:

* relocating Buildername to the Job details tab (signed off by @KWierso and other sheriffs)
* providing a dyanmic Job details count, for discoverability if you aren't on that tab
* adding a divider between the two pieces of UI for all tabs

Here's before (resized to display what would otherwise be clipped off screen):

![jobdetailscurrent](https://cloud.githubusercontent.com/assets/3660661/7477347/2ff4d4d4-f321-11e4-9c77-7ecd5838e97f.jpg)

Here's proposed:

![jobdetailsproposed](https://cloud.githubusercontent.com/assets/3660661/7477403/904d9ef6-f321-11e4-82fc-782eb4ec7852.jpg)

Everything seems fine in general testing on both browsers. I would like to do a bit more testing also before I merge.

Tested on OSX 10.10.3:
FF Release **37.0.2**
Chrome Latest Release **42.0.2311.135** (64-bit)

Adding @camd for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/508)
<!-- Reviewable:end -->
