### PR TITLE
Bug 1080760 - Failure Summary tab bug suggestions polling

### DIFF
--- a/webapp/app/js/models/job_log_url.js
+++ b/webapp/app/js/models/job_log_url.js
@@ -19,9 +19,9 @@ treeherder.factory('ThJobLogUrlModel', [
         if(!this.hasOwnProperty("id")){
             throw "The id property is required in order to parse a log";
         }
-        var uri = ThJobLogUrlModel.get_uri()+this.id+"/parse/"
+        var uri = ThJobLogUrlModel.get_uri()+this.id+"/parse/";
         return $http.post(uri);
-    }
+    };
 
     ThJobLogUrlModel.get_uri = function(){
         var url = thUrl.getProjectUrl("/job-log-url/");
@@ -42,7 +42,7 @@ treeherder.factory('ThJobLogUrlModel', [
             var item_list = [];
             angular.forEach(response.data, function(elem){
                 var buildData = elem.url.split("/");
-                var buildUrl = elem.url.slice(0, elem.url.lastIndexOf("/")) + "/"
+                var buildUrl = elem.url.slice(0, elem.url.lastIndexOf("/")) + "/";
                 elem.buildUrl = buildUrl;
                 item_list.push(new ThJobLogUrlModel(elem));
             });

--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -162,9 +162,6 @@ treeherder.controller('PluginCtrl', [
                                 function(parseLogResponse){return parseLogResponse.status === 200;}
                             )){
                                 selectJobRetryPromise = $timeout(function(){
-                                    // the failure summary tab update must also be triggered here,
-                                    // otherwise it will never update.
-                                    thTabs.tabs.failureSummary.update();
                                     // refetch the job data details
                                     selectJobAndRender(job_id);
                                 }, 5000);

--- a/webapp/app/plugins/failure_summary/controller.js
+++ b/webapp/app/plugins/failure_summary/controller.js
@@ -5,9 +5,9 @@
 "use strict";
 
 treeherder.controller('BugsPluginCtrl', [
-    '$scope', 'ThLog', 'ThJobArtifactModel','$q', 'thTabs',
+    '$scope', 'ThLog', 'ThJobArtifactModel','$q', 'thTabs', '$timeout',
     function BugsPluginCtrl(
-        $scope, ThLog, ThJobArtifactModel, $q, thTabs) {
+        $scope, ThLog, ThJobArtifactModel, $q, thTabs, $timeout) {
 
         var $log = new ThLog(this.constructor.name);
 
@@ -19,7 +19,6 @@ treeherder.controller('BugsPluginCtrl', [
 
         // update function triggered by the plugins controller
         thTabs.tabs.failureSummary.update = function() {
-
             var newValue = thTabs.tabs.failureSummary.contentId;
             $scope.suggestions = [];
             if (angular.isDefined(newValue)) {
@@ -62,6 +61,12 @@ treeherder.controller('BugsPluginCtrl', [
                             suggestions.push(suggestion);
                         });
                         $scope.suggestions = suggestions;
+                        $scope.bugSuggestionsLoaded = true;
+                    } else {
+                        $scope.bugSuggestionsLoaded = false;
+
+                        // set a timer to re-run update() after 5 seconds
+                        $timeout(thTabs.tabs.failureSummary.update, 5000);
                     }
                 })
                 .finally(function () {

--- a/webapp/app/plugins/failure_summary/controller.js
+++ b/webapp/app/plugins/failure_summary/controller.js
@@ -18,10 +18,11 @@ treeherder.controller('BugsPluginCtrl', [
         $scope.tabs = thTabs.tabs;
 
         // update function triggered by the plugins controller
-        thTabs.tabs.failureSummary.update = function(){
+        thTabs.tabs.failureSummary.update = function() {
+
             var newValue = thTabs.tabs.failureSummary.contentId;
             $scope.suggestions = [];
-            if(angular.isDefined(newValue)){
+            if (angular.isDefined(newValue)) {
                 thTabs.tabs.failureSummary.is_loading = true;
                 // if there's a ongoing request, abort it
                 if (timeout_promise !== null) {

--- a/webapp/app/plugins/failure_summary/main.html
+++ b/webapp/app/plugins/failure_summary/main.html
@@ -63,9 +63,16 @@
 
         </li>
 
-        <li ng-if="!tabs.failureSummary.is_loading && jobLogsAllParsed && job_log_urls.length && suggestions.length == 0">
+        <li ng-if="!tabs.failureSummary.is_loading && jobLogsAllParsed && bugSuggestionsLoaded && job_log_urls.length && suggestions.length == 0">
             <div class="failure-summary-line-empty">
                 <span>Failure summary is empty</span>
+            </div>
+        </li>
+
+        <li ng-if="!tabs.failureSummary.is_loading && jobLogsAllParsed && !bugSuggestionsLoaded && job_log_urls.length">
+            <div class="failure-summary-line-empty">
+                <span>Log parsing complete.  Generating bug suggestions</span>
+                <span>The content of this panel will refresh in 5 seconds.</span>
             </div>
         </li>
 


### PR DESCRIPTION
This implements polling for the ``Bug suggestions`` artifact.  

Previously we checked for this artifact as soon as we detect that log parsing is complete.  But now that non-buildbot jobs can submit log summaries that require the generation of ``Bug suggestions`` artifacts, we need to not rely on looking for that artifact based on whether the status of the log is ``parsed``.  

Instead, the ``Failure Summary`` tab now does its own polling for the existence of the ``Bug suggestions`` artifact.

This also includes a commit with a couple of syntax fixes I found while I was at it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/519)
<!-- Reviewable:end -->
