### PR TITLE
Bug 1165441 - Tidy up Annotations panel layout

### DIFF
--- a/webapp/app/css/treeherder.css
+++ b/webapp/app/css/treeherder.css
@@ -790,6 +790,7 @@ ul.failure-summary-list li .btn-xs {
 
 .failure-summary-line-empty {
     padding: 2px 4px 0px;
+    font-size: 12px;
     background: #ffffff;
 }
 
@@ -1082,6 +1083,11 @@ ul.failure-summary-list li .btn-xs {
 .bug-list {
     list-style: none inside none;
     padding-left: 0;
+}
+
+.bug-header {
+    margin-top: 8px;
+    margin-bottom: 8px;
 }
 
 /**

--- a/webapp/app/plugins/annotations/main.html
+++ b/webapp/app/plugins/annotations/main.html
@@ -1,7 +1,7 @@
-<div ng-controller="AnnotationsPluginCtrl" class="row annotations-panel">
-    <div class="col-xs-10 classifications-panel">
+<div ng-controller="AnnotationsPluginCtrl" class="annotations-panel">
+    <div class="col-xs-10 classifications-panel job-tabs-content">
         <table class="table-condensed table-hover">
-            <thead>
+            <thead ng-hide="classifications.length < 1">
                 <tr><th>Datetime</th><th>Author</th><th>Failure type</th><th>Note</th></tr>
             </thead>
             <tbody>
@@ -28,10 +28,10 @@
                 </tr>
             </tbody>
         </table>
-        <div ng-show="classifications.length < 1"></br><em>This job has not been classified</em></div>
+        <div ng-show="classifications.length < 1">This job has not been classified</div>
     </div>
     <div class="col-xs-2 bug-list-panel">
-        <h5><strong>Bugs</strong></h5>
+        <h6 class="bug-header" ng-hide="classifications.length < 1"><strong>Bugs</strong></h6>
         <ul class="bug-list">
             <li ng-repeat="bug in bugs">
                 <th-related-bug-saved></th-related-bug-saved>


### PR DESCRIPTION
This work fixes Bugzilla bug [1165441](https://bugzilla.mozilla.org/show_bug.cgi?id=1165441).

Specifically in the Annotations tab, it:

* fixes vertical alignment of the Classification and Bug container headers
* makes the "has not been classified" message consistent in size and style to the Failure Summary
* suppresses the data headers when there is no data so the panel is clean and simple
* makes the **Bugs** header the same computed size as the **Date**, **Author**, etc, headers

Here's current (red lines for alignment reference):
![annotationscurrent](https://cloud.githubusercontent.com/assets/3660661/7661114/ec169b94-fb1d-11e4-9817-1b197da10e93.jpg)

Here's proposed:
![annotationsproposed](https://cloud.githubusercontent.com/assets/3660661/7661118/04998cf8-fb1e-11e4-8ca7-0abc5acc04c1.jpg)

Here's current (no classifications):
![annotationsemptycurrent](https://cloud.githubusercontent.com/assets/3660661/7661242/d4aa9860-fb1e-11e4-9574-fd551c8acb86.jpg)
Here's proposed (no classifications):
![annotationsemptyproposed](https://cloud.githubusercontent.com/assets/3660661/7661248/dccfd3ac-fb1e-11e4-85f8-924d33ef4eff.jpg)


There's more I'll probably tweak later. Everything seems fine on all browsers.

Tested on OSX 10.10.3:
FF Release **38.0**
FF Nightly **40.0a1**
Chrome Latest Release **42.0.2311.152** (64-bit)

Adding @wlach for review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/528)
<!-- Reviewable:end -->
