### PR TITLE
Bug 1165702 - Remove webapp/logs/.gitkeep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,4 @@ docs/_build/
 node_modules
 .tmp/
 webapp/coverage/
-webapp/logs/
 !.gitkeep

--- a/webapp/scripts/watchr.rb
+++ b/webapp/scripts/watchr.rb
@@ -5,7 +5,7 @@
 # run: watch watchr.rb
 # note: make sure that you have jstd server running (server.sh) and a browser captured
 
-log_file = File.expand_path(File.dirname(__FILE__) + '/../logs/jstd.log')
+log_file = File.expand_path(File.dirname(__FILE__) + '/../jstd.log')
 
 `cd ..`
 `touch #{log_file}`


### PR DESCRIPTION
The directory is empty apart from a .gitkeep, since it only exists to house jstd.log, which is output by watchr.rb. I was going to move the directory around in bug 1056877, but let's just delete it and move the
log file one directory higher up.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/530)
<!-- Reviewable:end -->
