### PR TITLE
Bug 1164092 - Add utf-8 encoding to Perfherder to quiet the console

### DIFF
--- a/webapp/app/perf.html
+++ b/webapp/app/perf.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html ng-app="perf">
 <head>
+    <meta charset="utf-8">
     <title>Perfherder</title>
     <!-- build:css css/perf.min.css -->
     <link href="css/bootstrap.css" rel="stylesheet" media="screen">


### PR DESCRIPTION
This tweak fixes Bugzilla bug [1164092](https://bugzilla.mozilla.org/show_bug.cgi?id=1164092).

Nothing gripping, the change just quiets this console diagnostic below, when loading Perfherder on Release and Nightly, at least during local development. Chrome is unaffected.

![consolediagnostics](https://cloud.githubusercontent.com/assets/3660661/7593276/ef9d5628-f8a6-11e4-91fd-dc1e7e1a5842.jpg)

Tested on OSX 10.10.3:
FF Release **37.0.2**
FF Nightly **40.0a1**
Chrome Latest Release **42.0.2311.135** (64-bit)

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/521)
<!-- Reviewable:end -->
