### PR TITLE
Bug 1160613 - Use t-test as confidence level for highlight and display

### DIFF
--- a/webapp/app/partials/perf/comparectrl.html
+++ b/webapp/app/partials/perf/comparectrl.html
@@ -20,7 +20,7 @@
       <table class="table">
         <tbody ng-repeat="testName in testList">
           <tr class="subtest-header">
-            <td>{{titles[testName]}}</td><td>Old Geomean</td><td>Old StdDev</td><td>New Geomean</td><td>New StdDev</td><td>Delta</td><td>Delta %</td><td></td>
+            <td>{{titles[testName]}}</td><td>Old Geomean</td><td>Old StdDev</td><td>New Geomean</td><td>New StdDev</td><td>Delta</td><td>Delta %</td><td></td><td>Confidence</td>
           </tr>
           <tr ng-class="getCompareClasses(compareResult, 'row')" ng-repeat="compareResult in compareResults[testName]">
             <td>{{compareResult.name}} (<a ng-href="{{compareResult.detailsLink}}">Details</a>)</td>
@@ -34,6 +34,7 @@
             <td ng-class="getCompareClasses(compareResult)">{{compareResult.deltaPercentage|displayPrecision}}%</td>
             <td ng-if="compareResult.delta" width="20%"><div ng-class="getCompareClasses(compareResult, 'bar')" style="margin-{{compareResult.marginDirection}}: {{compareResult.barGraphMargin}}%;"></div></td>
             <td ng-if="!compareResult.delta"></td>
+          <td><span ng-show="compareResult.confidenceText">{{compareResult.confidence|displayPrecision}} ({{compareResult.confidenceText}})</span></td>
           </tr>
         </tbody>
       </table>

--- a/webapp/app/partials/perf/comparesubtestctrl.html
+++ b/webapp/app/partials/perf/comparesubtestctrl.html
@@ -14,7 +14,7 @@
     <table class="table">
       <tbody ng-repeat="testName in testList">
         <tr class="subtest-header">
-          <td>{{platformList[0]}} : {{titles[testName]}}</td><td>Old Geomean</td><td>Old StdDev</td><td>New Geomean</td><td>New StdDev</td><td>Delta</td><td>Delta %</td><td></td>
+          <td>{{platformList[0]}} : {{titles[testName]}}</td><td>Old Geomean</td><td>Old StdDev</td><td>New Geomean</td><td>New StdDev</td><td>Delta</td><td>Delta %</td><td></td><td>Confidence</td>
         </tr>
         <tr ng-class="getCompareClasses(compareResult, 'row')" ng-repeat="compareResult in compareResults[testName]">
           <td>{{compareResult.name}} (<a ng-href="{{compareResult.detailsLink}}">graph</a>)</td>
@@ -30,6 +30,7 @@
           <td ng-if="compareResult.delta" ng-class="getCompareClasses(compareResult)">{{compareResult.deltaPercentage|displayPrecision}}%</td>
           <td ng-if="compareResult.delta" width="20%"><div ng-class="getCompareClasses(compareResult, 'bar')" style="margin-{{compareResult.marginDirection}}: {{compareResult.barGraphMargin}}%;"></div></td>
           <td ng-if="!compareResult.delta"></td>
+          <td><span ng-show="compareResult.confidenceText">{{compareResult.confidence|displayPrecision}} ({{compareResult.confidenceText}})</span></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
The confidence level is used for deciding which changes to highlight (red/green)
and also for display at the table view.

New behavior:
- Ignore differences below 1.5% and low (<0.5) t-test values.
- Diff above 1.5%, and t-value below 1.0 -> not-sure-regression.
- Above t-value of 1.0 -> confident -> highlight red/green.
- Added the t-test value as the last column at the table ("Conf.")
- Added the actual runs values at the "Runs" tooltip.

TODO:
- Fine tune the t-test constants 0.5 and 1.0 if required.
- Possibly unify this calculation with our regression alerts thresholds.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/532)
<!-- Reviewable:end -->
