### PR TITLE
Bug 1164209 - Fix page flash when UI switching from Perf to Treeherder

### DIFF
--- a/webapp/app/perf.html
+++ b/webapp/app/perf.html
@@ -23,7 +23,7 @@
               <span class="fa fa-angle-down lightgray"></span>
             </button>
             <ul class="dropdown-menu" role="menu" aria-labelledby="perf-logo">
-              <li><a href="/#">Treeherder</a></li>
+              <li><a href="/">Treeherder</a></li>
             </ul>
           </span>
         </li>


### PR DESCRIPTION
This (hopefully) fixes Bugzilla bug [1164209](https://bugzilla.mozilla.org/show_bug.cgi?id=1164209).

Basically we adjust the href on Perfherder side, so when we switch back to Treeherder we don't touch an empty `/#` fragment and instead just start at `/`. This still works fine with vagrant for local development.

I can mimic the problem and the fix on stage, simulating our new UI navigation menus by:

(problem)
* loading https://treeherder.allizom.org/perf.html#/graphs
* editing the url bar to **treeherder.allizom.org/#** (and enter)
* ...we see a double flash page load

(fix)
* loading https://treeherder.allizom.org/perf.html#/graphs
* editing the url bar to **treeherder.allizom.org/** (and enter)

Given vagrant masks the problem for local development, I can't really prove it's working until we push to stage. But I think it will be fine.

Tested on OSX 10.10.3:
FF Release **37.0.2**
FF Nightly **40.0a1**
Chrome Latest Release **42.0.2311.135** (64-bit)

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/525)
<!-- Reviewable:end -->
