### PR TITLE
Bug 1164166 - Create a shortcut to delete a classification

### DIFF
--- a/webapp/app/help.html
+++ b/webapp/app/help.html
@@ -141,6 +141,8 @@
                         </span><span class="kbd">u</span></td>
                       <td>Clear the pinboard</td>
                     </tr>
+                    <tr><td><span class="kbd">ctrl</span><span class="kbd">backspace</span></td>
+                    <td>Delete job classification and related bugs</td></tr>
                     <tr><td class="kbd">i</td>
                     <td>Toggle in-progress (running/pending) jobs</td></tr>
                     <tr><td class="kbd">u</td>

--- a/webapp/app/js/controllers/main.js
+++ b/webapp/app/js/controllers/main.js
@@ -215,6 +215,13 @@ treeherderApp.controller('MainCtrl', [
                 $scope.$evalAsync($rootScope.$emit(thEvents.saveClassification));
             });
 
+            // Shortcut: delete classification and related bugs
+            Mousetrap.bind('ctrl+backspace', function() {
+                if ($scope.selectedJob) {
+                    $scope.$evalAsync($rootScope.$emit(thEvents.deleteClassification));
+                }
+            });
+
         };
 
         $scope.repoModel = ThRepositoryModel;

--- a/webapp/app/js/providers.js
+++ b/webapp/app/js/providers.js
@@ -227,6 +227,8 @@ treeherder.provider('thEvents', function() {
 
             saveClassification: "save-classification-EVT",
 
+            deleteClassification: "delete-classification-EVT",
+
             clearPinboard: "clear-pinboard-EVT",
 
             searchPage: "search-page-EVT",

--- a/webapp/app/plugins/annotations/controller.js
+++ b/webapp/app/plugins/annotations/controller.js
@@ -15,10 +15,23 @@ treeherder.controller('AnnotationsPluginCtrl', [
 
         $log.debug("annotations plugin initialized");
 
-        $scope.$watch('classifications', function(newValue, oldValue){
-
+        $scope.$watch('classifications', function(newValue, oldValue) {
             thTabs.tabs.annotations.num_items = newValue ? $scope.classifications.length : 0;
         }, true);
+
+        $rootScope.$on(thEvents.deleteClassification, function(event) {
+            if ($scope.classifications[0]) {
+                $scope.deleteClassification($scope.classifications[0]);
+                // Delete any number of bugs if they exist
+                for (var i = 0; i < $scope.bugs.length; i++) {
+                    $scope.deleteBug($scope.bugs[i]);
+                }
+            } else {
+                thNotify.send("No classification on this job to delete", 'warning');
+            }
+            // We reselect job in place ensuring a correct state for other actions
+            $rootScope.$emit(thEvents.selectJob, $rootScope.selectedJob);
+        });
 
         $scope.deleteClassification = function(classification) {
 

--- a/webapp/app/plugins/pinboard.js
+++ b/webapp/app/plugins/pinboard.js
@@ -78,6 +78,8 @@ treeherder.controller('PinboardCtrl', [
             } else {
                 thNotify.send("Must be logged in to save job classifications", "danger");
             }
+            // We reselect job in place ensuring a correct state for other actions
+            $rootScope.$emit(thEvents.selectJob, $rootScope.selectedJob);
         };
 
         $scope.saveClassificationOnly = function() {


### PR DESCRIPTION
This work fixes Bugzilla bug [1164166](https://bugzilla.mozilla.org/show_bug.cgi?id=1164166).

In it we provide the shortcut **ctrl+backspace** to delete a job classification if one exists. Generally everything seems to be working correctly in various testing I've done:

* rapidly deleting multiple classifications
* deleting immediately after saving the classification
* saving and deleting entirely by shortcuts (focus in main pane)
* saving via pinboard UI interaction (focus in job panel) and deleting via shortcut
* deleting classifications with and without related bugs
* deleting bug associations in Annotations, then deleting via shortcut

So here's what we have when we delete a classification via the shortcut on a job with a related bug:

![deletesuccessshortcut](https://cloud.githubusercontent.com/assets/3660661/7686248/6cf3859c-fd62-11e4-99fe-834ede926906.jpg)

I've also provided a warning notification in case we end up with job which is not classified, but the UI wrongly claims it is, or the user simply invokes the shortcut on an unclassified job.

![noclassificationtodeleteproposed](https://cloud.githubusercontent.com/assets/3660661/7686364/460df682-fd63-11e4-875a-50c688e3de78.jpg)

To me it makes sense we'd tell them :)

I have experienced one edge case where this improper display state occurs, but it is not consistently reproducible:

1. Manually pin, add a related bug, add a comment, manually click Save in pinboard
2. ctrl+backspace to delete the classification 1-2 sec after the green success msgs disappear
3. Observed: ~50% of the time the job asterisk doesn't disappear in the UI (requires a page reload)

I wonder if this is a timing thing related to either a) evalAsync() being used for save and delete, or b) non-Async emits being used in the pinboard service. Perhaps one or the other is yet to be digested.

Otherwise I haven't encountered any problems with any other workflows.

I also applied the same (perhaps slightly kludgy) fix to Save classification, simply ensuring the job is re-selected after Save so that the Annotations pane contents refresh without the user having to flip back and forth between tabs and manually unselect and re-select the job. This was a current complaint and bug reported by users in channel. Perhaps there is a better way.

Tested on OSX 10.10.3:
FF Release **38.0**
FF Nightly **40.0a1**
Chrome Latest Release **42.0.2311.152** (64-bit)

Adding @camd for review.