### PR TITLE
Bug 1159719 - Add severity-state icons to notifications

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -1912,23 +1912,29 @@ div.similar_jobs .left_panel table tr.active > td {
 /* Avoid using the hand pointer unless we are on a link */
 div.similar_jobs .left_panel table tr { cursor: default; }
 
-#notification_box {
+#notification-box {
     position: fixed;
     top: 105px;
     left: 10px;
     z-index: 1100;
 }
 
-#notification_box div.alert {
+#notification-box div.alert {
     padding: 10px 16px 10px 10px;
     margin-bottom: 5px;
 }
 
-#notification_box button.close {
+#notification-box button.close {
     position: relative;
     top: -4px;
     right: -8px;
     color: inherit;
+}
+
+/* Notification icon */
+#notification-box div span:first-child {
+    display: inline-block;
+    width: 22px;
 }
 
 .add-new-filter .form-group{

--- a/webapp/app/partials/main/thNotificationsBox.html
+++ b/webapp/app/partials/main/thNotificationsBox.html
@@ -1,8 +1,13 @@
-<ul id="notification_box" class="list-unstyled">
-    <li ng-repeat="notification in notifier.notifications">
-        <div  class="alert alert-{{::notification.severity}}">
-            {{::notification.message}}
-            <button ng-click="notifier.remove($index)" ng-if="notification.sticky" class="close">x</button>
-        </div>
-    </li>
+<ul id="notification-box" class="list-unstyled">
+  <li ng-repeat="notification in notifier.notifications">
+    <div ng-switch on="notification.severity" class="alert alert-{{::notification.severity}}">
+      <span ng-switch-when="danger" class="fa fa-ban"></span>
+      <span ng-switch-when="warning" class="fa fa-warning"></span>
+      <span ng-switch-when="info" class="fa fa-info-circle"></span>
+      <span ng-switch-when="success" class="fa fa-check"></span>
+      <span ng-switch-default></span>
+      {{::notification.message}}
+      <button ng-click="notifier.remove($index)" ng-if="notification.sticky" class="close">x</button>
+    </div>
+  </li>
 </ul>


### PR DESCRIPTION
This work fixes Bugzilla bug [1159719](https://bugzilla.mozilla.org/show_bug.cgi?id=1159719).

This adds severity-state icons to our notifications. For users who are color-impaired it will help, and I think in quick recognition in general.

I haven't included 'real' notifications in the screen grabs below, I just modified retrigger to be momentarily sticky, and changed its severity for the purposes of reviewing all four types:

Error aka. danger:

![errorproposed](https://cloud.githubusercontent.com/assets/3660661/7502255/9105ed5c-f408-11e4-9f5f-d1757f0fe7eb.jpg)

Warning:

![warningproposed](https://cloud.githubusercontent.com/assets/3660661/7502263/9f7f37d0-f408-11e4-8312-e39ee8df76e7.jpg)

Info:

![infoproposed](https://cloud.githubusercontent.com/assets/3660661/7502269/aac851e4-f408-11e4-89b9-834bcada7ec3.jpg)

Success:

![successproposed](https://cloud.githubusercontent.com/assets/3660661/7502272/b060a142-f408-11e4-92fa-724fb4f923a6.jpg)

I had also done a version using `ng-class` but the markup wasn't as elegant, or as easy to grok. So I went with `ng-switch` since there isn't any more replicated code than with ng-class. I targeted the new span with a pseudo selector for a fixed width, to avoid replicating it in the -switch markup.

I went with 22px width for the element, we can tweak it if needed. Everything seems fine in testing on both browsers.

Tested on OSX 10.10.3:
FF Release **37.0.2**
Chrome Latest Release **42.0.2311.135** (64-bit)

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/513)
<!-- Reviewable:end -->
