### PR TITLE
Bug 1162706 - Add UI access between treeherder and perfherder

### DIFF
--- a/webapp/app/css/perf.css
+++ b/webapp/app/css/perf.css
@@ -85,6 +85,13 @@ to { opacity: 0; }
   flex-flow: row;
 }
 
+#perf-logo {
+    padding: 15px;
+    border: none;
+    color: #555;
+    background: #f8f8f8;
+}
+
 #graph-chooser { flex: none; width: 240px; padding: 8px; }
 
 #data-display { flex: auto; }

--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -69,17 +69,6 @@ input:focus::-moz-placeholder {
     margin-bottom: 0px;
 }
 
-.navbar-brand {
-    margin-bottom: 0px;
-    line-height: 2px;
-    height: 32px;
-    font-weight: normal;
-}
-
-.navbar-inverse .navbar-brand:hover {
-    color: #777;
-}
-
 .navbar .dropdown-menu {
     max-height: 600px;
     overflow: auto;
@@ -89,7 +78,13 @@ input:focus::-moz-placeholder {
 }
 
 .th-global-navbar {
+    padding-left: 0;
     border-bottom: 1px solid black;
+}
+
+#th-logo {
+    padding-left: 14px;
+    border-left: 0;
 }
 
 th-watched-repo {

--- a/webapp/app/partials/main/thGlobalTopNavPanel.html
+++ b/webapp/app/partials/main/thGlobalTopNavPanel.html
@@ -1,9 +1,16 @@
 <nav class="navbar navbar-inverse">
-    <div class="navbar-header">
-        <label class="navbar-brand">Treeherder</label>
-    </div>
     <div class="navbar-collapse collapse th-global-navbar">
-        <!-- nav begin -->
+        <!-- Logo Menu -->
+        <span class="dropdown">
+            <button id="th-logo" title="Treeherder services" role="button"
+                    href="#" data-toggle="dropdown" data-target="#"
+                    class="btn btn-view-nav">Treeherder
+              <span class="fa fa-angle-down lightgray"></span>
+            </button>
+            <ul class="dropdown-menu" role="menu" aria-labelledby="th-logo">
+              <li><a href="perf.html">Perfherder</a></li>
+            </ul>
+        </span>
         <span class="navbar-right">
             <!-- Sheriffing Button -->
             <span ng-show="user.is_staff">

--- a/webapp/app/perf.html
+++ b/webapp/app/perf.html
@@ -5,6 +5,7 @@
     <!-- build:css css/perf.min.css -->
     <link href="css/bootstrap.css" rel="stylesheet" media="screen">
     <link href="css/perf.css" rel="stylesheet" media="screen">
+    <link href="css/font-awesome.min.css" rel="stylesheet" media="screen">
     <!-- endbuild -->
     <link id="favicon" type="image/png" rel="shortcut icon" href="img/line_chart.png">
     <style>
@@ -13,12 +14,22 @@
 <body>
   <nav class="navbar navbar-default" role="navigation">
     <div class="container-fluid">
-      <div class="navbar-header">
-        <a class="navbar-brand" href="#">Perfherder</a>
-      </div>
       <ul class="nav navbar-nav">
+        <li>
+          <span class="dropdown">
+            <button id="perf-logo" title="Treeherder services" role="button"
+                    href="#" data-toggle="dropdown" data-target="#">Perfherder
+              <span class="fa fa-angle-down lightgray"></span>
+            </button>
+            <ul class="dropdown-menu" role="menu" aria-labelledby="perf-logo">
+              <li><a href="/#">Treeherder</a></li>
+            </ul>
+          </span>
+        </li>
         <li ng-class="{active: $state.includes('graphs')}"><a href="#/graphs">Graphs</a></li>
-        <li ng-class="{active: $state.current.name.indexOf('compare') >= 0}"><a href="#/comparechooser">Compare</a></li>
+        <li ng-class="{active: $state.current.name.indexOf('compare') >= 0}">
+          <a href="#/comparechooser">Compare</a>
+        </li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
This work fixes Bugzilla bug [1162706](https://bugzilla.mozilla.org/show_bug.cgi?id=1162706).

This converts our inert Treeherder and Perfherder 'logos' into equivalent nav menus, so you can switch back and forth between platforms, and discover Perfherder from Treeherder.

Here's current (inert logo):

![current](https://cloud.githubusercontent.com/assets/3660661/7589318/f1450a00-f88f-11e4-807d-597951d5c822.jpg)

Here's Treeherder proposed (menu posted):

![treeherderproposed1a](https://cloud.githubusercontent.com/assets/3660661/7589443/b96fce0c-f890-11e4-9bd7-6498cfba93b4.jpg)

We consciously use the same style as our other right hand nav bar buttons, to cue the user it is navigable, and for consistency. I don't see a downside to that approach.

Here's the proposed tooltip for both:

![perftooltipproposed](https://cloud.githubusercontent.com/assets/3660661/7589056/968e4712-f88e-11e4-8a0f-13d916a210e7.jpg)


Here's Perfherder proposed (menu posted):

![perfproposed](https://cloud.githubusercontent.com/assets/3660661/7589072/aef8e64a-f88e-11e4-847f-5572fdfc7fe8.jpg)

The only workflow I discovered that doesn't work as expected, is if you use the Perfherder menu to navigate to Treeherder, and then hit 'back' on your browser, we just reload Treeherder instead of reloading Perfherder. The other direction is fine. I wonder if it related to our hash routing or my -ui local server development configuration. I will poke around a bit more on that. That being said, you can use the menu to easily navigate back.

Otherwise everything seems fine.

Tested on OSX 10.10.3:
FF Release **37.0.2**
FF Nightly **40.0a1**
Chrome Latest Release **42.0.2311.135** (64-bit)

Adding @wlach for review and @jmaher for visibility.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/520)
<!-- Reviewable:end -->
