### PR TITLE
Bug 1162725 - Use flex: 1 with treeherder content

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -223,7 +223,7 @@ th-watched-repo {
 }
 
 .th-content {
-    flex: auto;
+    flex: 1; /* Not using auto because it causes unnecessary reflows, see https://bugzilla.mozilla.org/show_bug.cgi?id=1162725 */
     -webkit-flex: auto;
     position: relative;/* need this to position inner content */
     overflow-y: auto;


### PR DESCRIPTION
Prevents unnecessary reflows

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/515)
<!-- Reviewable:end -->
