### PR TITLE
Bug 1164023 - Remove treeherder-dev from service config

### DIFF
--- a/webapp/app/js/config/sample.local.conf.js
+++ b/webapp/app/js/config/sample.local.conf.js
@@ -8,7 +8,6 @@
  * used to retrieve job result data. Valid settings are  */
 var production = "https://treeherder.mozilla.org";
 var stage = "https://treeherder.allizom.org";
-var dev = "http://treeherder-dev.allizom.org";
 var vagrant = "";
 
 // Set the service


### PR DESCRIPTION
Supplemental for Bugzilla bug [1164023](https://bugzilla.mozilla.org/show_bug.cgi?id=1164023).

We've retired treeherder-dev, so also removing it's reference as a backend service from our config file.

Adding @edmorley for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/527)
<!-- Reviewable:end -->
