### PR TITLE
Bug 1125094 - Improve the log parsing in-progress message

### DIFF
--- a/webapp/app/plugins/failure_summary/main.html
+++ b/webapp/app/plugins/failure_summary/main.html
@@ -69,12 +69,15 @@
             </div>
         </li>
 
-        <li ng-if="!tabs.failureSummary.is_loading && !jobLogsAllParsed">
-            <div class="failure-summary-line-empty">
-                <span>Log parsing in progress.</span>
-                <span>The content of this panel will refresh in 5 seconds.</span>
-
-            </div>
+        <li ng-if="!tabs.failureSummary.is_loading && !jobLogsAllParsed"
+            ng-repeat="job_log_url in job_log_urls">
+          <div class="failure-summary-line-empty">
+            <span>Log parsing in progress. The</span>
+            <a title="Open the raw log in a new window"
+               target="_blank"
+               href="{{::job_log_url.url}}">raw log</a>
+            <span>is available. This panel will automatically recheck every 5 seconds.</span>
+          </div>
         </li>
         <li ng-if="!tabs.failureSummary.is_loading && !job_log_urls.length">
             <div class="failure-summary-line-empty">


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1125094](https://bugzilla.mozilla.org/show_bug.cgi?id=1125094).

This improves the user message when Treeherder is in the middle of parsing the log for failure summary/logviewer, so the user knows they have access to the raw log during that short period.

It's actually a fairly rare condition at present, as our log parser concurrency seems to have made the interval from not-parsed to parsed very brief, per job. 

It is also challenging to capture/test in that state across running jobs :)

Here's the proposed wording:

![logparsinginprogmsgproposed](https://cloud.githubusercontent.com/assets/3660661/7537746/09342102-f569-11e4-9f3c-148dd352d477.jpg)

The raw log link launches fine when in that state. Some minor wordsmithing on the last sentence, but I can tweak further/revert if needed.

Tested on OSX 10.10.3:
FF Release **37.0.2**
Chrome Latest Release **42.0.2311.135** (64-bit)

Adding @edmorley for review.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/516)

<!-- Reviewable:end -->
