### PR TITLE
Bug 1166028 - Move Job Details tab to be first in the tab sequence

### DIFF
--- a/webapp/app/plugins/controller.js
+++ b/webapp/app/plugins/controller.js
@@ -91,17 +91,26 @@ treeherder.controller('PluginCtrl', [
                     $scope.eta = $scope.job.get_current_eta();
                     $scope.eta_abs = Math.abs($scope.job.get_current_eta());
                     $scope.typical_eta = $scope.job.get_typical_eta();
-                    // this is a bit hacky but for now talos is the only exception we have
-                    if($scope.job.job_group_name.indexOf('Talos') !== -1){
+
+                    // we handle which tab gets presented in the job details panel
+                    // and a special set of rules for talos
+                    if ($scope.job.job_group_name.indexOf('Talos') !== -1) {
                         $scope.tabService.tabs.talos.enabled = true;
-                        if(thResultStatus($scope.job) === 'success'){
+                        if (thResultStatus($scope.job) === 'success') {
                             $scope.tabService.selectedTab = 'talos';
-                        }else{
+                        } else {
                             $scope.tabService.selectedTab = 'failureSummary';
                         }
-                    }else{
+                    } else {
+                        // tab presentation for any other (non-talos) job
                         $scope.tabService.tabs.talos.enabled = false;
+                        if (thResultStatus($scope.job) === 'success') {
+                            $scope.tabService.selectedTab = 'jobDetails';
+                        } else {
+                            $scope.tabService.selectedTab = 'failureSummary';
+                        }
                     }
+
                     // the second result come from the buildapi artifact promise
                     var buildapi_artifact = results[1];
 

--- a/webapp/app/plugins/pluginpanel.html
+++ b/webapp/app/plugins/pluginpanel.html
@@ -212,6 +212,12 @@
     <div id="bottom-center-top">
       <nav class="navbar navbar-dark">
         <ul class="nav navbar-nav tab-headers">
+          <li ng-class="{'active': tabService.selectedTab == 'jobDetails'}">
+            <a title="Show additional job information"
+               href="" prevent-default-on-left-click
+               ng-click="tabService.showTab('jobDetails', job.id)">
+              Job details
+            </a>
           <li ng-class="{'active': tabService.selectedTab == 'failureSummary'}">
             <a title="Show failure summary"
                href="" prevent-default-on-left-click
@@ -226,12 +232,6 @@
               Annotations
             </a>
           </li>
-          <li ng-class="{'active': tabService.selectedTab == 'jobDetails'}">
-            <a title="Show additional job information"
-               href="" prevent-default-on-left-click
-               ng-click="tabService.showTab('jobDetails', job.id)">
-              Job details
-            </a>
           </li>
           <li ng-class="{'active': tabService.selectedTab == 'similarJobs'}">
             <a title="Show similar jobs"

--- a/webapp/app/plugins/tabs.js
+++ b/webapp/app/plugins/tabs.js
@@ -8,6 +8,11 @@ treeherder.factory('thTabs', [
     function() {
         var thTabs = {
             "tabs": {
+                "jobDetails": {
+                    title: "Job details",
+                    content: "plugins/job_details/main.html",
+                    enabled: true
+                },
                 "failureSummary": {
                     title: "Failure summary",
                     content: "plugins/failure_summary/main.html",
@@ -16,11 +21,6 @@ treeherder.factory('thTabs', [
                 "annotations": {
                     title: "Annotations",
                     content: "plugins/annotations/main.html",
-                    enabled: true
-                },
-                "jobDetails": {
-                    title: "Job details",
-                    content: "plugins/job_details/main.html",
                     enabled: true
                 },
                 "similarJobs": {
@@ -34,11 +34,11 @@ treeherder.factory('thTabs', [
                     enabled: false
                 }
             },
-            "selectedTab": "failureSummary",
+            "selectedTab": "jobDetails",
             "showTab" : function(tab, contentId){
                 thTabs.selectedTab = tab;
                 if(!thTabs.tabs[thTabs.selectedTab].enabled){
-                    thTabs.selectedTab = 'failureSummary';
+                    thTabs.selectedTab = 'jobDetails';
                 }
                 // if the tab exposes an update function, call it
                 // only refresh the tab if the content hasn't been loaded yet


### PR DESCRIPTION
This fixes Bugzilla bug [1166028](https://bugzilla.mozilla.org/show_bug.cgi?id=1166028).

This re-orders the new Job Details tab to be first in the tab sequence in the details panel. We preserve existing rules for Talos display.

Talos pass (unchanged, defaults to Talos tab):

![passedtalosjob](https://cloud.githubusercontent.com/assets/3660661/7689037/557d50ae-fd77-11e4-8c7b-1d628821123c.jpg)

Talos failure (unchanged, defaults to Failure summary):

![failedtalosjob](https://cloud.githubusercontent.com/assets/3660661/7689046/622d0cea-fd77-11e4-9d5a-0957c0c803d3.jpg)

We add new rule for all other jobs: *any other* job status type other than success lands us on the Failure Summary tab. A successful job now defaults us on the Job Details tab, since there is no 'Failure summary' failure, log parsing status, or raw log availability message to view.

All other jobs, success (changed, defaults to Job details):
![passednontalos](https://cloud.githubusercontent.com/assets/3660661/7689063/81906ed8-fd77-11e4-8b2a-9e8db7851f2b.jpg)

All other jobs, eg. failure (unchanged, defaults to Failure summary);

![nonpassednontalos](https://cloud.githubusercontent.com/assets/3660661/7689072/92741092-fd77-11e4-80bf-ee9f5e88ee29.jpg)

All other jobs, eg. pending/running (unchanged, defaults to Failure summary);

![runningpendingnontalos](https://cloud.githubusercontent.com/assets/3660661/7689084/a8164988-fd77-11e4-9c6e-286f940655f9.jpg)

Everything seems fine on both browsers.

Tested on OSX 10.10.3:
FF Nightly **40.0a1**
Chrome Latest Release **42.0.2311.152** (64-bit)

Adding @camd for review and @KWierso and @rvandermeulen for visibility.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-ui/535)
<!-- Reviewable:end -->
